### PR TITLE
Feature:added reset player button for unexpected scenarios（增加了播放器状态重置按钮）

### DIFF
--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -271,6 +271,14 @@ class AppContext:
         with self._player_status_lock:
             self._player_status = None
 
+    def reset_player_state(self) -> None:
+        self.store.reset_player_state()
+        with self._player_control_lock:
+            self._player_control_ack_seq = self._player_control_seq
+            self._player_control_command = None
+        with self._player_status_lock:
+            self._player_status = None
+
     def bind_server(self, server: ThreadingHTTPServer, *, shutdown_on_last_client: bool) -> None:
         with self._client_lock:
             self._server = server
@@ -658,6 +666,10 @@ class BilikaraHandler(BaseHTTPRequestHandler):
                 return
             if route == "/api/backup/discard":
                 CONTEXT.discard_backup()
+                self._write_json({"ok": True, "data": CONTEXT.snapshot()})
+                return
+            if route == "/api/player/reset":
+                CONTEXT.reset_player_state()
                 self._write_json({"ok": True, "data": CONTEXT.snapshot()})
                 return
             if route == "/api/data/reset":

--- a/bilikara/store.py
+++ b/bilikara/store.py
@@ -385,6 +385,16 @@ class PlaylistStore:
             self.updated_at = time.time()
             self._delete_runtime_json_files_unlocked()
 
+    def reset_player_state(self) -> None:
+        with self.lock:
+            self.playback_mode = "local"
+            self.av_offset_ms = 0
+            self.volume_percent = 100
+            self.is_muted = False
+            self.song_advance_delay_seconds = DEFAULT_SONG_ADVANCE_DELAY_SECONDS
+            self.current_item_started = False
+            self._touch(persist_backup=False)
+
     def backup_summary(self) -> dict[str, Any]:
         with self.lock:
             return self._backup_summary_unlocked()

--- a/static/app.js
+++ b/static/app.js
@@ -133,6 +133,7 @@ const elements = {
   cacheQualitySelect: document.getElementById("cache-quality-select"),
   cacheHiresCheckbox: document.getElementById("cache-hires-checkbox"),
   dataResetButton: document.getElementById("data-reset-button"),
+  playerResetButton: document.getElementById("player-reset-button"),
   currentTitle: document.getElementById("current-title"),
   playerPanel: document.querySelector(".player-panel"),
   playerFrame: document.getElementById("player-frame"),
@@ -3626,6 +3627,30 @@ async function resetRuntimeData() {
   }
 }
 
+async function resetPlayerState() {
+  try {
+    teardownMountedPlayer();
+    state.playerSignature = "";
+    state.playerContext = null;
+    state.localPlayerVolume = 1;
+    state.localPlayerMuted = false;
+    state.localAvOffsetMs = 0;
+    state.playerSettingsEchoSuppressUntil = 0;
+    state.avOffsetEchoSuppressUntil = 0;
+    state.volumeSaveSeq += 1;
+    state.avOffsetSaveSeq += 1;
+    state.avOffsetSaving = false;
+    persistLocalVolumePreferences();
+    writeLocalPreference(storageKeys.avOffsetMs, 0);
+    state.data = await apiPost("/api/player/reset");
+    closeConfirm();
+    render();
+    setAppMessage("\u64ad\u653e\u5668\u72b6\u6001\u5df2\u91cd\u7f6e\u3002");
+  } catch (error) {
+    setAppMessage(error.message, true);
+  }
+}
+
 /*
   const name = String(elements.sessionUserInput.value || "").trim();
   if (!name) {
@@ -4194,6 +4219,16 @@ elements.dataResetButton?.addEventListener("click", (event) => {
   });
 });
 
+elements.playerResetButton?.addEventListener("click", (event) => {
+  event.stopPropagation();
+  const point = anchorPointForEvent(event, elements.playerResetButton);
+  openConfirm({
+    type: "reset-player",
+    message: "\u786e\u8ba4\u91cd\u7f6e\u64ad\u653e\u5668\u72b6\u6001\uff1f\u4f1a\u91cd\u65b0\u8f7d\u5165\u5f53\u524d\u64ad\u653e\u5668\u5e76\u6062\u590d\u64ad\u653e\u5668\u8bbe\u7f6e\u3002\u6b4c\u5355\u3001\u5386\u53f2\u548c\u7f13\u5b58\u4e0d\u4f1a\u88ab\u6e05\u7a7a\u3002",
+    ...point,
+  });
+});
+
 elements.audioVariantBar.addEventListener("click", async (event) => {
   const toggleButton = event.target.closest('button[data-action="toggle-audio-variants"]');
   if (toggleButton) {
@@ -4365,6 +4400,10 @@ elements.confirmOk.addEventListener("click", async () => {
       await resetRuntimeData();
       return;
     }
+    if (intent.type === "reset-player") {
+      await resetPlayerState();
+      return;
+    }
     if (intent.type === "remove-item" && intent.itemId) {
       state.data = await apiPost("/api/playlist/remove", { item_id: intent.itemId });
       closeConfirm();
@@ -4406,6 +4445,7 @@ document.addEventListener("click", (event) => {
       event.target.closest('button[data-action="remove"]') ||
       event.target.closest("#queue-next-button") ||
       event.target.closest("#data-reset-button") ||
+      event.target.closest("#player-reset-button") ||
       event.target.closest("#add-form") ||
       event.target.closest("#history-list")
     ) {

--- a/static/index.html
+++ b/static/index.html
@@ -200,6 +200,20 @@
                   清空
                 </button>
               </div>
+              <div class="cache-panel-row cache-panel-danger-row">
+                <div>
+                  <p class="cache-panel-label">重置播放器状态</p>
+                  <p class="cache-panel-hint">在遇到播放问题时重置播放器</p>
+                </div>
+                <button
+                  type="button"
+                  class="toolbar-button cache-data-reset-button"
+                  id="player-reset-button"
+                  title="重置播放器状态"
+                >
+                  重置
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -119,5 +119,27 @@ class HistoryRouteTest(unittest.TestCase):
         self.assertEqual(writes[1], {"ok": True, "data": {"history": []}})
 
 
+class PlayerResetRouteTest(unittest.TestCase):
+    def test_player_reset_route_returns_fresh_snapshot(self):
+        handler = BilikaraHandler.__new__(BilikaraHandler)
+        writes: list[dict] = []
+        context = SimpleNamespace(
+            touch_client=lambda client_id, is_host=True: None,
+            reset_player_state=lambda: writes.append({"reset_player": True}),
+            snapshot=lambda: {"playback_mode": "local"},
+        )
+
+        handler.path = "/api/player/reset"
+        handler.headers = {}
+        handler._read_json_body = lambda: {}
+        handler._write_json = lambda payload, status=None: writes.append(payload)
+
+        with patch("bilikara.server.CONTEXT", context):
+            handler.do_POST()
+
+        self.assertEqual(writes[0], {"reset_player": True})
+        self.assertEqual(writes[1], {"ok": True, "data": {"playback_mode": "local"}})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -13,7 +13,7 @@ from bilikara.bilibili import (
     select_matching_pages,
 )
 from bilikara.models import PlaylistItem
-from bilikara.store import PlaylistStore
+from bilikara.store import DEFAULT_SONG_ADVANCE_DELAY_SECONDS, PlaylistStore
 from bilikara.title_cleanup import clean_display_title
 
 
@@ -80,6 +80,32 @@ class PlaylistStoreTest(unittest.TestCase):
         snapshot = self.store.snapshot()["player_settings"]
         self.assertEqual(snapshot["song_advance_delay_seconds"], 8)
         self.assertEqual(restored_store.song_advance_delay_seconds, 8)
+
+    def test_reset_player_state_keeps_queue_and_runtime_data(self):
+        self.store.set_mode("online")
+        self.store.set_av_offset_ms(230)
+        self.store.set_volume_percent(35)
+        self.store.set_muted(True)
+        self.store.set_song_advance_delay_seconds(8)
+        self.add_item("a", requester_name="A")
+        self.add_item("b", requester_name="B")
+        self.mark_started("a")
+
+        self.store.reset_player_state()
+
+        snapshot = self.store.snapshot()
+        self.assertEqual(snapshot["playback_mode"], "local")
+        self.assertEqual(snapshot["player_settings"]["av_offset_ms"], 0)
+        self.assertEqual(snapshot["player_settings"]["volume_percent"], 100)
+        self.assertFalse(snapshot["player_settings"]["is_muted"])
+        self.assertEqual(
+            snapshot["player_settings"]["song_advance_delay_seconds"],
+            DEFAULT_SONG_ADVANCE_DELAY_SECONDS,
+        )
+        self.assertEqual(snapshot["current_item"]["id"], "a")
+        self.assertEqual([item["id"] for item in snapshot["playlist"]], ["b"])
+        self.assertEqual(snapshot["session_users"], ["A", "B", "C", "D"])
+        self.assertFalse(self.store.current_item_started)
 
     def test_legacy_state_file_is_ignored_and_removed(self):
         for name in ["player_state.json", "history.json", "session_users.json"]:


### PR DESCRIPTION
## 总结
- 在服务设置的数据维护下方新增“重置播放器状态”按钮
- 增加确认弹窗和 POST /api/player/reset 接口
- 仅重置播放器相关状态，包括播放模式、音量、静音、AV 偏移、歌曲切换延迟和当前播放器状态
- 保留歌单、历史、用户、缓存和已唱归档数据

## 测试
- py -m unittest tests.test_store_and_bilibili tests.test_server tests.test_build_bundle"

## Summary
- add a reset player state button under service settings data maintenance
- add a confirmation flow and POST /api/player/reset endpoint
- reset player-only state such as playback mode, volume, mute, AV offset, song transition delay, and active player status
- preserve queue, history, users, cache, and archived play data

## Tests
- py -m unittest tests.test_store_and_bilibili tests.test_server tests.test_build_bundle"