### PR TITLE
Test:Expand dev smoke coverage and harden re-cache/transition behavior

### DIFF
--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -431,7 +431,8 @@ class CacheManager:
 
         with self.lock:
             active_process = self.active_process if self.active_item_id == item_id else None
-            if active_process is not None:
+            in_flight = item_id in self.pending_ids or self.active_item_id == item_id
+            if in_flight:
                 self.retry_requested_ids.add(item_id)
 
         self.store.update_item(
@@ -447,8 +448,9 @@ class CacheManager:
         )
         self._record_item_activity(item_id)
 
-        if active_process is not None:
-            self._terminate_process(active_process)
+        if in_flight:
+            if active_process is not None:
+                self._terminate_process(active_process)
             return
 
         self._remove_cache_dir(item_id)
@@ -493,6 +495,8 @@ class CacheManager:
     def _cache_item(self, item_id: str, allow_refresh_retry: bool = True) -> None:
         if self.stop_event.is_set() or not self._should_cache(item_id):
             return
+        if self._take_retry_request(item_id):
+            self._remove_cache_dir(item_id)
         item = self.store.get_item(item_id)
         if not item:
             self._remove_cache_dir(item_id)
@@ -553,7 +557,9 @@ class CacheManager:
 
         try:
             cache_result = self._download_selected_streams(item, binary_path, ffmpeg_path, item_dir, log_path)
+            self._raise_if_retry_requested(item_id)
             self._validate_cache_result(item.id, cache_result, ffmpeg_path, log_path)
+            self._raise_if_retry_requested(item_id)
         except CacheCancelledError as exc:
             if str(exc) == RETRY_REQUESTED_MESSAGE:
                 self._append_log_line(log_path, f"[{self._log_timestamp()}] restarting cache by manual request")
@@ -566,6 +572,13 @@ class CacheManager:
             self._drop_item_cache(item_id, str(exc))
             return
         except DownloadCommandError as exc:
+            if self._take_retry_request(item_id):
+                self._append_log_line(log_path, f"[{self._log_timestamp()}] restarting cache by manual request")
+                self._remove_cache_dir(item_id)
+                fresh_item = self.store.get_item(item_id)
+                if fresh_item and self._should_cache(item_id):
+                    self._cache_item_multi(item_id, fresh_item, allow_refresh_retry=allow_refresh_retry)
+                return
             last_message = str(exc)
             if allow_refresh_retry and self._should_force_refresh_bbdown(last_message):
                 self._append_log_line(
@@ -967,6 +980,7 @@ class CacheManager:
         )
 
         allowed_extensions = MEDIA_EXTENSIONS if stream_kind == "video" else AUDIO_EXTENSIONS
+        self._raise_if_retry_requested(item.id)
         stream_file = self._find_stream_file(target_dir, allowed_extensions)
         if not stream_file:
             raise DownloadCommandError(f"{stage_label} 完成后未找到输出文件")
@@ -1062,6 +1076,7 @@ class CacheManager:
             persist_backup=False,
         )
         self._record_item_activity(item_id)
+        self._raise_if_retry_requested(item_id)
 
     # LEGACY: old mux step used by the single-output cache path. Split playback
     # keeps video and audio files separate, so this remains only as a reference.
@@ -1309,6 +1324,7 @@ class CacheManager:
         )
 
         for entry in validation_files:
+            self._raise_if_retry_requested(item_id)
             if not isinstance(entry, dict):
                 continue
             path = entry.get("path")
@@ -1626,25 +1642,33 @@ class CacheManager:
         return BB_DOWN_DIR / ("BBDown.exe" if os.name == "nt" else "BBDown")
 
     def _find_media_file(self, item_dir: Path) -> Path | None:
-        media_files = [
-            path
-            for path in item_dir.rglob("*")
-            if path.is_file() and path.suffix.lower() in MEDIA_EXTENSIONS
-        ]
-        if not media_files:
-            return None
-        return max(media_files, key=lambda path: path.stat().st_size)
+        return self._largest_media_file(item_dir, MEDIA_EXTENSIONS)
+
+    @classmethod
+    def _find_stream_file(cls, target_dir: Path, allowed_extensions: set[str]) -> Path | None:
+        return cls._largest_media_file(target_dir, allowed_extensions)
 
     @staticmethod
-    def _find_stream_file(target_dir: Path, allowed_extensions: set[str]) -> Path | None:
-        media_files = [
-            path
-            for path in target_dir.rglob("*")
-            if path.is_file() and path.suffix.lower() in allowed_extensions
-        ]
+    def _largest_media_file(root_dir: Path, allowed_extensions: set[str]) -> Path | None:
+        try:
+            candidate_paths = list(root_dir.rglob("*"))
+        except OSError:
+            return None
+
+        media_files: list[tuple[int, Path]] = []
+        for path in candidate_paths:
+            try:
+                if not path.is_file() or path.suffix.lower() not in allowed_extensions:
+                    continue
+                size = path.stat().st_size
+            except OSError:
+                continue
+            media_files.append((size, path))
+
         if not media_files:
             return None
-        return max(media_files, key=lambda path: path.stat().st_size)
+        media_files.sort(key=lambda entry: entry[0], reverse=True)
+        return media_files[0][1]
 
     @staticmethod
     def _iter_output_messages(stream: TextIO) -> Iterator[str]:
@@ -2024,6 +2048,10 @@ class CacheManager:
                 return False
             self.retry_requested_ids.discard(item_id)
             return True
+
+    def _raise_if_retry_requested(self, item_id: str) -> None:
+        if self._take_retry_request(item_id):
+            raise CacheCancelledError(RETRY_REQUESTED_MESSAGE)
 
     def _should_cache(self, item_id: str) -> bool:
         with self.lock:

--- a/scripts/dev_smoke_test.py
+++ b/scripts/dev_smoke_test.py
@@ -5,6 +5,7 @@ import argparse
 import base64
 from dataclasses import dataclass
 import json
+import math
 import os
 from pathlib import Path
 import queue
@@ -391,9 +392,13 @@ class SmokeRunner:
             else:
                 print_ok(f"Queued song #{index}: {item.get('display_title')} ({item.get('id')})")
 
+        self.exercise_playlist_resort(regular_urls)
         restore_cache_max = self.expand_cache_window_for_items(len(added_items))
         try:
             self.focus_created_items_for_cache_window(added_items)
+            current_item_id = str(((self.get_state().get("current_item") or {}).get("id")) or "")
+            if current_item_id:
+                self.exercise_current_item_recache(current_item_id)
             self.visual_checkpoint("Host and Remote pages should now show this test's current song plus queued songs. Inspect both before caching completes.", seconds=5)
 
             created_ids = [str((item or {}).get("id") or "") for item in added_items if str((item or {}).get("id") or "")]
@@ -631,6 +636,109 @@ class SmokeRunner:
         for item_id in unique_ids:
             self.wait_for_cache(item_id)
 
+    def exercise_playlist_resort(self, song_urls: list[str]) -> None:
+        if not song_urls:
+            print_skip("Playlist resort API", "No song URLs were available for resort testing")
+            return
+        state = self.get_state()
+        current = state.get("current_item") or {}
+        current_requester = str(current.get("requester_name") or "").strip()
+        if not current_requester:
+            print_skip("Playlist resort API", "Need a current song with a requester before testing resort")
+            return
+
+        print_header("Playlist resort API")
+        suffix = str(int(time.time()))[-6:]
+        temp_users = [f"Cycle{suffix}A", f"Cycle{suffix}B"]
+        temp_items: list[dict[str, Any]] = []
+        added_users: list[str] = []
+        urls = self.urls_for_count(song_urls, len(temp_users))
+
+        try:
+            for user_name in temp_users:
+                self.add_user(user_name)
+                added_users.append(user_name)
+
+            for user_name, url in zip(temp_users, urls):
+                before_ids = self.item_ids(self.get_state())
+                state = self.add_song(url, user_name, position="tail")
+                item = self.find_item_not_in_ids(state, before_ids) or self.find_newest_item(state, prefer_playlist=True)
+                if not item:
+                    continue
+                temp_items.append(item)
+                print_ok(f"Resort probe item added: {item.get('display_title')} ({item.get('id')}) requester={user_name}")
+
+            if len(temp_items) < 2:
+                print_skip("Playlist resort API", "Could not create enough probe queue items")
+                return
+
+            state = self.get_state()
+            playlist = state.get("playlist") or []
+            first_id = str(temp_items[0].get("id") or "")
+            second_id = str(temp_items[1].get("id") or "")
+            first_index = next((index for index, item in enumerate(playlist) if str(item.get("id") or "") == first_id), None)
+            second_index = next((index for index, item in enumerate(playlist) if str(item.get("id") or "") == second_id), None)
+            if first_index is None or second_index is None:
+                print_skip("Playlist resort API", "Probe items were not found in the queue")
+                return
+            if first_index < second_index:
+                self.api_post("/api/playlist/reorder", {"item_id": second_id, "index": first_index})
+                print_ok(f"Scrambled queue order for resort test: {second_id} moved before {first_id}")
+            else:
+                print_ok("Probe queue order was already scrambled for resort testing")
+
+            state = self.api_post("/api/playlist/resort", {}, remote=True)
+            playlist = state.get("playlist") or []
+            expected_users = self.rotated_users_after_current(state, current_requester, temp_users)
+            actual_users = [
+                str(item.get("requester_name") or "").strip()
+                for item in playlist
+                if str(item.get("id") or "") in {first_id, second_id}
+            ]
+            if actual_users == expected_users:
+                print_ok(f"Playlist resort API works: requester order {actual_users}")
+            else:
+                print_warn(f"Playlist resort returned requester order {actual_users}; expected {expected_users}")
+        finally:
+            for item in temp_items:
+                item_id = str(item.get("id") or "")
+                if not item_id:
+                    continue
+                try:
+                    self.api_post("/api/playlist/remove", {"item_id": item_id})
+                except ApiError as exc:
+                    print_warn(f"Could not remove resort probe item {item_id}: {exc}")
+            for user_name in added_users:
+                try:
+                    self.api_post("/api/session-users/remove", {"name": user_name})
+                except ApiError as exc:
+                    print_warn(f"Could not remove resort probe user {user_name}: {exc}")
+
+    def exercise_current_item_recache(self, item_id: str) -> None:
+        print_header("Current song re-cache")
+        deadline = time.time() + 20
+        last_status = ""
+        while time.time() < deadline:
+            state = self.get_state(timeout=10)
+            current = state.get("current_item") or {}
+            current_id = str(current.get("id") or "")
+            if current_id != item_id:
+                print_skip("Current song re-cache", f"Current song changed before retry test: {item_id} -> {current_id or 'none'}")
+                return
+            cache_status = str(current.get("cache_status") or "").strip() or "unknown"
+            if cache_status != last_status:
+                print_info(f"Current item cache status before re-cache: {cache_status}")
+                last_status = cache_status
+            if cache_status in {"downloading", "failed"}:
+                self.api_post("/api/cache/retry", {"item_id": item_id, "force": True})
+                print_ok(f"Current song re-cache API works: {item_id} (from {cache_status}, force=true)")
+                return
+            if cache_status == "ready":
+                print_skip("Current song re-cache", f"Current song became ready before a retryable state was observed: {item_id}")
+                return
+            time.sleep(1)
+        print_skip("Current song re-cache", "Current song did not reach a retryable cache state in time")
+
     def exercise_cache_retry(self, item_id: str) -> None:
         state = self.get_state()
         item = self.find_item_by_id(state, item_id)
@@ -736,21 +844,24 @@ class SmokeRunner:
         if state.get("playlist") and current_id:
             original_delay = int((state.get("player_settings") or {}).get("song_advance_delay_seconds") or 0)
             self.api_post("/api/player/advance-delay", {"delay_seconds": 5})
-            self.api_post("/api/player/control", {"action": "toggle-play", "item_id": current_id}, remote=True)
-            self.api_post("/api/player/control", {"action": "seek-relative", "item_id": current_id, "delta_seconds": 300}, remote=True)
-            print_ok("Requested Remote play plus large seek to exercise end-of-song transition UI")
-            self.visual_checkpoint(
-                "Watch the Host player now. If playback reaches the end, the in-player countdown should stay visible without leaving fullscreen.",
-                seconds=self.args.transition_visual_pause,
-            )
-            state_after_seek = self.get_state()
-            current_after_seek = (state_after_seek.get("current_item") or {}).get("id")
-            if current_after_seek == current_id and state_after_seek.get("playlist"):
-                self.api_post("/api/player/next", {})
-                print_ok("Forced next-song API after transition visual window")
-            else:
-                print_ok("Current song changed during transition visual window")
-            self.api_post("/api/player/advance-delay", {"delay_seconds": original_delay})
+            try:
+                if self.seek_current_item_near_end(current_id, tail_seconds=2.0):
+                    print_ok("Requested Remote seek near the end of the current song for transition UI testing")
+                else:
+                    print_warn("Could not confirm a near-end seek; transition UI may require fallback next-song")
+                self.visual_checkpoint(
+                    "Watch the Host player now. Playback should already be near the end so the in-player countdown can stay visible without leaving fullscreen.",
+                    seconds=self.args.transition_visual_pause,
+                )
+                state_after_seek = self.get_state()
+                current_after_seek = (state_after_seek.get("current_item") or {}).get("id")
+                if current_after_seek == current_id and state_after_seek.get("playlist"):
+                    self.api_post("/api/player/next", {})
+                    print_ok("Forced next-song API after transition visual window")
+                else:
+                    print_ok("Current song changed during transition visual window")
+            finally:
+                self.api_post("/api/player/advance-delay", {"delay_seconds": original_delay})
             new_current = self.get_state().get("current_item") or {}
             new_current_id = str(new_current.get("id") or "")
             if new_current_id:
@@ -767,6 +878,155 @@ class SmokeRunner:
             f"muted={settings.get('is_muted')} offset={settings.get('av_offset_ms')}"
         )
         self.visual_checkpoint("Confirm the player reloaded while queue/history stayed intact.", seconds=8)
+
+    def seek_current_item_near_end(self, item_id: str, *, tail_seconds: float) -> bool:
+        state = self.get_state()
+        item = self.find_item_by_id(state, item_id)
+        if not item:
+            print_skip("Transition seek", f"Current item was not found: {item_id}")
+            return False
+        duration_seconds = self.item_duration_seconds(item)
+        if duration_seconds <= 0:
+            print_skip("Transition seek", f"Current item duration is unavailable: {item_id}")
+            return False
+        current_time = self.player_current_time_seconds(state, item_id)
+        target_time = max(0.0, duration_seconds - max(0.5, tail_seconds))
+        remaining = target_time - current_time
+        if remaining <= 0.5:
+            print_ok(f"Playback is already near the end: current={current_time:.1f}s duration={duration_seconds:.1f}s")
+            return True
+        print_info(
+            f"Seeking near end for transition test: current={current_time:.1f}s "
+            f"target={target_time:.1f}s duration={duration_seconds:.1f}s"
+        )
+
+        estimated_time = current_time
+        while target_time - estimated_time > 0.5:
+            remaining = target_time - estimated_time
+            delta_seconds = int(min(300, max(1, math.ceil(remaining))))
+            seek_state = self.api_post(
+                "/api/player/control",
+                {"action": "seek-relative", "item_id": item_id, "delta_seconds": delta_seconds},
+                remote=True,
+            )
+            command = seek_state.get("player_control_command") or {}
+            seq = int(command.get("seq") or 0)
+            if seq and not self.wait_for_player_control_ack(seq):
+                print_warn(f"Timed out waiting for seek command ack: seq={seq} delta={delta_seconds}")
+                return False
+            estimated_time += delta_seconds
+            time.sleep(0.4)
+
+        observed_time = self.wait_for_player_time_at_least(
+            item_id,
+            min_seconds=max(0.0, target_time - 3.0),
+            timeout=8.0,
+        )
+        if observed_time is not None:
+            print_ok(f"Player reported near-end playback: current={observed_time:.1f}s duration={duration_seconds:.1f}s")
+        else:
+            print_info(
+                f"Seek commands were acknowledged; last estimated playback was about "
+                f"{min(estimated_time, duration_seconds):.1f}s / {duration_seconds:.1f}s"
+            )
+        return True
+
+    def wait_for_player_control_ack(self, seq: int, *, timeout: float = 8.0) -> bool:
+        if seq <= 0:
+            return True
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            state = self.get_state(timeout=10)
+            command = state.get("player_control_command") or {}
+            if not command:
+                return True
+            if int(command.get("seq") or 0) != seq:
+                return True
+            time.sleep(0.2)
+        return False
+
+    def wait_for_player_time_at_least(self, item_id: str, *, min_seconds: float, timeout: float) -> float | None:
+        deadline = time.time() + timeout
+        last_seen: float | None = None
+        while time.time() < deadline:
+            state = self.get_state(timeout=10)
+            status = self.player_status_for_item(state, item_id)
+            if status is None:
+                time.sleep(0.5)
+                continue
+            last_seen = max(0.0, float(status.get("current_time") or 0.0))
+            if last_seen >= min_seconds:
+                return last_seen
+            time.sleep(0.5)
+        return last_seen if last_seen is not None and last_seen >= min_seconds else None
+
+    @staticmethod
+    def player_status_for_item(state: dict[str, Any], item_id: str) -> dict[str, Any] | None:
+        status = state.get("player_status") or {}
+        if not isinstance(status, dict):
+            return None
+        if str(status.get("item_id") or "") != str(item_id or ""):
+            return None
+        return status
+
+    @classmethod
+    def player_current_time_seconds(cls, state: dict[str, Any], item_id: str) -> float:
+        status = cls.player_status_for_item(state, item_id)
+        if status is None:
+            return 0.0
+        try:
+            return max(0.0, float(status.get("current_time") or 0.0))
+        except (TypeError, ValueError):
+            return 0.0
+
+    @staticmethod
+    def item_duration_seconds(item: dict[str, Any]) -> float:
+        def positive_durations(payload: object) -> list[float]:
+            if not isinstance(payload, list):
+                return []
+            values: list[float] = []
+            for value in payload:
+                try:
+                    duration = float(value or 0)
+                except (TypeError, ValueError):
+                    continue
+                if duration > 0:
+                    values.append(duration)
+            return values
+
+        page = 0
+        try:
+            page = int(item.get("page") or item.get("video_page") or 0)
+        except (TypeError, ValueError):
+            page = 0
+
+        for pages_key, durations_key in (
+            ("available_pages", "available_durations"),
+            ("selected_pages", "selected_durations"),
+        ):
+            pages = item.get(pages_key)
+            durations = item.get(durations_key)
+            if not isinstance(pages, list) or not isinstance(durations, list):
+                continue
+            for index, page_value in enumerate(pages):
+                try:
+                    page_number = int(page_value or 0)
+                except (TypeError, ValueError):
+                    continue
+                if page_number != page or index >= len(durations):
+                    continue
+                try:
+                    duration = float(durations[index] or 0)
+                except (TypeError, ValueError):
+                    continue
+                if duration > 0:
+                    return duration
+
+        for durations_key in ("selected_durations", "available_durations"):
+            durations = positive_durations(item.get(durations_key))
+            if durations:
+                return max(durations)
+        return 0.0
 
     def check_gatcha(self) -> None:
         print_header("Gatcha")
@@ -938,6 +1198,22 @@ class SmokeRunner:
             if isinstance(item, dict) and str(item.get("id") or "") == item_id:
                 return item
         return None
+
+    @staticmethod
+    def rotated_users_after_current(state: dict[str, Any], current_requester: str, filter_users: list[str] | None = None) -> list[str]:
+        users = [str(user).strip() for user in (state.get("session_users") or []) if str(user).strip()]
+        if not users:
+            return []
+        normalized_current = str(current_requester or "").strip()
+        if normalized_current in users:
+            current_index = users.index(normalized_current)
+            rotated = users[current_index + 1 :] + users[: current_index + 1]
+        else:
+            rotated = list(users)
+        if not filter_users:
+            return rotated
+        allowed = {str(user).strip() for user in filter_users if str(user).strip()}
+        return [user for user in rotated if user in allowed]
 
     @staticmethod
     def print_state_summary(state: dict[str, Any], *, label: str) -> None:

--- a/scripts/dev_smoke_test.py
+++ b/scripts/dev_smoke_test.py
@@ -1,0 +1,1109 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import base64
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import queue
+import sys
+import threading
+import time
+from typing import Any
+import urllib.error
+import urllib.parse
+import urllib.request
+import webbrowser
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+except AttributeError:
+    pass
+
+CLIENT_ID = "dev-smoke-test-host"
+REMOTE_CLIENT_ID = "dev-smoke-test-remote"
+GATCHA_MULTI_PAGE_QUERY = "\u679c\u53a8"
+DEFAULT_BBDOWN_TIMEOUT_SECONDS = 300
+DEFAULT_CACHE_TIMEOUT_SECONDS = 420
+DEFAULT_VISUAL_PAUSE_SECONDS = 5
+DEFAULT_TRANSITION_VISUAL_SECONDS = 18
+
+
+class ApiError(RuntimeError):
+    def __init__(self, path: str, status: int, payload: dict[str, Any]) -> None:
+        self.path = path
+        self.status = status
+        self.payload = payload
+        message = payload.get("error") or payload.get("message") or f"HTTP {status}"
+        super().__init__(f"{path}: {message}")
+
+
+@dataclass
+class ServerHandle:
+    base_url: str
+    started_here: bool
+    server: Any | None = None
+    thread: threading.Thread | None = None
+    context: Any | None = None
+
+    def stop(self) -> None:
+        if not self.started_here or self.server is None:
+            return
+        print_step("Stopping the server started by this script")
+        self.server.shutdown()
+        if self.thread is not None:
+            self.thread.join(timeout=10)
+        if self.context is not None:
+            self.context.shutdown()
+        self.server.server_close()
+
+
+class SmokeRunner:
+    def __init__(self, args: argparse.Namespace, handle: ServerHandle) -> None:
+        self.args = args
+        self.handle = handle
+        self.base_url = handle.base_url.rstrip("/")
+        self.created_user_names: list[str] = []
+        self.created_item_ids: list[str] = []
+        self.original_snapshot: dict[str, Any] | None = None
+
+    def run(self) -> None:
+        print_header("bilikara developer smoke test")
+        print_info(f"Host page: {self.base_url}")
+        print_info(f"Remote page: {self.base_url}/remote")
+        print_info("This script does not change frontend layout or switch ports.")
+        print_info("It drives the current service via API. Use dev/test data when possible.")
+
+        self.wait_for_server_ready()
+        self.open_observer_pages()
+        self.visual_checkpoint(
+            "The host page is open. Keep it visible to inspect player and UI changes during the test."
+        )
+
+        self.check_static_pages()
+        self.check_remote_surface()
+        self.original_snapshot = self.get_state()
+        self.print_state_summary(self.original_snapshot, label="Initial state")
+        self.print_remote_access(self.original_snapshot)
+
+        if not self.args.skip_bbdown_login:
+            self.check_bbdown_login()
+        else:
+            print_skip("BBDown QR login", "Skipped by --skip-bbdown-login")
+        print_skip("Manual cookie input", "Skipped by request")
+
+        self.check_service_settings()
+        self.check_users()
+        self.check_song_flow()
+        self.check_player_controls()
+        self.check_gatcha()
+
+        if self.args.destructive:
+            self.check_destructive_maintenance()
+        else:
+            print_skip("Clear playlist / history / data", "Pass --destructive to run data-clearing checks")
+
+        self.final_report()
+
+    def wait_for_server_ready(self) -> None:
+        deadline = time.time() + 20
+        last_error = ""
+        while time.time() < deadline:
+            try:
+                self.get_state(timeout=2)
+                print_ok("State API is reachable")
+                return
+            except Exception as exc:  # noqa: BLE001
+                last_error = str(exc)
+                time.sleep(0.5)
+        raise RuntimeError(f"Server did not become ready: {last_error}")
+
+    def open_observer_pages(self) -> None:
+        if self.args.no_open_browser:
+            print_skip("Open browser", "Skipped by --no-open-browser")
+            return
+        opened_host = webbrowser.open(self.base_url)
+        time.sleep(0.5)
+        opened_remote = webbrowser.open_new_tab(f"{self.base_url}/remote")
+        if opened_host:
+            print_ok("Requested the system browser to open the host page")
+        else:
+            print_warn("Browser open was not confirmed for the Host page; open the URL manually if needed.")
+        if opened_remote:
+            print_ok("Requested the system browser to open the Remote page")
+        else:
+            print_warn("Browser open was not confirmed for the Remote page; open /remote manually if needed.")
+
+    def visual_checkpoint(self, message: str, seconds: float | None = None) -> None:
+        pause_seconds = self.args.visual_pause if seconds is None else seconds
+        print_step(f"Visual checkpoint: {message}")
+        if pause_seconds <= 0:
+            return
+        print_info(f"Pausing {pause_seconds:.0f}s for visual inspection.")
+        time.sleep(pause_seconds)
+
+    def check_static_pages(self) -> None:
+        print_header("Static pages and assets")
+        for path in ["/", "/remote", "/app.js", "/styles.css", "/remote.js", "/remote-queue.js"]:
+            body = self.http_get(path, expect_json=False)
+            print_ok(f"GET {path} ({len(body)} bytes)")
+
+    def check_remote_surface(self) -> None:
+        print_header("Remote page surface")
+        state = self.get_state(remote=True)
+        print_ok(f"Remote state API works: queue={len(state.get('playlist') or [])} users={len(state.get('session_users') or [])}")
+        result = self.http_get(f"/api/gatcha/search?q={urllib.parse.quote(GATCHA_MULTI_PAGE_QUERY)}", remote=True)
+        items = ((result.get("data") or {}).get("items") or []) if isinstance(result, dict) else []
+        print_ok(f"Remote gatcha search API works for multi-page keyword: {len(items)} results")
+        self.visual_checkpoint("Remote page should be open in another browser tab. Check queue, search, and control layout there.")
+
+    def check_bbdown_login(self) -> None:
+        print_header("BBDown QR login")
+        state = self.get_state()
+        login = ((state.get("bbdown") or {}).get("login") or {})
+        print_info(f"Current BBDown state: {login.get('state')} / logged_in={login.get('logged_in')}")
+        print_info(f"BBDown.data: {login.get('data_path')}")
+
+        if login.get("logged_in") and not self.args.force_bbdown_login:
+            print_ok("BBDown is already logged in. Use --force-bbdown-login to retest the QR flow.")
+            return
+
+        if login.get("logged_in") and self.args.force_bbdown_login:
+            print_step("Force login retest: logging out of BBDown first")
+            self.api_post("/api/bbdown/logout", {})
+
+        print_step("Starting BBDown login flow")
+        self.api_post("/api/bbdown/login/start", {"force": True})
+        print_info("Open Service Settings on the host page, or scan the QR image saved by this script.")
+        print_info("Waiting for scan completion. Use --bbdown-timeout to adjust; 0 waits forever.")
+
+        deadline = None if self.args.bbdown_timeout <= 0 else time.time() + self.args.bbdown_timeout
+        last_signature = ""
+        qr_written = False
+        while deadline is None or time.time() < deadline:
+            state = self.get_state(timeout=5)
+            login = ((state.get("bbdown") or {}).get("login") or {})
+            signature = json.dumps(
+                {
+                    "state": login.get("state"),
+                    "logged_in": login.get("logged_in"),
+                    "message": login.get("message"),
+                    "qr": bool(login.get("qr_image")),
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            if signature != last_signature:
+                print_info(
+                    "BBDown login state: "
+                    f"state={login.get('state')} logged_in={login.get('logged_in')} "
+                    f"message={login.get('message')} qr_image={bool(login.get('qr_image'))}"
+                )
+                last_signature = signature
+            if login.get("qr_image") and not qr_written:
+                qr_path = self.write_qr_image(str(login.get("qr_image")))
+                if qr_path:
+                    print_info(f"QR image saved to: {qr_path}")
+                    qr_written = True
+            if login.get("logged_in"):
+                print_ok("BBDown QR login completed")
+                return
+            if login.get("state") == "failed":
+                print_warn("BBDown login failed. Check the host page or logs/bbdown.")
+                return
+            time.sleep(2)
+        print_warn("Timed out waiting for BBDown QR login; continuing.")
+
+    def write_qr_image(self, data_url: str) -> Path | None:
+        prefix = "data:image/png;base64,"
+        if not data_url.startswith(prefix):
+            return None
+        target = Path.cwd() / ".tmp-dev-smoke-bbdown-qrcode.png"
+        try:
+            target.write_bytes(base64.b64decode(data_url[len(prefix):]))
+        except (OSError, ValueError) as exc:
+            print_warn(f"Failed to save QR image: {exc}")
+            return None
+        return target
+
+    def check_service_settings(self) -> None:
+        print_header("Service and player settings APIs")
+        state = self.get_state()
+        original_mode = state.get("playback_mode") or "local"
+        original_settings = dict(state.get("player_settings") or {})
+        original_policy = dict(state.get("cache_policy") or {})
+
+        next_mode = "online" if original_mode == "local" else "local"
+        state = self.api_post("/api/mode", {"mode": next_mode})
+        print_ok(f"Playback mode switched to {state.get('playback_mode')}")
+        state = self.api_post("/api/mode", {"mode": original_mode})
+        print_ok(f"Playback mode restored to {state.get('playback_mode')}")
+
+        state = self.api_post("/api/player/volume", {"volume_percent": 80, "is_muted": False})
+        settings = state.get("player_settings") or {}
+        print_ok(f"Volume set to {settings.get('volume_percent')}%, muted={settings.get('is_muted')}")
+
+        state = self.api_post("/api/player/av-offset", {"offset_ms": 120})
+        print_ok(f"AV offset set to {(state.get('player_settings') or {}).get('av_offset_ms')} ms")
+
+        state = self.api_post("/api/player/advance-delay", {"delay_seconds": 2})
+        print_ok(f"Song advance delay set to {(state.get('player_settings') or {}).get('song_advance_delay_seconds')}s")
+
+        choices = original_policy.get("video_quality_choices") or []
+        current_quality = original_policy.get("video_quality")
+        alternate_quality = ""
+        for choice in choices:
+            value = str((choice or {}).get("value") or "").strip()
+            if value and value != current_quality:
+                alternate_quality = value
+                break
+        if alternate_quality:
+            state = self.api_post(
+                "/api/cache-policy",
+                {
+                    "video_quality": alternate_quality,
+                    "audio_hires": not bool(original_policy.get("audio_hires")),
+                },
+            )
+            policy = state.get("cache_policy") or {}
+            print_ok(
+                "Video quality/Hi-Res selection API works: "
+                f"quality={policy.get('video_quality')} hires={policy.get('audio_hires')}"
+            )
+        else:
+            print_skip("Video quality selection", "No alternate quality choice was available")
+
+        policy_payload = {}
+        if "max_cache_items" in original_policy:
+            policy_payload["max_cache_items"] = original_policy["max_cache_items"]
+        if "video_quality" in original_policy:
+            policy_payload["video_quality"] = original_policy["video_quality"]
+        if "audio_hires" in original_policy:
+            policy_payload["audio_hires"] = original_policy["audio_hires"]
+        if policy_payload:
+            state = self.api_post("/api/cache-policy", policy_payload)
+            policy = state.get("cache_policy") or {}
+            print_ok(
+                "Cache policy restored: "
+                f"max={policy.get('max_cache_items')} quality={policy.get('video_quality')} hires={policy.get('audio_hires')}"
+            )
+        else:
+            print_skip("Cache policy API", "Current state has no cache_policy")
+
+        restore_payload: dict[str, Any] = {}
+        if "volume_percent" in original_settings:
+            restore_payload["volume_percent"] = int(original_settings.get("volume_percent") or 100)
+        if "is_muted" in original_settings:
+            restore_payload["is_muted"] = bool(original_settings.get("is_muted"))
+        if restore_payload:
+            self.api_post("/api/player/volume", restore_payload)
+        if "av_offset_ms" in original_settings:
+            self.api_post("/api/player/av-offset", {"offset_ms": int(original_settings.get("av_offset_ms") or 0)})
+        if "song_advance_delay_seconds" in original_settings:
+            self.api_post(
+                "/api/player/advance-delay",
+                {"delay_seconds": int(original_settings.get("song_advance_delay_seconds") or 0)},
+            )
+        print_ok("Player settings restored to the pre-test values")
+        self.visual_checkpoint("Service Settings should keep its layout; values may have changed briefly and then restored.")
+
+    def check_users(self) -> None:
+        print_header("Local user management")
+        suffix = str(int(time.time()))[-6:]
+        primary = f"Smoke{suffix}"
+        helper = f"SmokeB{suffix}"
+        self.add_user(primary)
+        self.add_user(helper)
+        self.created_user_names.extend([primary, helper])
+        state = self.api_post("/api/session-users/reorder", {"name": helper, "index": 0})
+        print_ok(f"User reorder API works: {state.get('session_users')}")
+        self.api_post("/api/session-users/remove", {"name": helper})
+        print_ok(f"Removed temporary user: {helper}")
+        self.created_user_names.remove(helper)
+
+    def add_user(self, name: str) -> None:
+        try:
+            state = self.api_post("/api/session-users/add", {"name": name})
+            print_ok(f"Added user: {name} -> {state.get('session_users')}")
+        except ApiError as exc:
+            if "already" in str(exc).lower() or "exists" in str(exc).lower() or "duplicate" in str(exc).lower():
+                print_warn(f"User already exists; continuing: {name}")
+                return
+            raise
+
+    def check_song_flow(self) -> None:
+        print_header("Song request, queue, search, multi-page binding, and cache buffering")
+        song_urls = list(self.args.song_url or [])
+        if song_urls:
+            print_info(f"Using song URLs from command line: {len(song_urls)}")
+        else:
+            song_urls = self.pick_gatcha_song_urls(3)
+        if not song_urls and not self.args.non_interactive:
+            raw = input("Gatcha did not return a usable URL. Enter a Bilibili URL for song testing, or leave blank to skip: ").strip()
+            if raw:
+                song_urls.append(raw)
+        if not song_urls:
+            print_skip("Song request / cache / player visuals", "No --song-url was provided and gatcha returned no usable URL")
+            return
+
+        state = self.get_state()
+        requester = self.created_user_names[0] if self.created_user_names else None
+        if not requester:
+            users = state.get("session_users") or []
+            requester = users[0] if users else "Smoke"
+            if not users:
+                self.add_user(requester)
+                self.created_user_names.append(requester)
+
+        added_items: list[dict[str, Any]] = []
+        multi_item = self.check_search_multi_page_binding(requester)
+        if multi_item:
+            added_items.append(multi_item)
+            self.created_item_ids.append(str(multi_item.get("id") or ""))
+            print_ok(f"Multi-page search item added: {multi_item.get('display_title')} ({multi_item.get('id')})")
+
+        regular_count = 2 if multi_item else 3
+        regular_urls = self.urls_for_count(song_urls, regular_count)
+        top_song_added = False
+        for index, url in enumerate(regular_urls, start=1):
+            has_current = bool((self.get_state().get("current_item") or {}).get("id"))
+            position = "next" if has_current and not top_song_added else "tail"
+            before_ids = self.item_ids(self.get_state())
+            state = self.add_song(url, requester, position=position)
+            if position == "next":
+                top_song_added = True
+            item = self.find_item_not_in_ids(state, before_ids) or self.find_newest_item(state, prefer_playlist=True)
+            if not item:
+                continue
+            added_items.append(item)
+            self.created_item_ids.append(str(item.get("id") or ""))
+            if position == "next":
+                print_ok(f"Top-song request succeeded: {item.get('display_title')} ({item.get('id')})")
+            elif index == 1 and not multi_item:
+                print_ok(f"Current song request succeeded: {item.get('display_title')} ({item.get('id')})")
+            else:
+                print_ok(f"Queued song #{index}: {item.get('display_title')} ({item.get('id')})")
+
+        restore_cache_max = self.expand_cache_window_for_items(len(added_items))
+        try:
+            self.focus_created_items_for_cache_window(added_items)
+            self.visual_checkpoint("Host and Remote pages should now show this test's current song plus queued songs. Inspect both before caching completes.", seconds=5)
+
+            created_ids = [str((item or {}).get("id") or "") for item in added_items if str((item or {}).get("id") or "")]
+            state = self.get_state()
+            queued = state.get("playlist") or []
+            target_id = ""
+            for item_id in reversed(created_ids[1:]):
+                if any(str(item.get("id") or "") == item_id for item in queued):
+                    target_id = item_id
+                    break
+            if target_id:
+                self.api_post("/api/playlist/move-next", {"item_id": target_id})
+                state = self.get_state()
+                first_id = str(((state.get("playlist") or [{}])[0]).get("id") or "")
+                if first_id == target_id:
+                    print_ok(f"Move-to-next/top-song API placed created item at the front: {target_id}")
+                else:
+                    print_warn(f"Move-to-next API returned, but front item is {first_id}; expected {target_id}")
+                self.api_post("/api/playlist/reorder", {"item_id": target_id, "index": 0})
+                print_ok(f"Playlist reorder API works: {target_id} -> index 0")
+                self.exercise_cache_retry(target_id)
+            elif queued:
+                item_id = str(queued[0].get("id") or "")
+                self.api_post("/api/playlist/move-next", {"item_id": item_id})
+                print_ok(f"Move-to-next API was exercised with the only queued item: {item_id}")
+            else:
+                print_skip("Move-to-next/top-song API", "No queued song was available")
+
+            self.wait_for_created_item_caches(self.cache_window_created_items(added_items))
+            if multi_item:
+                self.check_audio_variant_switch(str(multi_item.get("id") or ""))
+            self.visual_checkpoint("Downloads have been waited on. Inspect the player media, queue badges, and Remote queue state.", seconds=8)
+        finally:
+            if restore_cache_max is not None:
+                self.api_post("/api/cache-policy", {"max_cache_items": restore_cache_max})
+                print_ok(f"Restored max cache items to {restore_cache_max}")
+
+    def focus_created_items_for_cache_window(self, added_items: list[dict[str, Any]]) -> None:
+        created_ids = [str((item or {}).get("id") or "") for item in added_items if str((item or {}).get("id") or "")]
+        if not created_ids:
+            return
+        state = self.get_state()
+        current_id = str((state.get("current_item") or {}).get("id") or "")
+        first_id = created_ids[0]
+        if current_id != first_id:
+            try:
+                self.api_post("/api/playlist/play-now", {"item_id": first_id})
+                print_ok(f"Focused first created item as current song: {first_id}")
+            except ApiError as exc:
+                print_warn(f"Could not focus first created item {first_id}: {exc}")
+        for item_id in reversed(created_ids[1:]):
+            try:
+                self.api_post("/api/playlist/move-next", {"item_id": item_id})
+                print_ok(f"Focused created queued item near the front: {item_id}")
+            except ApiError as exc:
+                print_warn(f"Could not move created item near the front {item_id}: {exc}")
+
+    def expand_cache_window_for_items(self, item_count: int) -> int | None:
+        if item_count <= 0:
+            return None
+        state = self.get_state()
+        policy = state.get("cache_policy") or {}
+        try:
+            current_max = int(policy.get("max_cache_items") or 0)
+        except (TypeError, ValueError):
+            return None
+        if current_max >= item_count:
+            return None
+        state = self.api_post("/api/cache-policy", {"max_cache_items": item_count})
+        policy = state.get("cache_policy") or {}
+        print_ok(f"Expanded max cache items for this smoke run: {policy.get('max_cache_items')}")
+        return current_max
+
+    def cache_window_created_items(self, added_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        state = self.get_state()
+        policy = state.get("cache_policy") or {}
+        try:
+            max_items = max(1, int(policy.get("max_cache_items") or 3))
+        except (TypeError, ValueError):
+            max_items = 3
+        active_ids: list[str] = []
+        current = state.get("current_item") or {}
+        if current.get("id"):
+            active_ids.append(str(current.get("id")))
+        for item in state.get("playlist") or []:
+            if len(active_ids) >= max_items:
+                break
+            item_id = str(item.get("id") or "")
+            if item_id:
+                active_ids.append(item_id)
+        filtered = [item for item in added_items if str((item or {}).get("id") or "") in active_ids]
+        skipped = [str((item or {}).get("id") or "") for item in added_items if str((item or {}).get("id") or "") and str((item or {}).get("id") or "") not in active_ids]
+        if skipped:
+            print_warn(f"Skipping cache wait for created items outside the active cache window: {skipped}")
+        return filtered
+
+    def pick_gatcha_song_urls(self, count: int) -> list[str]:
+        print_step(f"No --song-url was provided; picking {count} random videos from gatcha candidates")
+        urls: list[str] = []
+        seen: set[str] = set()
+        attempts = max(6, count * 4)
+        for attempt in range(1, attempts + 1):
+            try:
+                result = self.http_get("/api/gatcha/candidate", timeout=30)
+            except Exception as exc:  # noqa: BLE001
+                print_warn(f"Failed to get gatcha candidate: {exc}")
+                break
+            if not result.get("ok"):
+                print_warn(f"Gatcha candidate returned no song: {result.get('error')}")
+                break
+            candidate = result.get("data") or {}
+            url = str(candidate.get("url") or "").strip()
+            title = str(candidate.get("title") or candidate.get("bvid") or url).strip()
+            if not url:
+                print_warn(f"Gatcha candidate #{attempt} had no URL; skipping")
+                continue
+            if url in seen:
+                print_info(f"Duplicate gatcha candidate; drawing again: {title}")
+                continue
+            seen.add(url)
+            urls.append(url)
+            print_ok(f"Gatcha selected: {title} -> {url}")
+            if len(urls) >= count:
+                break
+        if len(urls) < count:
+            print_warn(f"Gatcha only returned {len(urls)}/{count} usable videos")
+        return urls
+
+    def urls_for_count(self, urls: list[str], count: int) -> list[str]:
+        if not urls or count <= 0:
+            return []
+        return [urls[index % len(urls)] for index in range(count)]
+
+    def check_search_multi_page_binding(self, requester: str) -> dict[str, Any] | None:
+        print_header("Gatcha search and multi-page binding")
+        query = urllib.parse.quote(GATCHA_MULTI_PAGE_QUERY)
+        try:
+            result = self.http_get(f"/api/gatcha/search?q={query}", timeout=30)
+        except Exception as exc:  # noqa: BLE001
+            print_warn(f"Search for multi-page keyword failed: {exc}")
+            return None
+        items = ((result.get("data") or {}).get("items") or []) if isinstance(result, dict) else []
+        print_ok(f"Search keyword returned {len(items)} candidates")
+        if not items:
+            return None
+        for entry in items[:8]:
+            url = str((entry or {}).get("url") or "").strip()
+            title = str((entry or {}).get("title") or (entry or {}).get("bvid") or url).strip()
+            if not url:
+                continue
+            item = self.try_add_multi_page_search_result(url, title, requester)
+            if item:
+                return item
+        print_warn("No searched result triggered multi-page binding in the first candidates")
+        return None
+
+    def try_add_multi_page_search_result(self, url: str, title: str, requester: str) -> dict[str, Any] | None:
+        payload: dict[str, Any] = {
+            "url": url,
+            "position": "tail",
+            "requester_name": requester,
+            "allow_repeat": True,
+        }
+        try:
+            state = self.api_post("/api/playlist/add", payload, timeout=60)
+        except ApiError as exc:
+            if exc.payload.get("code") != "manual_binding_required":
+                print_warn(f"Search result could not be probed: {title}: {exc}")
+                return None
+            binding = exc.payload.get("binding") or {}
+            pages = binding.get("pages") or []
+            if len(pages) <= 1:
+                print_warn(f"Manual binding returned only one page for {title}; skipping")
+                return None
+            page_numbers = [int(page.get("page") or 0) for page in pages if int(page.get("page") or 0) > 0]
+            selected_page = 2 if 2 in page_numbers else page_numbers[min(1, len(page_numbers) - 1)]
+            audio_pages = [page for page in page_numbers[:2] if page > 0]
+            if selected_page not in audio_pages:
+                audio_pages.append(selected_page)
+            print_ok(
+                f"Multi-page binding required for search result; selecting video P{selected_page} "
+                f"with audio pages {audio_pages}: {title}"
+            )
+            payload["selected_video_page"] = selected_page
+            payload["selected_audio_pages"] = audio_pages
+            state = self.api_post("/api/playlist/add", payload, timeout=60)
+            item = self.find_newest_item(state, prefer_playlist=True)
+            if item:
+                print_ok(
+                    f"Multi-page add confirmed: page={item.get('page')} "
+                    f"selected_pages={item.get('selected_pages')} available_pages={item.get('available_pages')}"
+                )
+            return item
+
+        item = self.find_newest_item(state, prefer_playlist=True)
+        if item:
+            item_id = str(item.get("id") or "")
+            print_info(f"Search result did not require multi-page binding; removing probe item: {title} ({item_id})")
+            if item_id:
+                self.api_post("/api/playlist/remove", {"item_id": item_id})
+        return None
+
+    def add_song(self, url: str, requester: str, *, position: str) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "url": url,
+            "position": position,
+            "requester_name": requester,
+            "allow_repeat": True,
+        }
+        try:
+            return self.api_post("/api/playlist/add", payload, timeout=60)
+        except ApiError as exc:
+            if exc.payload.get("code") != "manual_binding_required":
+                raise
+            binding = exc.payload.get("binding") or {}
+            pages = binding.get("pages") or []
+            selected_page = binding.get("preferred_page") or (pages[0].get("page") if pages else None)
+            if not selected_page:
+                raise
+            print_warn(f"Video requires manual page binding; selecting P{selected_page}: {binding.get('title')}")
+            payload["selected_video_page"] = int(selected_page)
+            payload["selected_audio_pages"] = [int(selected_page)]
+            return self.api_post("/api/playlist/add", payload, timeout=60)
+
+    def wait_for_created_item_caches(self, items: list[dict[str, Any]]) -> None:
+        unique_ids: list[str] = []
+        for item in items:
+            item_id = str((item or {}).get("id") or "")
+            if item_id and item_id not in unique_ids:
+                unique_ids.append(item_id)
+        if not unique_ids:
+            print_skip("Cache completion wait", "No created items to wait for")
+            return
+        print_header("Cache completion wait")
+        for item_id in unique_ids:
+            self.wait_for_cache(item_id)
+
+    def exercise_cache_retry(self, item_id: str) -> None:
+        state = self.get_state()
+        item = self.find_item_by_id(state, item_id)
+        if not item:
+            print_skip("Cache retry API", f"Target item not found: {item_id}")
+            return
+        cache_status = str(item.get("cache_status") or "").strip() or "unknown"
+        if cache_status not in {"downloading", "failed"}:
+            print_skip(
+                "Cache retry API",
+                f"Skipped because current cache status is not retryable: {cache_status} ({item_id})",
+            )
+            return
+        self.api_post("/api/cache/retry", {"item_id": item_id})
+        print_ok(f"Cache retry API works: {item_id} (from {cache_status})")
+
+    def wait_for_cache(self, item_id: str) -> bool:
+        print_step(f"Waiting for local cache/buffer: {item_id}")
+        deadline = time.time() + self.args.cache_timeout
+        last_signature = ""
+        while time.time() < deadline:
+            state = self.get_state(timeout=10)
+            item = self.find_item_by_id(state, item_id)
+            if not item:
+                print_warn(f"Item not found: {item_id}")
+                return False
+            signature = json.dumps(
+                {
+                    "status": item.get("cache_status"),
+                    "progress": item.get("cache_progress"),
+                    "message": item.get("cache_message"),
+                    "bytes": item.get("cache_size_bytes"),
+                },
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            if signature != last_signature:
+                print_info(
+                    "Cache state: "
+                    f"status={item.get('cache_status')} progress={item.get('cache_progress')} "
+                    f"bytes={item.get('cache_size_bytes')} message={item.get('cache_message')}"
+                )
+                last_signature = signature
+            if item.get("cache_status") == "ready":
+                print_ok("Cache is ready; the player should use local media resources")
+                return True
+            if item.get("cache_status") == "failed":
+                print_warn("Cache failed; continuing with API checks. Check host page and logs/bbdown.")
+                return False
+            time.sleep(self.args.cache_poll_interval)
+        print_warn("Timed out waiting for cache; continuing.")
+        return False
+
+    def check_audio_variant_switch(self, item_id: str) -> None:
+        state = self.get_state()
+        current = state.get("current_item") or {}
+        if str(current.get("id") or "") != item_id:
+            print_skip("Audio/part switch", "The multi-page item is no longer current")
+            return
+        variants = [variant for variant in current.get("audio_variants") or [] if variant.get("id")]
+        if len(variants) <= 1:
+            print_skip("Audio/part switch", "The current multi-page item has one or zero cached variants")
+            return
+        selected = str(current.get("selected_audio_variant_id") or "")
+        target = next((variant for variant in variants if str(variant.get("id") or "") != selected), variants[0])
+        target_id = str(target.get("id") or "")
+        state = self.api_post("/api/player/audio-variant", {"item_id": item_id, "variant_id": target_id})
+        current = state.get("current_item") or {}
+        if str(current.get("selected_audio_variant_id") or "") == target_id:
+            print_ok(f"Audio/part switch API works: selected variant {target_id}")
+        else:
+            print_warn(f"Audio/part switch did not select expected variant {target_id}")
+        self.visual_checkpoint("Inspect the audio/part selector on Host and Remote; the selected variant should have changed.", seconds=5)
+
+    def check_player_controls(self) -> None:
+        print_header("Player controls, Remote controls, transition view, and reset")
+        state = self.get_state()
+        current = state.get("current_item") or {}
+        current_id = str(current.get("id") or "")
+        if current_id:
+            self.api_post("/api/player/status", {"item_id": current_id, "is_paused": True, "current_time": 0.0})
+            print_ok("Player status report API works")
+            state = self.api_post("/api/player/control", {"action": "toggle-play", "item_id": current_id})
+            command = state.get("player_control_command") or {}
+            print_ok(f"Host play/pause control command: seq={command.get('seq')} action={command.get('action')}")
+            state = self.api_post(
+                "/api/player/control",
+                {"action": "seek-relative", "item_id": current_id, "delta_seconds": 10},
+            )
+            command = state.get("player_control_command") or {}
+            print_ok(f"Host seek control command: seq={command.get('seq')} delta={command.get('delta_seconds')}")
+            state = self.api_post(
+                "/api/player/control",
+                {"action": "seek-relative", "item_id": current_id, "delta_seconds": -5},
+                remote=True,
+            )
+            command = state.get("player_control_command") or {}
+            print_ok(f"Remote seek control command: seq={command.get('seq')} delta={command.get('delta_seconds')}")
+        else:
+            print_skip("Player controls", "No current song")
+
+        state = self.get_state()
+        if state.get("playlist") and current_id:
+            original_delay = int((state.get("player_settings") or {}).get("song_advance_delay_seconds") or 0)
+            self.api_post("/api/player/advance-delay", {"delay_seconds": 5})
+            self.api_post("/api/player/control", {"action": "toggle-play", "item_id": current_id}, remote=True)
+            self.api_post("/api/player/control", {"action": "seek-relative", "item_id": current_id, "delta_seconds": 300}, remote=True)
+            print_ok("Requested Remote play plus large seek to exercise end-of-song transition UI")
+            self.visual_checkpoint(
+                "Watch the Host player now. If playback reaches the end, the in-player countdown should stay visible without leaving fullscreen.",
+                seconds=self.args.transition_visual_pause,
+            )
+            state_after_seek = self.get_state()
+            current_after_seek = (state_after_seek.get("current_item") or {}).get("id")
+            if current_after_seek == current_id and state_after_seek.get("playlist"):
+                self.api_post("/api/player/next", {})
+                print_ok("Forced next-song API after transition visual window")
+            else:
+                print_ok("Current song changed during transition visual window")
+            self.api_post("/api/player/advance-delay", {"delay_seconds": original_delay})
+            new_current = self.get_state().get("current_item") or {}
+            new_current_id = str(new_current.get("id") or "")
+            if new_current_id:
+                self.wait_for_cache(new_current_id)
+            self.visual_checkpoint("Inspect the player after the transition. The next song should be loaded and the queue should update.", seconds=8)
+        else:
+            print_skip("Transition UI and next-song API", "Need a current song and at least one queued song")
+
+        state = self.api_post("/api/player/reset", {})
+        settings = state.get("player_settings") or {}
+        print_ok(
+            "Player reset API works: "
+            f"mode={state.get('playback_mode')} volume={settings.get('volume_percent')} "
+            f"muted={settings.get('is_muted')} offset={settings.get('av_offset_ms')}"
+        )
+        self.visual_checkpoint("Confirm the player reloaded while queue/history stayed intact.", seconds=8)
+
+    def check_gatcha(self) -> None:
+        print_header("Gatcha")
+        try:
+            result = self.http_get(f"/api/gatcha/search?q={urllib.parse.quote(GATCHA_MULTI_PAGE_QUERY)}")
+            items = ((result.get("data") or {}).get("items") or []) if isinstance(result, dict) else []
+            print_ok(f"Gatcha search API works for multi-page keyword: {len(items)} results")
+        except ApiError as exc:
+            print_warn(f"Gatcha search returned an error: {exc}")
+
+        try:
+            result = self.http_get("/api/gatcha/candidate", timeout=30)
+            if result.get("ok"):
+                print_ok("Gatcha candidate API works")
+            else:
+                print_warn(f"Gatcha candidate returned no song: {result.get('error')}")
+        except Exception as exc:  # noqa: BLE001
+            print_warn(f"Gatcha candidate skipped/failed: {exc}")
+
+    def check_destructive_maintenance(self) -> None:
+        print_header("Destructive data maintenance APIs")
+        print_warn("About to test clear playlist, clear history, and clear data. This changes runtime data.")
+        if not self.args.yes:
+            confirm = input("Type YES to continue destructive checks: ").strip()
+            if confirm != "YES":
+                print_skip("Destructive data maintenance APIs", "User did not confirm")
+                return
+        self.api_post("/api/playlist/clear", {})
+        print_ok("Clear playlist API works")
+        self.api_post("/api/history/clear", {})
+        print_ok("Clear history API works")
+        self.api_post("/api/data/reset", {})
+        print_ok("Clear data API works")
+
+    def final_report(self) -> None:
+        print_header("Done")
+        state = self.get_state()
+        self.print_state_summary(state, label="Final state")
+        print_info("Final visual check: service settings, player, queue, remote QR, and BBDown login state.")
+        print_info("Manual cookie input was intentionally not tested.")
+        if not self.args.no_wait_at_end:
+            input("Press Enter to finish and stop the server started by this script...")
+
+    def api_post(
+        self,
+        path: str,
+        payload: dict[str, Any],
+        *,
+        timeout: int | float = 20,
+        remote: bool = False,
+    ) -> dict[str, Any]:
+        response = self.http_post(path, payload, timeout=timeout, remote=remote)
+        if not response.get("ok"):
+            raise ApiError(path, 200, response)
+        data = response.get("data")
+        return data if isinstance(data, dict) else response
+
+    def get_state(self, *, timeout: int | float = 10, remote: bool = False) -> dict[str, Any]:
+        response = self.http_get("/api/state", timeout=timeout, remote=remote)
+        if not response.get("ok"):
+            raise ApiError("/api/state", 200, response)
+        data = response.get("data")
+        if not isinstance(data, dict):
+            raise RuntimeError("/api/state did not return object data")
+        return data
+
+    def request_headers(self, *, remote: bool = False, extra: dict[str, str] | None = None) -> dict[str, str]:
+        headers = {"X-Bilikara-Client": REMOTE_CLIENT_ID if remote else CLIENT_ID}
+        if remote:
+            headers["Referer"] = f"{self.base_url}/remote"
+        if extra:
+            headers.update(extra)
+        return headers
+
+    def http_get(
+        self,
+        path: str,
+        *,
+        timeout: int | float = 10,
+        expect_json: bool = True,
+        remote: bool = False,
+    ) -> Any:
+        request = urllib.request.Request(
+            self.base_url + path,
+            headers=self.request_headers(remote=remote),
+            method="GET",
+        )
+        return self.open_request(path, request, timeout=timeout, expect_json=expect_json)
+
+    def http_post(
+        self,
+        path: str,
+        payload: dict[str, Any],
+        *,
+        timeout: int | float = 20,
+        remote: bool = False,
+    ) -> dict[str, Any]:
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            self.base_url + path,
+            data=body,
+            headers=self.request_headers(
+                remote=remote,
+                extra={"Content-Type": "application/json; charset=utf-8"},
+            ),
+            method="POST",
+        )
+        return self.open_request(path, request, timeout=timeout, expect_json=True)
+
+    def open_request(
+        self,
+        path: str,
+        request: urllib.request.Request,
+        *,
+        timeout: int | float,
+        expect_json: bool,
+    ) -> Any:
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                body = response.read()
+                if not expect_json:
+                    return body
+                return json.loads(body.decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                payload = {"ok": False, "error": raw or str(exc)}
+            raise ApiError(path, exc.code, payload) from exc
+
+    @staticmethod
+    def item_ids(state: dict[str, Any]) -> set[str]:
+        ids: set[str] = set()
+        current = state.get("current_item")
+        if isinstance(current, dict) and current.get("id"):
+            ids.add(str(current.get("id")))
+        for item in state.get("playlist") or []:
+            if isinstance(item, dict) and item.get("id"):
+                ids.add(str(item.get("id")))
+        return ids
+
+    @staticmethod
+    def find_item_not_in_ids(state: dict[str, Any], known_ids: set[str]) -> dict[str, Any] | None:
+        current = state.get("current_item")
+        if isinstance(current, dict) and current.get("id") and str(current.get("id") or "") not in known_ids:
+            return current
+        for item in state.get("playlist") or []:
+            if isinstance(item, dict) and item.get("id") and str(item.get("id") or "") not in known_ids:
+                return item
+        return None
+
+    @staticmethod
+    def find_newest_item(state: dict[str, Any], *, prefer_playlist: bool = False) -> dict[str, Any] | None:
+        playlist = state.get("playlist") or []
+        if prefer_playlist and playlist:
+            return playlist[-1]
+        if playlist:
+            return playlist[-1]
+        current = state.get("current_item")
+        return current if isinstance(current, dict) else None
+
+    @staticmethod
+    def find_item_by_id(state: dict[str, Any], item_id: str) -> dict[str, Any] | None:
+        current = state.get("current_item")
+        if isinstance(current, dict) and str(current.get("id") or "") == item_id:
+            return current
+        for item in state.get("playlist") or []:
+            if isinstance(item, dict) and str(item.get("id") or "") == item_id:
+                return item
+        return None
+
+    @staticmethod
+    def print_state_summary(state: dict[str, Any], *, label: str) -> None:
+        current = state.get("current_item") or {}
+        playlist = state.get("playlist") or []
+        history = state.get("history") or []
+        users = state.get("session_users") or []
+        settings = state.get("player_settings") or {}
+        bbdown = state.get("bbdown") or {}
+        cache_policy = state.get("cache_policy") or {}
+        print_info(
+            f"{label}: mode={state.get('playback_mode')} current={current.get('display_title') or 'None'} "
+            f"queue={len(playlist)} history={len(history)} users={users}"
+        )
+        print_info(
+            "Player settings: "
+            f"volume={settings.get('volume_percent')} muted={settings.get('is_muted')} "
+            f"offset={settings.get('av_offset_ms')}ms delay={settings.get('song_advance_delay_seconds')}s"
+        )
+        print_info(
+            "Tools/cache: "
+            f"bbdown={bbdown.get('state')} logged_in={bbdown.get('logged_in')} "
+            f"cache_items={cache_policy.get('cached_item_count')} usage={cache_policy.get('usage_bytes')} bytes"
+        )
+
+    @staticmethod
+    def print_remote_access(state: dict[str, Any]) -> None:
+        remote = state.get("remote_access") or {}
+        print_info(f"Remote local_url: {remote.get('local_url')}")
+        print_info(f"Remote preferred_url: {remote.get('preferred_url')}")
+        lan_urls = remote.get("lan_urls") or []
+        if lan_urls:
+            print_info(f"Remote LAN URLs: {', '.join(map(str, lan_urls))}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Open the real bilikara host page and run developer smoke checks against the configured port.",
+    )
+    parser.add_argument(
+        "--song-url",
+        action="append",
+        default=[],
+        help="Bilibili URL used for song-request/cache/player tests. Repeat for multiple songs. If omitted, three URLs are picked from gatcha candidates.",
+    )
+    parser.add_argument(
+        "--home",
+        help="Optional BILIKARA_HOME for this run. This changes data/tool location only, not the frontend or port.",
+    )
+    parser.add_argument("--skip-bbdown-login", action="store_true", help="Skip QR login flow.")
+    parser.add_argument("--force-bbdown-login", action="store_true", help="Logout first, then test QR login flow.")
+    parser.add_argument("--bbdown-timeout", type=int, default=DEFAULT_BBDOWN_TIMEOUT_SECONDS)
+    parser.add_argument("--cache-timeout", type=int, default=DEFAULT_CACHE_TIMEOUT_SECONDS)
+    parser.add_argument("--cache-poll-interval", type=int, default=5)
+    parser.add_argument("--visual-pause", type=float, default=DEFAULT_VISUAL_PAUSE_SECONDS)
+    parser.add_argument("--transition-visual-pause", type=float, default=DEFAULT_TRANSITION_VISUAL_SECONDS)
+    parser.add_argument("--destructive", action="store_true", help="Also test clear playlist/history/data endpoints.")
+    parser.add_argument("--yes", action="store_true", help="Do not ask for destructive confirmation.")
+    parser.add_argument("--non-interactive", action="store_true", help="Do not prompt for missing song URL.")
+    parser.add_argument("--no-open-browser", action="store_true", help="Do not call webbrowser.open; prints URL only.")
+    parser.add_argument("--no-wait-at-end", action="store_true", help="Exit immediately after checks.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.home:
+        os.environ["BILIKARA_HOME"] = str(Path(args.home).expanduser())
+
+    from bilikara.config import HOST, PORT
+
+    browser_host = "127.0.0.1" if HOST in {"0.0.0.0", "::"} else HOST
+    base_url = f"http://{browser_host}:{PORT}"
+
+    handle = None if args.home else maybe_use_existing_server(base_url)
+    if handle is None:
+        handle = start_server_exact_port(HOST, PORT, base_url)
+
+    runner = SmokeRunner(args, handle)
+    try:
+        runner.run()
+        return 0
+    except KeyboardInterrupt:
+        print_warn("Interrupted by user.")
+        return 130
+    except Exception as exc:  # noqa: BLE001
+        print_fail(str(exc))
+        return 1
+    finally:
+        handle.stop()
+
+
+def maybe_use_existing_server(base_url: str) -> ServerHandle | None:
+    request = urllib.request.Request(base_url + "/api/state", headers={"X-Bilikara-Client": CLIENT_ID})
+    try:
+        with urllib.request.urlopen(request, timeout=1.5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except Exception:  # noqa: BLE001
+        return None
+    if payload.get("ok") and isinstance(payload.get("data"), dict):
+        print_warn(f"Detected an existing bilikara service on this port; reusing it: {base_url}")
+        return ServerHandle(base_url=base_url, started_here=False)
+    return None
+
+
+def start_server_exact_port(host: str, port: int, base_url: str) -> ServerHandle:
+    from http.server import ThreadingHTTPServer
+
+    from bilikara.server import BilikaraHandler, CONTEXT
+
+    errors: "queue.Queue[BaseException]" = queue.Queue()
+    try:
+        server = ThreadingHTTPServer((host, port), BilikaraHandler)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Could not bind the configured port {host}:{port}. This script will not auto-switch ports; close the process using it or change BILIKARA_PORT before running."
+        ) from exc
+
+    CONTEXT.bind_server(server, shutdown_on_last_client=False)
+
+    def serve() -> None:
+        try:
+            server.serve_forever()
+        except BaseException as exc:  # noqa: BLE001
+            errors.put(exc)
+
+    thread = threading.Thread(target=serve, name="bilikara-dev-smoke-server", daemon=True)
+    thread.start()
+    time.sleep(0.3)
+    if not errors.empty():
+        raise RuntimeError(f"Server failed while starting: {errors.get()}")
+    print_ok(f"Started service with current config: {base_url}")
+    return ServerHandle(base_url=base_url, started_here=True, server=server, thread=thread, context=CONTEXT)
+
+
+def console_text(value: object) -> str:
+    return str(value).encode("ascii", "backslashreplace").decode("ascii")
+
+
+def print_header(title: str) -> None:
+    print(f"\n=== {console_text(title)} ===")
+
+
+def print_step(message: str) -> None:
+    print(f"[STEP] {console_text(message)}")
+
+
+def print_info(message: str) -> None:
+    print(f"[INFO] {console_text(message)}")
+
+
+def print_ok(message: str) -> None:
+    print(f"[ OK ] {console_text(message)}")
+
+
+def print_warn(message: str) -> None:
+    print(f"[WARN] {console_text(message)}")
+
+
+def print_skip(name: str, reason: str) -> None:
+    print(f"[SKIP] {console_text(name)}: {console_text(reason)}")
+
+
+def print_fail(message: str) -> None:
+    print(f"[FAIL] {console_text(message)}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -40,6 +40,10 @@ class CacheManagerOutputTest(unittest.TestCase):
         self.assertTrue(CacheManager._should_force_refresh_bbdown("请尝试升级到最新版本后重试!"))
         self.assertFalse(CacheManager._should_force_refresh_bbdown("缓存失败"))
 
+    def test_find_stream_file_returns_none_when_directory_disappears_mid_scan(self):
+        with patch.object(Path, "rglob", side_effect=FileNotFoundError("gone")):
+            self.assertIsNone(CacheManager._find_stream_file(Path("C:/missing"), {".mp4"}))
+
 class CacheManagerPolicyTest(unittest.TestCase):
     def setUp(self) -> None:
         self.temp_dir = TemporaryDirectory()
@@ -239,6 +243,57 @@ class CacheManagerPolicyTest(unittest.TestCase):
                     self.assertEqual(retried.cache_message, "准备重新下载")
                     self.assertEqual(retried.video_media_url, "")
                     enqueue_mock.assert_called_once_with("song-a")
+            finally:
+                manager.shutdown()
+
+    def test_retry_item_keeps_cache_dir_while_item_is_in_flight(self):
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir):
+            manager = CacheManager(self.store, max_cache_items=3)
+            try:
+                item = self.make_item("song-a")
+                self.store.add_item(item, requester_name="cache-test-user")
+                item_dir = self.cache_dir / "song-a" / "video-p1"
+                item_dir.mkdir(parents=True, exist_ok=True)
+                (item_dir / "video.mp4").write_bytes(b"media")
+                self.store.update_item(
+                    "song-a",
+                    cache_status="downloading",
+                    cache_message="downloading",
+                    persist_backup=False,
+                )
+                with manager.lock:
+                    manager.desired_ids = {"song-a"}
+                    manager.pending_ids = {"song-a"}
+                with patch.object(manager, "enqueue") as enqueue_mock, patch.object(
+                    manager, "_terminate_process"
+                ) as terminate_mock:
+                    manager.retry_item("song-a")
+                    retried = self.store.get_item("song-a")
+                    self.assertIsNotNone(retried)
+                    self.assertEqual(retried.cache_status, "pending")
+                    self.assertTrue((self.cache_dir / "song-a").exists())
+                    self.assertIn("song-a", manager.retry_requested_ids)
+                    enqueue_mock.assert_not_called()
+                    terminate_mock.assert_not_called()
+            finally:
+                manager.shutdown()
+
+    def test_cache_item_clears_old_cache_dir_before_processing_pending_retry(self):
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir):
+            manager = CacheManager(self.store, max_cache_items=3)
+            try:
+                item = self.make_item("song-a")
+                self.store.add_item(item, requester_name="cache-test-user")
+                item_dir = self.cache_dir / "song-a" / "video-p1"
+                item_dir.mkdir(parents=True, exist_ok=True)
+                (item_dir / "video.mp4").write_bytes(b"media")
+                with manager.lock:
+                    manager.desired_ids = {"song-a"}
+                    manager.retry_requested_ids.add("song-a")
+                with patch.object(manager, "_cache_item_multi") as cache_item_multi_mock:
+                    manager._cache_item("song-a")
+                    self.assertFalse((self.cache_dir / "song-a").exists())
+                    cache_item_multi_mock.assert_called_once()
             finally:
                 manager.shutdown()
 


### PR DESCRIPTION
## 中文
## Summary
本 PR 汇总了两个相关提交：

1. 扩展开发者 smoke 测试，使其更完整地覆盖真实的 host + remote 播放流程
2. 加固 re-cache 与切歌行为，使新的 smoke 覆盖在缓存竞争与长歌曲切换场景下更加稳定

## Commit Breakdown

### Commit 1
`扩展开发者 smoke 测试覆盖范围（涵盖 remote、队列、缓存与切歌流程）`

- 在 `scripts/dev_smoke_test.py` 中增加更全面的端到端 smoke 覆盖
- 同时打开 Host 与 Remote 页面以便可视化验证
- 覆盖 remote 专用 API 调用与控制路径
- 覆盖播放列表重排与当前歌曲 re-cache 流程
- 改进切歌 UI 测试，使倒计时 / 全屏行为对开发者可见

### Commit 2
`增强重新缓存竞争处理与接近结尾的切歌寻址稳定性`

- 修复 `bilikara/cache.py` 中的缓存重试竞争问题
- 避免在缓存任务仍在进行时过早删除缓存目录
- 在重试 / 重新缓存过程中，允许媒体文件扫描容忍路径短暂消失
- 在 `tests/test_cache.py` 中增加回归测试覆盖

## Full Smoke Test Coverage
运行:python scripts\dev_smoke_test.py

### Service / bootstrap
- 若已有配置好的 bilikara 服务则复用
- 否则在指定 host/port 启动服务，不改变前端布局或端口
- 在浏览器中打开 Host 与 Remote 页面
- 验证 `/`、`/remote`、`/app.js`、`yles.css`、`/remote.js`、`/remote-queue.js`

### Remote surface
- 验证 Remote `/apiate`
- 验证 Remote gatcha 搜索 API
- 测试过程中保持 Remote 页面开启以供观察

### BBDown / tool readiness
- 验证 BBDown 登录状态
- 必要时执行 BBDown 二维码登录流程
- 等待扫码完成并将二维码图片保存至本地供开发者使用
- 有意跳过手动 cookie 输入测试

### Service settings / player settings
- 切换播放模式并恢复
- 修改并恢复音量 / 静音状态
- 修改并恢复音视频偏移
- 修改并恢复歌曲切换延迟
- 修改并恢复缓存策略
- 覆盖视频清晰度选择
- 覆盖 Hi-Res 音频策略开关

### Session user management
- 添加临时用户
- 调整用户顺序
- 删除临时用户

### Song request / queue flow
- 支持显式 `--song-url`
- 否则自动随机选择 gatcha 候选
- 将歌曲添加到 current / tail / next 位置
- 覆盖置顶歌曲行为
- 将新建项目聚焦到当前缓存窗口
- 暂停以便观察 host / remote 队列

### Search / multi-P / binding flow
- 使用关键词 `果厨` 进行搜索
- 检查搜索结果中的多 P 手动绑定情况
- 在需要时选择视频页与音频页
- 通过与 UI 相同的 API 路径添加多页项目
- 验证已选 / 可选页元数据

### Queue operations
- play-now / 切换当前焦点
- move-next
- 按索引重排
- 按循环顺序重排播放列表
- remote 触发的重排路径
- 对可重试项执行 retry-cache

### Cache / download coverage
- 在测试期间临时扩大缓存窗口
- 等待缓存窗口内项目完成缓存
- 观察缓存进度 / 状态 / 字节变化
- 验证当前歌曲 `force=true` 的 re-cache 流程
- 验证缓存路径在重试中消失时不会崩溃

### Audio / part selection
- 验证多页项目中的音频版本 / 分段切换

### Player controls
- host 播放 / 暂停
- host 相对 seek
- remote 相对 seek
- 播放器状态上报
- 重置播放器状态

### Transition UI / next-song flow
- 设置临时歌曲切换延迟用于测试
- 使用 duration + 当前播放时间跳转到接近结尾
- 等待指令确认后继续
- 保持界面以观察播放器内倒计时
- 验证自然自动切歌
- 若未切歌则回退到手动下一首

### Gatcha coverage
- 验证 gatcha 搜索
- 验证随机候选 API

### Optional destructive coverage
- 清空播放列表
- 清空历史记录
- 清空运行时数据

## Reliability / regression fixes included in this PR
- 在重试过程中将 pending 与 active 缓存项视为进行中任务
- 在下载完成或校验阶段触发重试时安全重启缓存流程
- 媒体扫描过程中允许目录短暂消失
- 增加单元测试覆盖：
  - 进行中任务的重试行为
  - worker 重启前的重试清理
  - 扫描过程中缓存目录消失场景

## Validation
- `py -m unittest tests.test_cache tests.test_server tests.test_store_and_bilibili`
- `py -m py_compile bilikara\cache.py tests\test_cache.py scripts\dev_smoke_test.py`

## English
## Summary
This PR rolls up two related commits:

1. expand the developer smoke test so it exercises the real host + remote playback workflow much more completely
2. harden re-cache and transition behavior so the new smoke coverage is stable against in-flight cache races and long-song transition cases

## Commit Breakdown

### Commit 1
`Expand developer smoke coverage across remote, queue, cache, and transition flows`

- add broader end-to-end smoke coverage in `scripts/dev_smoke_test.py`
- open both Host and Remote pages for visual verification
- exercise remote-specific API calls and control paths
- cover playlist resort and current-song re-cache flows
- improve transition UI testing so countdown/fullscreen behavior is visible to the developer

### Commit 2
`Harden re-cache race handling and near-end transition seeking`

- fix cache retry races in `bilikara/cache.py`
- avoid deleting cache directories too early while a cache task is still in flight
- make media file discovery tolerate transient path disappearance during retry/re-cache
- add regression coverage in `tests/test_cache.py`

## Full Smoke Test Coverage
Run:python scripts\dev_smoke_test.py
### Service / bootstrap
- reuse an existing configured bilikara service when available
- otherwise start the service on the configured host/port without changing frontend layout or port
- open Host and Remote pages in the browser
- verify `/`, `/remote`, `/app.js`, `yles.css`, `/remote.js`, and `/remote-queue.js`

### Remote surface
- verify Remote `/apiate`
- verify Remote gatcha search API
- keep Remote open for visual inspection during the run

### BBDown / tool readiness
- verify BBDown login state
- exercise BBDown QR login flow when needed
- wait for QR scan completion and save QR image locally for developer use
- intentionally skip manual cookie input testing

### Service settings / player settings
- switch playback mode and restore it
- update and restore volume / mute
- update and restore AV offset
- update and restore song advance delay
- update and restore cache policy
- exercise video quality selection
- exercise Hi-Res audio policy toggle

### Session user management
- add temporary users
- reorder session users
- remove temporary users

### Song request / queue flow
- accept explicit `--song-url`
- otherwise pick random gatcha candidates automatically
- add songs to current / tail / next positions
- exercise top-song behavior
- focus created items into the active cache window
- pause for host/remote queue inspection

### Search / multi-P / binding flow
- search with keyword `果厨`
- probe search results for manual multi-page binding
- select video page and audio pages when manual binding is required
- add a multi-page item through the same API path used by the UI
- verify selected/available page metadata

### Queue operations
- play-now / move current focus
- move-next
- reorder to index
- playlist resort by cycle order
- remote-triggered resort path
- retry-cache on a queued item when retryable

### Cache / download coverage
- expand cache window temporarily for the smoke run
- wait for created items inside the active cache window to finish caching
- observe cache progress / status / bytes over time
- verify current-song re-cache path with `force=true`
- verify retry handling without crashing when cache paths disappear mid-retry

### Audio / part selection
- verify audio variant / part switching on the current multi-page item

### Player controls
- host play/pause command
- host relative seek
- remote relative seek
- player status reporting
- reset player state

### Transition UI / next-song flow
- set temporary song advance delay for transition testing
- seek near the real end of the current song using duration + current playback time
- wait for command ack before continuing
- hold the visual window so the in-player countdown can be inspected
- verify auto-advance when it happens naturally
- fall back to explicit next-song only if the song still has not changed

### Gatcha coverage
- verify gatcha search
- verify random candidate API

### Optional destructive coverage
- clear playlist
- clear history
- clear runtime data

## Reliability / regression fixes included in this PR
- treat pending and active cache items as in-flight during retry
- restart cache safely when retry is requested during download completion or validation
- make stream/media file scans tolerate transient directory disappearance
- add unit tests covering:
  - in-flight retry behavior
  - retry cleanup before worker restart
  - disappearing cache directories during scan

## Validation
- `py -m unittest tests.test_cache tests.test_server tests.test_store_and_bilibili`
- `py -m py_compile bilikara\cache.py tests\test_cache.py scripts\dev_smoke_test.py`



    parser.add_argument("--skip-bbdown-login", action="store_true", help="Skip QR login flow.")
    parser.add_argument("--force-bbdown-login", action="store_true", help="Logout first, then test QR login flow.")
    parser.add_argument("--bbdown-timeout", type=int, default=DEFAULT_BBDOWN_TIMEOUT_SECONDS)
    parser.add_argument("--cache-timeout", type=int, default=DEFAULT_CACHE_TIMEOUT_SECONDS)
    parser.add_argument("--cache-poll-interval", type=int, default=5)
    parser.add_argument("--visual-pause", type=float, default=DEFAULT_VISUAL_PAUSE_SECONDS)
    parser.add_argument("--transition-visual-pause", type=float, default=DEFAULT_TRANSITION_VISUAL_SECONDS)
    parser.add_argument("--destructive", action="store_true", help="Also test clear playlist/history/data endpoints.")
    parser.add_argument("--yes", action="store_true", help="Do not ask for destructive confirmation.")
    parser.add_argument("--non-interactive", action="store_true", help="Do not prompt for missing song URL.")
    parser.add_argument("--no-open-browser", action="store_true", help="Do not call webbrowser.open; prints URL only.")
    parser.add_argument("--no-wait-at-end", action="store_true", help="Exit immediately after checks.")
