### PR TITLE
Feature:added delay display between songs(增加歌曲间延迟以及显示UI)

### DIFF
--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -154,6 +154,9 @@ class AppContext:
     def set_muted(self, is_muted: bool) -> bool:
         return self.store.set_muted(is_muted)
 
+    def set_song_advance_delay_seconds(self, delay_seconds: int) -> int:
+        return self.store.set_song_advance_delay_seconds(delay_seconds)
+
     def set_audio_variant(self, item_id: str, variant_id: str) -> bool:
         return self.store.set_audio_variant(item_id, variant_id)
 
@@ -552,6 +555,13 @@ class BilikaraHandler(BaseHTTPRequestHandler):
                 if not isinstance(offset_ms, int):
                     raise ValueError("offset_ms must be an integer")
                 CONTEXT.set_av_offset_ms(offset_ms)
+                self._write_json({"ok": True, "data": CONTEXT.snapshot()})
+                return
+            if route == "/api/player/advance-delay":
+                delay_seconds = body.get("delay_seconds")
+                if not isinstance(delay_seconds, int):
+                    raise ValueError("delay_seconds must be an integer")
+                CONTEXT.set_song_advance_delay_seconds(delay_seconds)
                 self._write_json({"ok": True, "data": CONTEXT.snapshot()})
                 return
             if route == "/api/player/volume":

--- a/bilikara/store.py
+++ b/bilikara/store.py
@@ -15,6 +15,8 @@ MAX_SESSION_USERS = 32
 MAX_SESSION_USER_NAME_LENGTH = 24
 MAX_AV_OFFSET_MS = 5000
 MAX_VOLUME_PERCENT = 100
+DEFAULT_SONG_ADVANCE_DELAY_SECONDS = 5
+MAX_SONG_ADVANCE_DELAY_SECONDS = 30
 
 
 class PlaylistStore:
@@ -39,6 +41,7 @@ class PlaylistStore:
         self.av_offset_ms = 0
         self.volume_percent = 100
         self.is_muted = False
+        self.song_advance_delay_seconds = DEFAULT_SONG_ADVANCE_DELAY_SECONDS
         self.current_item: PlaylistItem | None = None
         self.current_item_started = False
         self.playlist: list[PlaylistItem] = []
@@ -63,6 +66,7 @@ class PlaylistStore:
                     "av_offset_ms": self.av_offset_ms,
                     "volume_percent": self.volume_percent,
                     "is_muted": self.is_muted,
+                    "song_advance_delay_seconds": self.song_advance_delay_seconds,
                 },
                 "playlist": [item.to_dict() for item in self.playlist],
                 "current_item": self.current_item.to_dict() if self.current_item else None,
@@ -244,6 +248,15 @@ class PlaylistStore:
             self._touch(persist_backup=True)
             return normalized
 
+    def set_song_advance_delay_seconds(self, delay_seconds: int) -> int:
+        with self.lock:
+            bounded = max(0, min(MAX_SONG_ADVANCE_DELAY_SECONDS, int(delay_seconds)))
+            if self.song_advance_delay_seconds == bounded:
+                return bounded
+            self.song_advance_delay_seconds = bounded
+            self._touch(persist_backup=True)
+            return bounded
+
     def set_audio_variant(self, item_id: str, variant_id: str) -> bool:
         with self.lock:
             item = self._find_item_unlocked(item_id)
@@ -362,6 +375,7 @@ class PlaylistStore:
             self.av_offset_ms = 0
             self.volume_percent = 100
             self.is_muted = False
+            self.song_advance_delay_seconds = DEFAULT_SONG_ADVANCE_DELAY_SECONDS
             self.current_item = None
             self.current_item_started = False
             self.playlist = []
@@ -592,6 +606,7 @@ class PlaylistStore:
                     "av_offset_ms": self.av_offset_ms,
                     "volume_percent": self.volume_percent,
                     "is_muted": self.is_muted,
+                    "song_advance_delay_seconds": self.song_advance_delay_seconds,
                 },
                 "updated_at": self.updated_at,
             },
@@ -714,6 +729,7 @@ class PlaylistStore:
                 self.av_offset_ms = self._load_av_offset_ms(player_payload)
                 self.volume_percent = self._load_volume_percent(player_payload)
                 self.is_muted = self._load_is_muted(player_payload)
+                self.song_advance_delay_seconds = self._load_song_advance_delay_seconds(player_payload)
 
             users_payload = self._read_json_payload_unlocked(self.session_users_state_file)
             if users_payload:
@@ -770,6 +786,21 @@ class PlaylistStore:
         if not isinstance(player_settings, dict):
             return False
         return bool(player_settings.get("is_muted", False))
+
+    @staticmethod
+    def _load_song_advance_delay_seconds(payload: dict[str, Any]) -> int:
+        player_settings = payload.get("player_settings")
+        if not isinstance(player_settings, dict):
+            return DEFAULT_SONG_ADVANCE_DELAY_SECONDS
+        raw_value = player_settings.get(
+            "song_advance_delay_seconds",
+            DEFAULT_SONG_ADVANCE_DELAY_SECONDS,
+        )
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            return DEFAULT_SONG_ADVANCE_DELAY_SECONDS
+        return max(0, min(MAX_SONG_ADVANCE_DELAY_SECONDS, value))
 
     @staticmethod
     def _history_key(item: PlaylistItem) -> str:

--- a/static/app.js
+++ b/static/app.js
@@ -3,7 +3,7 @@ const bannerAutoHideMs = 5000;
 const stalledRetrySeconds = 5;
 const gatchaCooldownMs = 15000;
 const localPlayerSyncIntervalMs = 120;
-const localPlayerHardSyncThresholdSeconds = 0.25;
+const localPlayerHardSyncThresholdSeconds = 0.08;
 const localPlayerForceSyncEpsilonSeconds = 0.015;
 const localPlayerSeekSettlePollMs = 50;
 const localPlayerSeekSettleMaxMs = 1400;
@@ -12,6 +12,8 @@ const playerSettingsEchoSuppressMs = 1800;
 const maxAvOffsetMs = 5000;
 const playerClickDelayMs = 220;
 const playerControlsAutoHideMs = 5000;
+const defaultSongAdvanceDelaySeconds = 3;
+const maxSongAdvanceDelaySeconds = 30;
 const storageKeys = {
   playerVolume: "bilikara.player.volume",
   playerMuted: "bilikara.player.muted",
@@ -72,6 +74,11 @@ const state = {
   backupBannerPaused: false,
   backupDismissHover: false,
   localAdvanceInFlight: false,
+  localAdvanceDelayTimer: null,
+  localAdvanceCountdownTimer: null,
+  localAdvanceDelayDeadline: 0,
+  localAdvanceDelayToken: 0,
+  localAdvanceDelayItemId: "",
   localShouldBePlaying: false,
   localSeekResumePending: false,
   localSeekSettling: false,
@@ -1655,6 +1662,19 @@ function currentAvOffsetSeconds() {
   return currentAvOffsetMs() / 1000;
 }
 
+function currentSongAdvanceDelaySeconds(playerSettings = state.data?.player_settings) {
+  const rawValue = Number(playerSettings?.song_advance_delay_seconds ?? defaultSongAdvanceDelaySeconds);
+  if (!Number.isFinite(rawValue)) {
+    return defaultSongAdvanceDelaySeconds;
+  }
+  return Math.max(0, Math.min(maxSongAdvanceDelaySeconds, Math.round(rawValue)));
+}
+
+function queuedNextItem() {
+  const playlist = state.data?.playlist;
+  return Array.isArray(playlist) && playlist.length ? playlist[0] : null;
+}
+
 function boundedAvOffsetMs(rawValue) {
   const numeric = Number(rawValue || 0);
   if (!Number.isFinite(numeric)) {
@@ -1707,10 +1727,97 @@ function clearLocalPlayerSeekState() {
   state.localSeekResumePending = false;
 }
 
+function playerDelayOverlay() {
+  return elements.playerFrame?.querySelector(".player-delay-overlay") || null;
+}
+
+function ensurePlayerDelayOverlay() {
+  let overlay = playerDelayOverlay();
+  if (overlay) {
+    return overlay;
+  }
+
+  overlay = document.createElement("div");
+  overlay.className = "player-delay-overlay hidden";
+  overlay.setAttribute("aria-live", "polite");
+  overlay.innerHTML = `
+    <div class="player-delay-copy">
+      <p class="player-delay-label">\u4e0b\u4e00\u9996\u5012\u8ba1\u65f6</p>
+      <p class="player-delay-count" data-delay-count>0</p>
+      <p class="player-delay-next" data-delay-next>\u51c6\u5907\u4e0b\u4e00\u9996</p>
+    </div>
+  `;
+  elements.playerFrame.appendChild(overlay);
+  return overlay;
+}
+
+function updateLocalAdvanceDelayOverlay() {
+  const overlay = ensurePlayerDelayOverlay();
+  const remainingSeconds = Math.max(
+    0,
+    Math.ceil((state.localAdvanceDelayDeadline - Date.now()) / 1000),
+  );
+  const countNode = overlay.querySelector("[data-delay-count]");
+  const nextNode = overlay.querySelector("[data-delay-next]");
+  const nextItem = queuedNextItem();
+  setTextContent(countNode, String(remainingSeconds));
+  setTextContent(nextNode, nextItem?.display_title ? `\u63a5\u4e0b\u6765\uff1a${nextItem.display_title}` : "\u51c6\u5907\u4e0b\u4e00\u9996");
+  overlay.classList.toggle("hidden", state.localAdvanceDelayDeadline <= 0);
+}
+
+function clearLocalAdvanceDelay({ resetInFlight = false } = {}) {
+  if (state.localAdvanceDelayTimer) {
+    window.clearTimeout(state.localAdvanceDelayTimer);
+    state.localAdvanceDelayTimer = null;
+  }
+  if (state.localAdvanceCountdownTimer) {
+    window.clearInterval(state.localAdvanceCountdownTimer);
+    state.localAdvanceCountdownTimer = null;
+  }
+  state.localAdvanceDelayDeadline = 0;
+  state.localAdvanceDelayItemId = "";
+  state.localAdvanceDelayToken += 1;
+  const overlay = playerDelayOverlay();
+  if (overlay) {
+    overlay.classList.add("hidden");
+  }
+  if (resetInFlight) {
+    state.localAdvanceInFlight = false;
+  }
+}
+
+function startLocalAdvanceDelay(delaySeconds) {
+  const currentItemId = String(state.data?.current_item?.id || "");
+  if (!currentItemId) {
+    return;
+  }
+  clearLocalAdvanceDelay();
+  state.localAdvanceInFlight = true;
+  state.localAdvanceDelayItemId = currentItemId;
+  state.localAdvanceDelayToken += 1;
+  const token = state.localAdvanceDelayToken;
+  state.localAdvanceDelayDeadline = Date.now() + delaySeconds * 1000;
+  updateLocalAdvanceDelayOverlay();
+  showMountedPlayerControls();
+  state.localAdvanceCountdownTimer = window.setInterval(updateLocalAdvanceDelayOverlay, 250);
+  state.localAdvanceDelayTimer = window.setTimeout(() => {
+    finishLocalAdvanceDelay(token, currentItemId).catch(() => {});
+  }, delaySeconds * 1000);
+}
+
+async function finishLocalAdvanceDelay(token, itemId) {
+  if (token !== state.localAdvanceDelayToken || itemId !== state.localAdvanceDelayItemId) {
+    return;
+  }
+  clearLocalAdvanceDelay({ resetInFlight: true });
+  await advanceLocalPlayerNow();
+}
+
 function teardownMountedPlayer() {
   clearLocalPlayerSyncTimer();
   clearLocalPlayerControlsHideTimer();
   clearLocalPlayerSeekState();
+  clearLocalAdvanceDelay({ resetInFlight: true });
   elements.playerFrame.querySelectorAll("video, audio").forEach((media) => {
     try {
       media.pause();
@@ -3599,10 +3706,11 @@ async function removeSessionUser(name) {
   }
 }
 
-async function handleLocalPlaybackEnded() {
+async function advanceLocalPlayerNow() {
   if (state.localAdvanceInFlight) {
     return;
   }
+  clearLocalAdvanceDelay();
   state.localAdvanceInFlight = true;
   try {
     state.data = await apiPost("/api/player/next");
@@ -3612,6 +3720,18 @@ async function handleLocalPlaybackEnded() {
   } finally {
     state.localAdvanceInFlight = false;
   }
+}
+
+async function handleLocalPlaybackEnded() {
+  if (state.localAdvanceInFlight) {
+    return;
+  }
+  const delaySeconds = currentSongAdvanceDelaySeconds();
+  if (delaySeconds <= 0 || !queuedNextItem()) {
+    await advanceLocalPlayerNow();
+    return;
+  }
+  startLocalAdvanceDelay(delaySeconds);
 }
 
 async function reorderPlaylist(itemId, index) {
@@ -4020,6 +4140,7 @@ elements.playerFrame?.addEventListener("dblclick", (event) => {
 
 elements.nextButton.addEventListener("click", async () => {
   try {
+    clearLocalAdvanceDelay({ resetInFlight: true });
     state.data = await apiPost("/api/player/next");
     render();
   } catch (error) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -1162,6 +1162,7 @@ h2 {
 }
 
 .player-frame {
+  position: relative;
   margin-top: 16px;
   aspect-ratio: 16 / 9;
   border-radius: 22px;
@@ -1229,6 +1230,62 @@ h2 {
 
 .player-frame audio {
   display: none;
+}
+
+.player-delay-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  color: #fff;
+  text-align: center;
+  background: rgba(0, 0, 0, 0.68);
+  pointer-events: none;
+}
+
+.player-delay-overlay.hidden {
+  display: none;
+}
+
+.player-delay-copy {
+  display: grid;
+  gap: 10px;
+  justify-items: center;
+  text-shadow: 0 3px 18px rgba(0, 0, 0, 0.5);
+}
+
+.player-delay-label {
+  font-size: 13px;
+  letter-spacing: 0.14em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.player-delay-count {
+  font-size: 72px;
+  line-height: 1;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.player-delay-next {
+  max-width: min(720px, calc(100vw - 48px));
+  color: rgba(255, 255, 255, 0.86);
+  font-size: 18px;
+  line-height: 1.45;
+}
+
+.player-panel:fullscreen .player-delay-count,
+.player-panel:-webkit-full-screen .player-delay-count {
+  font-size: 96px;
+}
+
+.player-panel:fullscreen .player-delay-next,
+.player-panel:-webkit-full-screen .player-delay-next {
+  font-size: 20px;
 }
 
 .audio-variant-bar {

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -68,6 +68,19 @@ class PlaylistStoreTest(unittest.TestCase):
         self.assertEqual(restored_store.volume_percent, 35)
         self.assertTrue(restored_store.is_muted)
 
+    def test_song_advance_delay_persists_in_player_state_file(self):
+        self.store.set_song_advance_delay_seconds(8)
+
+        restored_store = PlaylistStore(
+            state_file=self.state_file,
+            backup_file=self.backup_file,
+            session_archive_dir=self.session_archive_dir,
+        )
+
+        snapshot = self.store.snapshot()["player_settings"]
+        self.assertEqual(snapshot["song_advance_delay_seconds"], 8)
+        self.assertEqual(restored_store.song_advance_delay_seconds, 8)
+
     def test_legacy_state_file_is_ignored_and_removed(self):
         for name in ["player_state.json", "history.json", "session_users.json"]:
             (self.state_file.parent / name).unlink(missing_ok=True)


### PR DESCRIPTION
- 新增歌曲提前延迟设置，并通过服务器 API 支持持久化
- 在歌曲结束后延迟本地播放器自动切换下一首，同时手动切歌保持即时响应
- 在播放器内显示倒计时覆盖层，并在全屏模式下保持可见
- 为该延迟设置添加 store 层的持久化支持

## Tests
- py -m unittest tests.test_store_and_bilibili tests.test_server tests.test_build_bundle
EOF

## Summary
- add a persisted song advance delay setting with server API support
- delay automatic local-player advance after a song ends, while keeping manual next immediate
- show an in-player countdown overlay that remains visible in fullscreen
- add store coverage for persisting the delay setting

## Tests
- py -m unittest tests.test_store_and_bilibili tests.test_server tests.test_build_bundle"
