### PR TITLE
Feature&fix:Enhance and harden gatcha with persistent UID management, incremental cache refresh, Remote-side UID support, smoke test resilience improvements, and Windows cache retry stability fixes.

### DIFF
--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -10,7 +10,7 @@ import re
 import random
 import hashlib
 import time
-from .config import BILIBILI_HEADERS, GATCHA_UIDS, GATCHA_KEYWORDS
+from .config import BILIBILI_HEADERS, GATCHA_KEYWORDS
 from dataclasses import dataclass
 from .models import PlaylistItem
 import bilikara.config as cfg  
@@ -18,6 +18,10 @@ import bilikara.config as cfg
 VIDEO_PATH_RE = re.compile(r"/video/(?P<vid>(BV[0-9A-Za-z]+|av\d+))", re.IGNORECASE)
 BV_RE = re.compile(r"^(BV[0-9A-Za-z]+)$", re.IGNORECASE)
 AV_RE = re.compile(r"^(av\d+)$", re.IGNORECASE)
+SPACE_UID_RE = re.compile(
+    r"^(?:https?://)?space\.bilibili\.com/(?P<uid>\d+)(?:[/?#].*)?$",
+    re.IGNORECASE,
+)
 SHORT_HOSTS = {"b23.tv", "bili2233.cn"}
 DURATION_TOLERANCE_SECONDS = 3
 WBI_MIXIN_TABLE = [
@@ -30,12 +34,17 @@ _WBI_CACHE = {
     "keys": None,
     "last_update": 0
 }
+_GATCHA_PROFILE_CACHE: dict[str, tuple[float, dict]] = {}
+_GATCHA_PROFILE_CACHE_LOCK = threading.Lock()
 _GATCHA_CACHE_LOCK = threading.Lock()
+_GATCHA_UIDS_LOCK = threading.Lock()
 _GATCHA_REFRESH_LOCK = threading.Lock()
 _GATCHA_REQUEST_LOCK = threading.Lock()
 _GATCHA_LAST_REQUEST_AT = 0.0
 _GATCHA_CACHE_FILE = cfg.DATA_DIR / "gatcha_cache.json"
+_GATCHA_UIDS_FILE = cfg.DATA_DIR / "gatcha_uids.json"
 GATCHA_RETRY_DELAY_SECONDS = 5
+GATCHA_PROFILE_CACHE_TTL_SECONDS = 300
 MISSING_BILIBILI_COOKIE_MESSAGE = "请登录 Bilibili 账号或输入 Cookie"
 _COOKIE_REQUIRED_KEYS = {"sessdata", "bili_jct"}
 _COOKIE_PREFERRED_ORDER = (
@@ -131,6 +140,107 @@ def cookie_from_bbdown_data() -> str:
 
 def effective_bilibili_cookie() -> str:
     return cookie_from_bbdown_data() or str(cfg.COOKIE or "").strip()
+
+
+def _normalize_gatcha_uid(raw_mid: object) -> str:
+    text = str(raw_mid or "").strip()
+    if not text:
+        raise BilibiliError("UID 不能为空")
+
+    if text.isdigit():
+        uid = text
+    else:
+        match = SPACE_UID_RE.match(text)
+        if not match:
+            lower_text = text.lower()
+            if BV_RE.match(text) or AV_RE.match(text) or "/video/" in lower_text:
+                raise BilibiliError("请输入 Bilibili UID 或 UP 主空间链接，不要输入 BV/av 视频号")
+            raise BilibiliError("请输入纯数字 UID 或 UP 主空间链接")
+        uid = match.group("uid")
+
+    uid = uid.lstrip("0") or "0"
+    if not uid.isdigit() or int(uid) <= 0:
+        raise BilibiliError("Bilibili UID 必须是正整数")
+    return uid
+
+
+def _normalize_gatcha_uid_list(raw_uids: object) -> list[str]:
+    if not isinstance(raw_uids, list):
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_mid in raw_uids:
+        try:
+            mid = _normalize_gatcha_uid(raw_mid)
+        except BilibiliError:
+            continue
+        if mid in seen:
+            continue
+        seen.add(mid)
+        normalized.append(mid)
+    return normalized
+
+
+def _default_gatcha_uids() -> list[str]:
+    return _normalize_gatcha_uid_list(getattr(cfg, "GATCHA_UIDS", []))
+
+
+def _save_gatcha_uid_payload(uid_payload: dict) -> None:
+    cfg.DATA_DIR.mkdir(parents=True, exist_ok=True)
+    temp_path = _GATCHA_UIDS_FILE.with_suffix(".tmp")
+    with temp_path.open("w", encoding="utf-8") as handle:
+        json.dump(uid_payload, handle, ensure_ascii=False, indent=2)
+    temp_path.replace(_GATCHA_UIDS_FILE)
+
+
+def _load_gatcha_uid_payload() -> dict:
+    if not _GATCHA_UIDS_FILE.exists():
+        payload = {"uids": _default_gatcha_uids(), "updated_at": time.time()}
+        _save_gatcha_uid_payload(payload)
+        return payload
+
+    try:
+        with _GATCHA_UIDS_FILE.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        payload = {"uids": _default_gatcha_uids(), "updated_at": time.time()}
+        _save_gatcha_uid_payload(payload)
+        return payload
+
+    if isinstance(payload, list):
+        normalized_payload = {
+            "uids": _normalize_gatcha_uid_list(payload),
+            "updated_at": time.time(),
+        }
+        _save_gatcha_uid_payload(normalized_payload)
+        return normalized_payload
+
+    if not isinstance(payload, dict):
+        payload = {"uids": _default_gatcha_uids(), "updated_at": time.time()}
+        _save_gatcha_uid_payload(payload)
+        return payload
+
+    return {
+        "uids": _normalize_gatcha_uid_list(payload.get("uids")),
+        "updated_at": float(payload.get("updated_at") or 0),
+    }
+
+
+def gatcha_uid_snapshot() -> dict:
+    with _GATCHA_UIDS_LOCK:
+        payload = _load_gatcha_uid_payload()
+    uids = payload.get("uids") if isinstance(payload, dict) else []
+    if not isinstance(uids, list):
+        uids = []
+    return {
+        "uids": list(uids),
+        "count": len(uids),
+        "updated_at": float(payload.get("updated_at") or 0),
+    }
+
+
+def _configured_gatcha_uids() -> list[str]:
+    return gatcha_uid_snapshot()["uids"]
 
 @dataclass
 class VideoReference:
@@ -262,15 +372,61 @@ def _request_gatcha_page(mid: str, page_number: int, page_size: int = 50) -> dic
         raise
 
 
+def _request_gatcha_uid_profile(mid: str) -> dict:
+    normalized_mid = str(mid).strip()
+    now = time.time()
+    with _GATCHA_PROFILE_CACHE_LOCK:
+        cached_at, cached_profile = _GATCHA_PROFILE_CACHE.get(normalized_mid, (0.0, {}))
+        if cached_profile and now - cached_at < GATCHA_PROFILE_CACHE_TTL_SECONDS:
+            return dict(cached_profile)
+
+    try:
+        img_key, sub_key = get_cached_wbi_keys()
+    except Exception as exc:
+        raise BilibiliError(f"WBI keys failed: {exc}") from exc
+
+    signed_params = enc_wbi({"mid": normalized_mid}, img_key, sub_key)
+    query_string = urllib.parse.urlencode(signed_params)
+    url = f"https://api.bilibili.com/x/space/wbi/acc/info?{query_string}"
+    _wait_for_gatcha_request_slot()
+    payload = request_json(url)
+    try:
+        code = int(payload.get("code") or 0)
+    except (TypeError, ValueError):
+        code = 0
+    if code != 0:
+        message = str(payload.get("message") or "UP 主信息获取失败")
+        raise BilibiliError(message)
+
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise BilibiliError("UP 主信息获取失败")
+    owner_mid = str(data.get("mid") or normalized_mid).strip()
+    owner_name = str(data.get("name") or "").strip()
+    if not owner_mid.isdigit() or int(owner_mid) <= 0 or not owner_name:
+        raise BilibiliError("没有找到这个 UID 对应的 UP 主")
+    profile = {
+        "uid": owner_mid.lstrip("0") or "0",
+        "name": owner_name,
+        "space_url": f"https://space.bilibili.com/{owner_mid}",
+    }
+    with _GATCHA_PROFILE_CACHE_LOCK:
+        _GATCHA_PROFILE_CACHE[normalized_mid] = (time.time(), dict(profile))
+        _GATCHA_PROFILE_CACHE[profile["uid"]] = (time.time(), dict(profile))
+    return profile
+
+
 def _fetch_gatcha_videos_for_uid(
     mid: str,
     *,
     on_progress: callable | None = None,
+    max_pages: int | None = None,
 ) -> list[dict]:
     page_size = 50
     page_number = 1
     all_entries: list[dict] = []
     seen_bvids: set[str] = set()
+    page_limit = max(1, int(max_pages)) if max_pages is not None else None
 
     while True:
         while True:
@@ -294,12 +450,120 @@ def _fetch_gatcha_videos_for_uid(
         if on_progress is not None:
             on_progress(list(all_entries))
 
+        if page_limit is not None and page_number >= page_limit:
+            break
+
         vlist = data.get("list", {}).get("vlist", [])
         if not isinstance(vlist, list) or len(vlist) < page_size:
             break
         page_number += 1
 
     return all_entries
+
+
+def _dedupe_gatcha_entries(raw_entries: object) -> list[dict]:
+    if not isinstance(raw_entries, list):
+        return []
+    entries: list[dict] = []
+    seen_bvids: set[str] = set()
+    for raw_entry in raw_entries:
+        if not isinstance(raw_entry, dict):
+            continue
+        bvid = str(raw_entry.get("bvid") or "").strip()
+        if not bvid or bvid in seen_bvids:
+            continue
+        seen_bvids.add(bvid)
+        entries.append(dict(raw_entry))
+    return entries
+
+
+def preview_gatcha_uid(raw_mid: object) -> dict:
+    if not effective_bilibili_cookie():
+        raise BilibiliError(MISSING_BILIBILI_COOKIE_MESSAGE)
+
+    mid = _normalize_gatcha_uid(raw_mid)
+    profile = _request_gatcha_uid_profile(mid)
+    mid = str(profile["uid"])
+
+    with _GATCHA_UIDS_LOCK:
+        uid_payload = _load_gatcha_uid_payload()
+    followed_uids = uid_payload.get("uids") if isinstance(uid_payload, dict) else []
+    if not isinstance(followed_uids, list):
+        followed_uids = []
+
+    with _GATCHA_CACHE_LOCK:
+        cache_payload = _load_gatcha_cache()
+    uid_cache = cache_payload.get("uids") if isinstance(cache_payload, dict) else {}
+    if not isinstance(uid_cache, dict):
+        uid_cache = {}
+    existing_entries = _dedupe_gatcha_entries(uid_cache.get(mid, []))
+    cache_mode = "incremental" if existing_entries else "full"
+
+    return {
+        "uid": mid,
+        "name": str(profile.get("name") or ""),
+        "space_url": str(profile.get("space_url") or f"https://space.bilibili.com/{mid}"),
+        "already_followed": mid in followed_uids,
+        "cache_mode": cache_mode,
+        "cache_mode_label": "最新" if cache_mode == "incremental" else "所有",
+        "cached_count": len(existing_entries),
+    }
+
+
+def _merge_incremental_gatcha_entries(existing_entries: object, fresh_entries: object) -> tuple[list[dict], int]:
+    existing = _dedupe_gatcha_entries(existing_entries)
+    seen_bvids = {str(entry.get("bvid") or "").strip() for entry in existing}
+    new_entries: list[dict] = []
+    for fresh_entry in _dedupe_gatcha_entries(fresh_entries):
+        bvid = str(fresh_entry.get("bvid") or "").strip()
+        if not bvid or bvid in seen_bvids:
+            continue
+        seen_bvids.add(bvid)
+        new_entries.append(fresh_entry)
+    return new_entries + existing, len(new_entries)
+
+
+def _refresh_gatcha_uid_cache(cache_payload: dict, mid: str, *, force_full: bool = False) -> dict:
+    if not isinstance(cache_payload.get("uids"), dict):
+        cache_payload["uids"] = {}
+
+    existing_entries = _dedupe_gatcha_entries(cache_payload["uids"].get(mid, []))
+    if existing_entries and not force_full:
+        fresh_entries = _fetch_gatcha_videos_for_uid(mid, max_pages=1)
+        merged_entries, added_count = _merge_incremental_gatcha_entries(existing_entries, fresh_entries)
+        cache_payload["uids"][mid] = merged_entries
+        cache_payload["updated_at"] = time.time()
+        with _GATCHA_CACHE_LOCK:
+            _save_gatcha_cache(cache_payload)
+        return {
+            "uid": mid,
+            "mode": "incremental",
+            "added_count": added_count,
+            "total_count": len(merged_entries),
+        }
+
+    cache_payload["uids"][mid] = []
+    cache_payload["updated_at"] = time.time()
+    with _GATCHA_CACHE_LOCK:
+        _save_gatcha_cache(cache_payload)
+
+    def _save_mid_progress(entries: list[dict]) -> None:
+        cache_payload["uids"][mid] = _dedupe_gatcha_entries(entries)
+        cache_payload["updated_at"] = time.time()
+        with _GATCHA_CACHE_LOCK:
+            _save_gatcha_cache(cache_payload)
+
+    fetched_entries = _fetch_gatcha_videos_for_uid(mid, on_progress=_save_mid_progress)
+    cache_payload["uids"][mid] = _dedupe_gatcha_entries(fetched_entries)
+    cache_payload["updated_at"] = time.time()
+    with _GATCHA_CACHE_LOCK:
+        _save_gatcha_cache(cache_payload)
+    return {
+        "uid": mid,
+        "mode": "full",
+        "added_count": len(cache_payload["uids"][mid]),
+        "total_count": len(cache_payload["uids"][mid]),
+    }
 
 
 def refresh_gatcha_cache() -> dict:
@@ -315,34 +579,19 @@ def refresh_gatcha_cache() -> dict:
         cache_payload["uids"] = {}
 
     cache_payload["updated_at"] = time.time()
-    for raw_mid in GATCHA_UIDS:
+    for raw_mid in _configured_gatcha_uids():
         mid = str(raw_mid).strip()
         if not mid:
             continue
-        existing_entries = cache_payload["uids"].get(mid, [])
-        if isinstance(existing_entries, list) and any(isinstance(entry, dict) for entry in existing_entries):
-            continue
-        cache_payload["uids"][mid] = []
-        with _GATCHA_CACHE_LOCK:
-            _save_gatcha_cache(cache_payload)
-
-        def _save_mid_progress(entries: list[dict]) -> None:
-            cache_payload["uids"][mid] = entries
-            cache_payload["updated_at"] = time.time()
-            with _GATCHA_CACHE_LOCK:
-                _save_gatcha_cache(cache_payload)
-
-        cache_payload["uids"][mid] = _fetch_gatcha_videos_for_uid(mid, on_progress=_save_mid_progress)
-        cache_payload["updated_at"] = time.time()
-        with _GATCHA_CACHE_LOCK:
-            _save_gatcha_cache(cache_payload)
+        _refresh_gatcha_uid_cache(cache_payload, mid)
     return cache_payload
 
 
-def refresh_gatcha_cache_in_background() -> None:
+def refresh_gatcha_cache_in_background() -> bool:
+    if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
+        return False
+
     def _worker() -> None:
-        if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
-            return
         try:
             refresh_gatcha_cache()
         except Exception:
@@ -351,6 +600,43 @@ def refresh_gatcha_cache_in_background() -> None:
             _GATCHA_REFRESH_LOCK.release()
 
     threading.Thread(target=_worker, daemon=True, name="gatcha-cache-refresh").start()
+    return True
+
+
+def add_gatcha_uid(raw_mid: object) -> dict:
+    preview = preview_gatcha_uid(raw_mid)
+    mid = preview["uid"]
+    with _GATCHA_UIDS_LOCK:
+        uid_payload = _load_gatcha_uid_payload()
+        uids = uid_payload.get("uids") if isinstance(uid_payload, dict) else []
+        if not isinstance(uids, list):
+            uids = []
+        added = False
+        if mid in uids:
+            uids = list(uids)
+        else:
+            uids.append(mid)
+            uid_payload["uids"] = uids
+            uid_payload["updated_at"] = time.time()
+            _save_gatcha_uid_payload(uid_payload)
+            added = True
+
+    _GATCHA_REFRESH_LOCK.acquire()
+    try:
+        with _GATCHA_CACHE_LOCK:
+            cache_payload = _load_gatcha_cache()
+        cache_result = _refresh_gatcha_uid_cache(cache_payload, mid)
+    finally:
+        _GATCHA_REFRESH_LOCK.release()
+
+    return {
+        "uid": mid,
+        "name": preview["name"],
+        "space_url": preview["space_url"],
+        "added": added,
+        "uids": list(uids),
+        "cache": cache_result,
+    }
 
 
 def _local_gatcha_candidates() -> list[dict]:
@@ -359,7 +645,7 @@ def _local_gatcha_candidates() -> list[dict]:
 
     candidates: list[dict] = []
     uid_payload = cache_payload.get("uids") or {}
-    for raw_mid in GATCHA_UIDS:
+    for raw_mid in _configured_gatcha_uids():
         entries = uid_payload.get(str(raw_mid), [])
         if not isinstance(entries, list):
             continue
@@ -373,7 +659,7 @@ def _local_gatcha_candidates_by_uid() -> dict[str, list[dict]]:
 
     grouped_candidates: dict[str, list[dict]] = {}
     uid_payload = cache_payload.get("uids") or {}
-    for raw_mid in GATCHA_UIDS:
+    for raw_mid in _configured_gatcha_uids():
         mid = str(raw_mid).strip()
         if not mid:
             continue

--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -586,7 +586,7 @@ class CacheManager:
                 )
                 try:
                     self._ensure_bbdown(force_refresh=True)
-                    shutil.rmtree(item_dir, ignore_errors=True)
+                    self._safe_rmtree(item_dir)
                     item_dir.mkdir(parents=True, exist_ok=True)
                     self._cache_item_multi(item_id, item, allow_refresh_retry=False)
                     return
@@ -1986,7 +1986,7 @@ class CacheManager:
         for child in CACHE_DIR.iterdir():
             if child.name not in valid_ids:
                 if child.is_dir():
-                    shutil.rmtree(child, ignore_errors=True)
+                    self._safe_rmtree(child)
                 else:
                     child.unlink(missing_ok=True)
                 self._remove_item_log(child.name)
@@ -1994,7 +1994,7 @@ class CacheManager:
     def _clear_cache_root(self) -> None:
         for child in CACHE_DIR.iterdir():
             if child.is_dir():
-                shutil.rmtree(child, ignore_errors=True)
+                self._safe_rmtree(child)
             else:
                 child.unlink(missing_ok=True)
         self._clear_log_root()
@@ -2072,7 +2072,7 @@ class CacheManager:
         self._record_item_activity(item_id)
 
     def _remove_cache_dir(self, item_id: str) -> None:
-        shutil.rmtree(CACHE_DIR / item_id, ignore_errors=True)
+        self._safe_rmtree(CACHE_DIR / item_id)
         self._remove_item_log(item_id)
 
     def _remove_item_log(self, item_id: str) -> None:
@@ -2083,9 +2083,16 @@ class CacheManager:
             return
         for child in self.log_dir.iterdir():
             if child.is_dir():
-                shutil.rmtree(child, ignore_errors=True)
+                self._safe_rmtree(child)
             else:
                 child.unlink(missing_ok=True)
+
+    @staticmethod
+    def _safe_rmtree(path: Path) -> None:
+        try:
+            shutil.rmtree(path, ignore_errors=True)
+        except OSError:
+            return
 
     def _record_item_activity(self, item_id: str) -> None:
         with self.lock:

--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -17,11 +17,13 @@ from .bilibili import (
     BilibiliError,
     ManualBindingRequiredError,
     MISSING_BILIBILI_COOKIE_MESSAGE,
+    add_gatcha_uid,
     effective_bilibili_cookie,
     fetch_gatcha_candidate,
     fetch_owner_info,
     fetch_video_item,
-    refresh_gatcha_cache,
+    gatcha_uid_snapshot,
+    preview_gatcha_uid,
     refresh_gatcha_cache_in_background,
     search_gatcha_cache,
 )
@@ -506,6 +508,12 @@ class BilikaraHandler(BaseHTTPRequestHandler):
             except Exception as e:
                 self._write_json({"ok": False, "error": str(e)})
             return
+        if route == "/api/gatcha/uids":
+            try:
+                self._write_json({"ok": True, "data": gatcha_uid_snapshot()})
+            except Exception as e:
+                self._write_json({"ok": False, "error": str(e)})
+            return
         if route.startswith("/media/"):
             self._serve_media(route)
             return
@@ -640,6 +648,20 @@ class BilikaraHandler(BaseHTTPRequestHandler):
                 self._require_id(body)
                 CONTEXT.retry_cache_item(body["item_id"], force=bool(body.get("force")))
                 self._write_json({"ok": True, "data": CONTEXT.snapshot()})
+                return
+            if route == "/api/gatcha/uids/add":
+                result = add_gatcha_uid(body.get("uid"))
+                self._write_json({"ok": True, "data": result})
+                return
+            if route == "/api/gatcha/uids/preview":
+                result = preview_gatcha_uid(body.get("uid"))
+                self._write_json({"ok": True, "data": result})
+                return
+            if route == "/api/gatcha/refresh":
+                if not effective_bilibili_cookie():
+                    raise ValueError(MISSING_BILIBILI_COOKIE_MESSAGE)
+                started = refresh_gatcha_cache_in_background()
+                self._write_json({"ok": True, "data": {"started": started}})
                 return
             if route == "/api/player/audio-variant":
                 self._require_id(body)
@@ -973,6 +995,8 @@ def _serve(
     actual_port = _find_available_port(host, port) if auto_select_port else port
     server = ThreadingHTTPServer((host, actual_port), BilikaraHandler)
     CONTEXT.bind_server(server, shutdown_on_last_client=shutdown_on_last_client)
+    if CONTEXT.cache_manager.bbdown_login_status().get("logged_in"):
+        refresh_gatcha_cache_in_background()
     browser_host = "127.0.0.1" if host == "0.0.0.0" else host
     url = f"http://{browser_host}:{actual_port}"
     print(f"{status_label} running on {url}")

--- a/bilikara/store.py
+++ b/bilikara/store.py
@@ -787,7 +787,7 @@ class PlaylistStore:
 
     def _delete_runtime_json_files_unlocked(self) -> None:
         data_dir = self.state_file.parent
-        keep_names = {"gatcha_cache.json"}
+        keep_names = {"gatcha_cache.json", "gatcha_uids.json"}
         for path in data_dir.glob("*.json"):
             if path.name in keep_names:
                 continue

--- a/scripts/dev_smoke_test.py
+++ b/scripts/dev_smoke_test.py
@@ -35,6 +35,7 @@ DEFAULT_BBDOWN_TIMEOUT_SECONDS = 300
 DEFAULT_CACHE_TIMEOUT_SECONDS = 420
 DEFAULT_VISUAL_PAUSE_SECONDS = 5
 DEFAULT_TRANSITION_VISUAL_SECONDS = 18
+DEFAULT_TRANSITION_TAIL_SECONDS = 3.0
 
 
 class ApiError(RuntimeError):
@@ -345,7 +346,7 @@ class SmokeRunner:
         if song_urls:
             print_info(f"Using song URLs from command line: {len(song_urls)}")
         else:
-            song_urls = self.pick_gatcha_song_urls(3)
+            song_urls = self.pick_gatcha_song_urls(8)
         if not song_urls and not self.args.non_interactive:
             raw = input("Gatcha did not return a usable URL. Enter a Bilibili URL for song testing, or leave blank to skip: ").strip()
             if raw:
@@ -371,13 +372,20 @@ class SmokeRunner:
             print_ok(f"Multi-page search item added: {multi_item.get('display_title')} ({multi_item.get('id')})")
 
         regular_count = 2 if multi_item else 3
-        regular_urls = self.urls_for_count(song_urls, regular_count)
+        regular_urls = list(song_urls) if len(song_urls) >= regular_count else self.urls_for_count(song_urls, regular_count)
         top_song_added = False
-        for index, url in enumerate(regular_urls, start=1):
+        regular_added_count = 0
+        for url in regular_urls:
+            if regular_added_count >= regular_count:
+                break
             has_current = bool((self.get_state().get("current_item") or {}).get("id"))
             position = "next" if has_current and not top_song_added else "tail"
             before_ids = self.item_ids(self.get_state())
-            state = self.add_song(url, requester, position=position)
+            try:
+                state = self.add_song(url, requester, position=position)
+            except ApiError as exc:
+                print_warn(f"Skipping unusable song candidate: {url}: {exc}")
+                continue
             if position == "next":
                 top_song_added = True
             item = self.find_item_not_in_ids(state, before_ids) or self.find_newest_item(state, prefer_playlist=True)
@@ -385,14 +393,18 @@ class SmokeRunner:
                 continue
             added_items.append(item)
             self.created_item_ids.append(str(item.get("id") or ""))
+            regular_added_count += 1
             if position == "next":
                 print_ok(f"Top-song request succeeded: {item.get('display_title')} ({item.get('id')})")
-            elif index == 1 and not multi_item:
+            elif regular_added_count == 1 and not multi_item:
                 print_ok(f"Current song request succeeded: {item.get('display_title')} ({item.get('id')})")
             else:
-                print_ok(f"Queued song #{index}: {item.get('display_title')} ({item.get('id')})")
+                print_ok(f"Queued song #{regular_added_count}: {item.get('display_title')} ({item.get('id')})")
 
-        self.exercise_playlist_resort(regular_urls)
+        if regular_added_count < regular_count:
+            print_warn(f"Only added {regular_added_count}/{regular_count} regular song candidates; continuing with available items")
+
+        self.exercise_playlist_resort(song_urls)
         restore_cache_max = self.expand_cache_window_for_items(len(added_items))
         try:
             self.focus_created_items_for_cache_window(added_items)
@@ -652,16 +664,23 @@ class SmokeRunner:
         temp_users = [f"Cycle{suffix}A", f"Cycle{suffix}B"]
         temp_items: list[dict[str, Any]] = []
         added_users: list[str] = []
-        urls = self.urls_for_count(song_urls, len(temp_users))
+        urls = self.urls_for_count(song_urls, max(len(temp_users), min(len(song_urls), len(temp_users) * 4)))
 
         try:
             for user_name in temp_users:
                 self.add_user(user_name)
                 added_users.append(user_name)
 
-            for user_name, url in zip(temp_users, urls):
+            for url in urls:
+                if len(temp_items) >= len(temp_users):
+                    break
+                user_name = temp_users[len(temp_items)]
                 before_ids = self.item_ids(self.get_state())
-                state = self.add_song(url, user_name, position="tail")
+                try:
+                    state = self.add_song(url, user_name, position="tail")
+                except ApiError as exc:
+                    print_warn(f"Skipping unusable resort probe candidate for {user_name}: {url}: {exc}")
+                    continue
                 item = self.find_item_not_in_ids(state, before_ids) or self.find_newest_item(state, prefer_playlist=True)
                 if not item:
                     continue
@@ -845,12 +864,12 @@ class SmokeRunner:
             original_delay = int((state.get("player_settings") or {}).get("song_advance_delay_seconds") or 0)
             self.api_post("/api/player/advance-delay", {"delay_seconds": 5})
             try:
-                if self.seek_current_item_near_end(current_id, tail_seconds=2.0):
-                    print_ok("Requested Remote seek near the end of the current song for transition UI testing")
+                if self.seek_current_item_near_end(current_id, tail_seconds=DEFAULT_TRANSITION_TAIL_SECONDS):
+                    print_ok("Requested Remote seek to 3s before the end of the current song for transition UI testing")
                 else:
                     print_warn("Could not confirm a near-end seek; transition UI may require fallback next-song")
                 self.visual_checkpoint(
-                    "Watch the Host player now. Playback should already be near the end so the in-player countdown can stay visible without leaving fullscreen.",
+                    "Watch the Host player now. Playback should be about 3s before the end so the in-player countdown can stay visible without leaving fullscreen.",
                     seconds=self.args.transition_visual_pause,
                 )
                 state_after_seek = self.get_state()
@@ -893,17 +912,20 @@ class SmokeRunner:
         target_time = max(0.0, duration_seconds - max(0.5, tail_seconds))
         remaining = target_time - current_time
         if remaining <= 0.5:
-            print_ok(f"Playback is already near the end: current={current_time:.1f}s duration={duration_seconds:.1f}s")
+            print_ok(
+                f"Playback is already near the transition target: "
+                f"current={current_time:.1f}s target={target_time:.1f}s duration={duration_seconds:.1f}s"
+            )
             return True
         print_info(
-            f"Seeking near end for transition test: current={current_time:.1f}s "
+            f"Seeking to {tail_seconds:.1f}s before the end for transition test: current={current_time:.1f}s "
             f"target={target_time:.1f}s duration={duration_seconds:.1f}s"
         )
 
         estimated_time = current_time
-        while target_time - estimated_time > 0.5:
+        while target_time - estimated_time > 1.0:
             remaining = target_time - estimated_time
-            delta_seconds = int(min(300, max(1, math.ceil(remaining))))
+            delta_seconds = int(min(300, max(1, math.floor(remaining))))
             seek_state = self.api_post(
                 "/api/player/control",
                 {"action": "seek-relative", "item_id": item_id, "delta_seconds": delta_seconds},
@@ -914,16 +936,23 @@ class SmokeRunner:
             if seq and not self.wait_for_player_control_ack(seq):
                 print_warn(f"Timed out waiting for seek command ack: seq={seq} delta={delta_seconds}")
                 return False
-            estimated_time += delta_seconds
             time.sleep(0.4)
+            estimated_time += delta_seconds
+            observed_state = self.get_state()
+            observed_status_time = self.player_current_time_seconds(observed_state, item_id)
+            if observed_status_time > 0:
+                estimated_time = max(estimated_time, observed_status_time)
 
         observed_time = self.wait_for_player_time_at_least(
             item_id,
-            min_seconds=max(0.0, target_time - 3.0),
+            min_seconds=max(0.0, target_time - 1.0),
             timeout=8.0,
         )
         if observed_time is not None:
-            print_ok(f"Player reported near-end playback: current={observed_time:.1f}s duration={duration_seconds:.1f}s")
+            print_ok(
+                f"Player reported near-end playback: "
+                f"current={observed_time:.1f}s target={target_time:.1f}s duration={duration_seconds:.1f}s"
+            )
         else:
             print_info(
                 f"Seek commands were acknowledged; last estimated playback was about "

--- a/static/app.js
+++ b/static/app.js
@@ -1,7 +1,6 @@
 const pollIntervalMs = 1000;
 const bannerAutoHideMs = 5000;
 const stalledRetrySeconds = 5;
-const gatchaCooldownMs = 15000;
 const localPlayerSyncIntervalMs = 120;
 const localPlayerHardSyncThresholdSeconds = 0.08;
 const localPlayerForceSyncEpsilonSeconds = 0.015;
@@ -33,7 +32,8 @@ const state = {
   remoteAccessRenderSignature: "",
   cacheSettingsRenderSignature: "",
   bbdownLoginRenderSignature: "",
-  gatchaCookieFaceRenderSignature: "",
+  searchCookieFaceRenderSignature: "",
+  gatchaUidFaceRenderSignature: "",
   historyRenderSignature: "",
   playlistEmptyRenderSignature: "",
   cacheSliderRenderSignature: "",
@@ -99,9 +99,10 @@ const state = {
   bindingIntent: null,
   retryActivityById: {},
   gatchaCandidate: null,
-  gatchaCooldownUntil: 0,
-  gatchaCooldownTimer: null,
-  gatchaCookieVisible: false,
+  searchCookieVisible: false,
+  gatchaUidVisible: false,
+  gatchaUidSaving: false,
+  gatchaRefreshSaving: false,
   bbdownLoginRequesting: false,
   appToastTimer: null,
   layoutMode: "full",
@@ -203,14 +204,21 @@ const elements = {
   remotePopoverQrPlaceholder: document.getElementById("remote-popover-qr-placeholder"),
   remotePopoverUrlLink: document.getElementById("remote-popover-url-link"),
   remotePopoverUrlHint: document.getElementById("remote-popover-url-hint"),
+  searchPanel: document.getElementById("search-panel"),
+  searchTag: document.getElementById("search-tag"),
+  searchTitle: document.getElementById("search-title"),
+  searchCookieToggle: document.getElementById("search-cookie-toggle"),
+  searchStage: document.getElementById("search-stage"),
+  searchMainView: document.getElementById("search-main-view"),
+  searchCookieView: document.getElementById("search-cookie-view"),
   gatchaPanel: document.getElementById("gatcha-panel"),
   gatchaTag: document.getElementById("gatcha-tag"),
   gatchaTitle: document.getElementById("gatcha-title"),
   gatchaStage: document.getElementById("gatcha-stage"),
   gatchaButton: document.getElementById("gatcha-button"),
-  gatchaCookieToggle: document.getElementById("gatcha-cookie-toggle"),
+  gatchaUidToggle: document.getElementById("gatcha-uid-toggle"),
   gatchaMainView: document.getElementById("gatcha-main-view"),
-  gatchaCookieView: document.getElementById("gatcha-cookie-view"),
+  gatchaUidView: document.getElementById("gatcha-uid-view"),
   gatchaConfirmButton: document.getElementById("gatcha-confirm-button"),
   gatchaRetryButton: document.getElementById("gatcha-retry-button"),
   gatchaMessage: document.getElementById("gatcha-message"),
@@ -226,6 +234,11 @@ const elements = {
   cookieJct: document.getElementById("cookie-jct"),
   saveCookieButton: document.getElementById("save-cookie-button"),
   cookieMessage: document.getElementById("cookie-message"),
+  gatchaUidForm: document.getElementById("gatcha-uid-form"),
+  gatchaUidInput: document.getElementById("gatcha-uid-input"),
+  addGatchaUidButton: document.getElementById("add-gatcha-uid-button"),
+  refreshGatchaCacheButton: document.getElementById("refresh-gatcha-cache-button"),
+  gatchaUidMessage: document.getElementById("gatcha-uid-message"),
 };
 
 function setFormMessage(message, isError = false) {
@@ -736,6 +749,47 @@ async function searchGatchaCache(query) {
   return Array.isArray(payload.data?.items) ? payload.data.items : [];
 }
 
+async function previewGatchaUid(uid) {
+  return apiPost("/api/gatcha/uids/preview", { uid: String(uid || "").trim() });
+}
+
+async function addGatchaUid(uid) {
+  return apiPost("/api/gatcha/uids/add", { uid: String(uid || "").trim() });
+}
+
+async function refreshGatchaCache() {
+  return apiPost("/api/gatcha/refresh");
+}
+
+function gatchaUidResultMessage(result, fallbackUid = "") {
+  const cache = result?.cache || {};
+  const addedCount = Number(cache.added_count || 0);
+  const totalCount = Number(cache.total_count || 0);
+  const modeLabel = cache.mode === "incremental" ? "最新" : "所有";
+  const ownerLabel = result?.name ? `UP 主 ${result.name}` : `UID ${result?.uid || fallbackUid}`;
+  const listAction = result?.added ? "已添加" : "已在关注列表中";
+  return `${ownerLabel} ${listAction}，已拉取${modeLabel}稿件，新增 ${addedCount} 条，缓存共 ${totalCount} 条。`;
+}
+
+async function confirmGatchaUidAdd(intent) {
+  closeConfirm();
+  state.gatchaUidSaving = true;
+  renderGatchaUidFace();
+  setGatchaUidMessage(`正在拉取 UP 主：${intent.name || intent.uid} 的稿件...`);
+  try {
+    const result = await addGatchaUid(intent.uid);
+    setGatchaUidMessage(gatchaUidResultMessage(result, intent.uid));
+    if (elements.gatchaUidInput) {
+      elements.gatchaUidInput.value = "";
+    }
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaUidSaving = false;
+    renderGatchaUidFace();
+  }
+}
+
 function hideSearchResults() {
   elements.searchResults.innerHTML = "";
   elements.searchResults.classList.add("hidden");
@@ -781,10 +835,6 @@ function renderSearchResults(items) {
 }
 
 async function handleGatchaDraw() {
-  if (gatchaCooldownRemainingSeconds() > 0) {
-    syncGatchaCooldownButtons();
-    return;
-  }
   setGatchaMessage("正在连接 B 站寻找幸运投稿...");
   try {
     const response = await fetch("/api/gatcha/candidate", { headers: clientHeaders() });
@@ -795,7 +845,6 @@ async function handleGatchaDraw() {
 
     state.gatchaCandidate = payload.data;
     elements.gatchaCandidateTitle.textContent = state.gatchaCandidate.title;
-    startGatchaCooldown();
     
     // 切换界面
     elements.gatchaInitView.classList.add("hidden");
@@ -822,54 +871,59 @@ function setCookieMessage(message, isError = false) {
   elements.cookieMessage.classList.toggle("is-error", Boolean(isError));
 }
 
-function renderGatchaCookieFace() {
-  const showCookie = Boolean(state.gatchaCookieVisible);
-  const signature = showCookie ? "cookie" : "gatcha";
-  if (signature === state.gatchaCookieFaceRenderSignature) {
+function setGatchaUidMessage(message, isError = false) {
+  if (!elements.gatchaUidMessage) {
     return;
   }
-  state.gatchaCookieFaceRenderSignature = signature;
+  elements.gatchaUidMessage.textContent = message || "";
+  elements.gatchaUidMessage.classList.toggle("is-error", Boolean(isError));
+}
 
-  setClassToggle(elements.gatchaPanel, "is-cookie-view", showCookie);
-  setClassToggle(elements.gatchaStage, "is-cookie-view", showCookie);
-  setTextContent(elements.gatchaTag, showCookie ? "Cookie Config" : "gatcha Draw");
-  setTextContent(elements.gatchaTitle, showCookie ? "Cookie" : "试试运气");
-  setTextContent(elements.gatchaCookieToggle, showCookie ? "返回抽卡" : "输入 Cookie");
-  if (elements.gatchaCookieToggle?.getAttribute("aria-pressed") !== String(showCookie)) {
-    elements.gatchaCookieToggle.setAttribute("aria-pressed", String(showCookie));
+function renderSearchCookieFace() {
+  const showCookie = Boolean(state.searchCookieVisible);
+  const signature = showCookie ? "cookie" : "search";
+  if (signature === state.searchCookieFaceRenderSignature) {
+    return;
+  }
+  state.searchCookieFaceRenderSignature = signature;
+
+  setClassToggle(elements.searchPanel, "is-cookie-view", showCookie);
+  setClassToggle(elements.searchStage, "is-cookie-view", showCookie);
+  setTextContent(elements.searchTag, showCookie ? "Cookie Config" : "Local Search");
+  setTextContent(elements.searchTitle, showCookie ? "Cookie" : "搜索");
+  setTextContent(elements.searchCookieToggle, showCookie ? "返回搜索" : "输入 Cookie");
+  if (elements.searchCookieToggle?.getAttribute("aria-pressed") !== String(showCookie)) {
+    elements.searchCookieToggle.setAttribute("aria-pressed", String(showCookie));
   }
 }
 
-function gatchaCooldownRemainingSeconds() {
-  return Math.max(0, Math.ceil((state.gatchaCooldownUntil - Date.now()) / 1000));
-}
-
-function startGatchaCooldown() {
-  state.gatchaCooldownUntil = Date.now() + gatchaCooldownMs;
-  syncGatchaCooldownButtons();
-  if (state.gatchaCooldownTimer) {
-    clearInterval(state.gatchaCooldownTimer);
+function renderGatchaUidFace() {
+  const showUid = Boolean(state.gatchaUidVisible);
+  const signature = JSON.stringify({
+    showUid,
+    saving: state.gatchaUidSaving,
+    refreshing: state.gatchaRefreshSaving,
+  });
+  if (signature === state.gatchaUidFaceRenderSignature) {
+    return;
   }
-  state.gatchaCooldownTimer = setInterval(() => {
-    syncGatchaCooldownButtons();
-    if (gatchaCooldownRemainingSeconds() <= 0) {
-      clearInterval(state.gatchaCooldownTimer);
-      state.gatchaCooldownTimer = null;
-    }
-  }, 250);
-}
+  state.gatchaUidFaceRenderSignature = signature;
 
-function syncGatchaCooldownButtons() {
-  const remainingSeconds = gatchaCooldownRemainingSeconds();
-  const coolingDown = remainingSeconds > 0;
-  const cooldownText = `等待 ${remainingSeconds}s`;
-  if (elements.gatchaButton) {
-    elements.gatchaButton.disabled = coolingDown;
-    elements.gatchaButton.textContent = coolingDown ? cooldownText : "试试运气";
+  setClassToggle(elements.gatchaPanel, "is-uid-view", showUid);
+  setClassToggle(elements.gatchaStage, "is-uid-view", showUid);
+  setTextContent(elements.gatchaTag, showUid ? "Follow UID" : "gatcha Draw");
+  setTextContent(elements.gatchaTitle, showUid ? "关注 UID" : "试试运气");
+  setTextContent(elements.gatchaUidToggle, showUid ? "返回抽卡" : "添加 UID");
+  if (elements.gatchaUidToggle?.getAttribute("aria-pressed") !== String(showUid)) {
+    elements.gatchaUidToggle.setAttribute("aria-pressed", String(showUid));
   }
-  if (elements.gatchaRetryButton) {
-    elements.gatchaRetryButton.disabled = coolingDown;
-    elements.gatchaRetryButton.textContent = coolingDown ? cooldownText : "重新再来";
+  if (elements.addGatchaUidButton) {
+    elements.addGatchaUidButton.disabled = state.gatchaUidSaving;
+    elements.addGatchaUidButton.textContent = state.gatchaUidSaving ? "处理中" : "添加";
+  }
+  if (elements.refreshGatchaCacheButton) {
+    elements.refreshGatchaCacheButton.disabled = state.gatchaRefreshSaving;
+    elements.refreshGatchaCacheButton.textContent = state.gatchaRefreshSaving ? "更新中" : "手动更新";
   }
 }
 
@@ -931,7 +985,8 @@ function render() {
     Boolean(data.session_flags?.auto_restored_backup),
   );
   syncListStageView();
-  renderGatchaCookieFace();
+  renderSearchCookieFace();
+  renderGatchaUidFace();
   renderConfirmPopover();
   state.lastPollRenderSignature = renderSignatureForData(data);
 }
@@ -4457,6 +4512,10 @@ elements.confirmOk.addEventListener("click", async () => {
       render();
       return;
     }
+    if (intent.type === "gatcha-uid-add" && intent.uid) {
+      await confirmGatchaUidAdd(intent);
+      return;
+    }
     if (intent.type === "duplicate-add" && intent.url) {
       state.data = await submitAddRequest(intent.url, intent.position || "tail", {
         requesterName: intent.requesterName || selectedRequesterName(),
@@ -4494,6 +4553,8 @@ document.addEventListener("click", (event) => {
       event.target.closest("#current-cache-retry-button") ||
       event.target.closest("#player-reset-button") ||
       event.target.closest("#add-form") ||
+      event.target.closest("#gatcha-uid-form") ||
+      event.target.closest("#refresh-gatcha-cache-button") ||
       event.target.closest("#history-list")
     ) {
       return;
@@ -4675,9 +4736,14 @@ elements.listStage.addEventListener("wheel", (event) => {
 elements.gatchaButton.addEventListener("click", handleGatchaDraw);
 elements.gatchaRetryButton.addEventListener("click", handleGatchaDraw);
 
-elements.gatchaCookieToggle?.addEventListener("click", () => {
-  state.gatchaCookieVisible = !state.gatchaCookieVisible;
-  renderGatchaCookieFace();
+elements.searchCookieToggle?.addEventListener("click", () => {
+  state.searchCookieVisible = !state.searchCookieVisible;
+  renderSearchCookieFace();
+});
+
+elements.gatchaUidToggle?.addEventListener("click", () => {
+  state.gatchaUidVisible = !state.gatchaUidVisible;
+  renderGatchaUidFace();
 });
 
 elements.gatchaConfirmButton.addEventListener("click", async () => {
@@ -4729,6 +4795,54 @@ elements.gatchaConfirmButton.addEventListener("click", async () => {
       return;
     }
     setGatchaMessage(error.message, true);
+  }
+});
+
+elements.gatchaUidForm?.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const uid = String(elements.gatchaUidInput?.value || "").trim();
+  if (!uid) {
+    setGatchaUidMessage("请输入 UID", true);
+    return;
+  }
+
+  state.gatchaUidSaving = true;
+  renderGatchaUidFace();
+  setGatchaUidMessage("正在检测 UID...");
+  try {
+    const preview = await previewGatchaUid(uid);
+    const ownerName = preview?.name || `UID ${preview?.uid || uid}`;
+    const modeLabel = preview?.cache_mode_label || (preview?.cache_mode === "incremental" ? "最新" : "所有");
+    const followedPrefix = preview?.already_followed ? "已在关注列表中，" : "";
+    const point = anchorPointForEvent(event, elements.addGatchaUidButton);
+    openConfirm({
+      type: "gatcha-uid-add",
+      uid: preview?.uid || uid,
+      name: ownerName,
+      message: `确认拉取 UP 主：${ownerName} 的${modeLabel}稿件？`,
+      ...point,
+    });
+    setGatchaUidMessage(`${followedPrefix}检测到 UP 主：${ownerName}`);
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaUidSaving = false;
+    renderGatchaUidFace();
+  }
+});
+
+elements.refreshGatchaCacheButton?.addEventListener("click", async () => {
+  state.gatchaRefreshSaving = true;
+  renderGatchaUidFace();
+  setGatchaUidMessage("正在后台更新抽卡缓存...");
+  try {
+    const result = await refreshGatchaCache();
+    setGatchaUidMessage(result?.started === false ? "抽卡缓存已经在更新中。" : "已开始更新抽卡缓存。");
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaRefreshSaving = false;
+    renderGatchaUidFace();
   }
 });
 

--- a/static/index.html
+++ b/static/index.html
@@ -373,22 +373,49 @@
               </div>
             </section>
 
-            <section class="list-card sub-card search-sub-card">
+            <section class="list-card sub-card search-sub-card" id="search-panel">
               <div class="search-card">
                 <div class="search-sub-card-head">
                   <div>
-                    <p class="section-tag">Local Search</p>
-                    <h2>搜索</h2>
+                    <p class="section-tag" id="search-tag">Local Search</p>
+                    <h2 id="search-title">搜索</h2>
+                  </div>
+                  <button type="button" id="search-cookie-toggle" class="toolbar-button ghost search-cookie-toggle">
+                    输入 Cookie
+                  </button>
+                </div>
+
+                <div id="search-stage" class="search-stage">
+                  <div class="search-stage-inner">
+                    <div id="search-main-view" class="search-face search-face-front">
+                      <form id="search-form" class="search-inputs">
+                        <div class="input-group">
+                          <input type="text" id="search-query" placeholder="搜索本地歌曲目录 (需要登录或者 cookie)" autocomplete="off">
+                        </div>
+                        <button type="submit" id="search-button" class="next-button">搜索</button>
+                      </form>
+                      <p class="search-message" id="search-message" role="status"></p>
+                      <div id="search-results" class="search-results hidden"></div>
+                    </div>
+
+                    <div id="search-cookie-view" class="search-face search-face-back search-cookie-view">
+                      <div class="cookie-config-bar">
+                        <div class="cookie-inputs">
+                          <div class="input-group">
+                            <label>SESSDATA</label>
+                            <input type="text" id="cookie-sessdata" placeholder="从浏览器获取的 SESSDATA">
+                          </div>
+                          <div class="input-group">
+                            <label>bili_jct</label>
+                            <input type="text" id="cookie-jct" placeholder="从浏览器获取的 bili_jct">
+                          </div>
+                          <button type="button" id="save-cookie-button" class="next-button">更新配置</button>
+                        </div>
+                        <p class="gatcha-message" id="cookie-message" role="status"></p>
+                      </div>
+                    </div>
                   </div>
                 </div>
-                <form id="search-form" class="search-inputs">
-                  <div class="input-group">
-                    <input type="text" id="search-query" placeholder="搜索本地歌曲目录 (需要登录或者 cookie)" autocomplete="off">
-                  </div>
-                  <button type="submit" id="search-button" class="next-button">搜索</button>
-                </form>
-                <p class="search-message" id="search-message" role="status"></p>
-                <div id="search-results" class="search-results hidden"></div>
               </div>
             </section>
             
@@ -398,8 +425,8 @@
                  <p class="section-tag" id="gatcha-tag">gatcha Draw</p>
                  <h2 id="gatcha-title">试试运气</h2>
                 </div>
-                <button type="button" id="gatcha-cookie-toggle" class="toolbar-button ghost gatcha-cookie-toggle">
-                  输入 Cookie
+                <button type="button" id="gatcha-uid-toggle" class="toolbar-button ghost gatcha-uid-toggle">
+                  添加 UID
                 </button>
               </div>
       
@@ -423,20 +450,19 @@
                     </div>
                   </div>
 
-                  <div id="gatcha-cookie-view" class="gatcha-face gatcha-face-back gatcha-cookie-view">
-                    <div class="cookie-config-bar">
-                      <div class="cookie-inputs">
+                  <div id="gatcha-uid-view" class="gatcha-face gatcha-face-back gatcha-uid-view">
+                    <div class="gatcha-uid-bar">
+                      <form id="gatcha-uid-form" class="gatcha-uid-form">
                         <div class="input-group">
-                          <label>SESSDATA</label>
-                          <input type="text" id="cookie-sessdata" placeholder="从浏览器获取的 SESSDATA">
+                          <label>UID</label>
+                          <input type="text" id="gatcha-uid-input" placeholder="UID 或 UP 主空间链接">
                         </div>
-                        <div class="input-group">
-                          <label>bili_jct</label>
-                          <input type="text" id="cookie-jct" placeholder="从浏览器获取的 bili_jct">
-                        </div>
-                        <button type="button" id="save-cookie-button" class="next-button">更新配置</button>
-                      </div>
-                      <p class="gatcha-message" id="cookie-message" role="status"></p>
+                        <button type="submit" id="add-gatcha-uid-button" class="next-button">添加</button>
+                      </form>
+                      <button type="button" id="refresh-gatcha-cache-button" class="toolbar-button gatcha-refresh-button">
+                        手动更新
+                      </button>
+                      <p class="gatcha-message" id="gatcha-uid-message" role="status"></p>
                     </div>
                   </div>
                 </div>

--- a/static/remote.css
+++ b/static/remote.css
@@ -1060,6 +1060,12 @@ select:disabled {
   text-align: center;
 }
 
+.gatcha-uid-toggle {
+  min-height: 40px;
+  padding-inline: 12px;
+  white-space: nowrap;
+}
+
 .gatcha-icon {
   font-size: 32px;
 }
@@ -1083,6 +1089,23 @@ select:disabled {
 #gatcha-candidate-title {
   font-size: 16px;
   line-height: 1.4;
+}
+
+.gatcha-uid-view {
+  text-align: left;
+}
+
+.gatcha-uid-form {
+  display: grid;
+  gap: 10px;
+}
+
+.gatcha-uid-form .primary-button {
+  min-height: 48px;
+}
+
+.gatcha-uid-view .gatcha-message {
+  text-align: center;
 }
 
 .queue-item,

--- a/static/remote.html
+++ b/static/remote.html
@@ -189,6 +189,9 @@
       <section class="panel gatcha-panel">
         <div class="panel-head">
           <p class="panel-tag">Gatcha Draw</p>
+          <button type="button" id="gatcha-uid-toggle" class="secondary-button gatcha-uid-toggle" aria-pressed="false">
+            添加 UID
+          </button>
         </div>
         <div id="gatcha-init-view" class="gatcha-content">
           <div class="gatcha-icon">🎲</div>
@@ -203,6 +206,19 @@
             <button type="button" id="gatcha-confirm-button" class="primary-button">确定点歌</button>
             <button type="button" id="gatcha-retry-button" class="secondary-button">重新再来</button>
           </div>
+        </div>
+        <div id="gatcha-uid-view" class="gatcha-content gatcha-uid-view hidden">
+          <form id="gatcha-uid-form" class="request-form gatcha-uid-form">
+            <input
+              type="text"
+              id="gatcha-uid-input"
+              placeholder="UID 或 UP 主空间链接"
+              aria-label="UID 或 UP 主空间链接"
+              autocomplete="off"
+            />
+            <button type="submit" id="add-gatcha-uid-button" class="primary-button">添加</button>
+          </form>
+          <p class="gatcha-message" id="gatcha-uid-message" role="status"></p>
         </div>
       </section>
 

--- a/static/remote.js
+++ b/static/remote.js
@@ -1,5 +1,4 @@
 const audioVariantSwitchDebounceMs = 350;
-const gatchaCooldownMs = 15000;
 const playerSettingsEchoSuppressMs = 1800;
 const remoteVolumeCommitDebounceMs = 160;
 const viewportScaleResetDelaysMs = [0, 120, 360];
@@ -39,8 +38,8 @@ const state = {
   eventStreamReconnectTimer: null,
   eventStreamRetryMs: eventStreamInitialRetryMs,
   gatchaCandidate: null,
-  gatchaCooldownUntil: 0,
-  gatchaCooldownTimer: null,
+  gatchaUidVisible: false,
+  gatchaUidSaving: false,
   layoutMode: "full",
   remoteAccessRenderSignature: "",
   remoteQrPopoverOpen: false,
@@ -96,6 +95,7 @@ const elements = {
   addNextButton: document.getElementById("add-next-button"),
   resortPlaylistButton: document.getElementById("resort-playlist-button"),
   refreshButton: document.getElementById("refresh-button"),
+  gatchaUidToggle: document.getElementById("gatcha-uid-toggle"),
   gatchaButton: document.getElementById("gatcha-button"),
   gatchaConfirmButton: document.getElementById("gatcha-confirm-button"),
   gatchaRetryButton: document.getElementById("gatcha-retry-button"),
@@ -103,6 +103,11 @@ const elements = {
   gatchaInitView: document.getElementById("gatcha-init-view"),
   gatchaResultView: document.getElementById("gatcha-result-view"),
   gatchaCandidateTitle: document.getElementById("gatcha-candidate-title"),
+  gatchaUidView: document.getElementById("gatcha-uid-view"),
+  gatchaUidForm: document.getElementById("gatcha-uid-form"),
+  gatchaUidInput: document.getElementById("gatcha-uid-input"),
+  addGatchaUidButton: document.getElementById("add-gatcha-uid-button"),
+  gatchaUidMessage: document.getElementById("gatcha-uid-message"),
   listTag: document.getElementById("list-tag"),
   listTitle: document.getElementById("list-title"),
   listCount: document.getElementById("list-count"),
@@ -521,6 +526,24 @@ async function searchGatchaCache(query) {
   return Array.isArray(payload.data?.items) ? payload.data.items : [];
 }
 
+async function previewGatchaUid(uid) {
+  return apiPost("/api/gatcha/uids/preview", { uid: String(uid || "").trim() });
+}
+
+async function addGatchaUid(uid) {
+  return apiPost("/api/gatcha/uids/add", { uid: String(uid || "").trim() });
+}
+
+function gatchaUidResultMessage(result, fallbackUid = "") {
+  const cache = result?.cache || {};
+  const addedCount = Number(cache.added_count || 0);
+  const totalCount = Number(cache.total_count || 0);
+  const modeLabel = cache.mode === "incremental" ? "最新" : "所有";
+  const ownerLabel = result?.name ? `UP 主 ${result.name}` : `UID ${result?.uid || fallbackUid}`;
+  const listAction = result?.added ? "已添加" : "已在关注列表中";
+  return `${ownerLabel} ${listAction}，已拉取${modeLabel}稿件，新增 ${addedCount} 条，缓存共 ${totalCount} 条。`;
+}
+
 function hideSearchResults() {
   elements.searchResults.innerHTML = "";
   elements.searchResults.classList.add("hidden");
@@ -565,10 +588,8 @@ function renderSearchResults(items) {
 }
 
 async function handleGatchaDraw() {
-  if (gatchaCooldownRemainingSeconds() > 0) {
-    syncGatchaCooldownButtons();
-    return;
-  }
+  state.gatchaUidVisible = false;
+  renderGatchaUidView();
   setGatchaMessage("正在随机抽取一首歌曲...");
   try {
     const response = await fetch("/api/gatcha/candidate", { headers: clientHeaders() });
@@ -579,9 +600,7 @@ async function handleGatchaDraw() {
 
     state.gatchaCandidate = payload.data;
     elements.gatchaCandidateTitle.textContent = state.gatchaCandidate.title;
-    startGatchaCooldown();
-    elements.gatchaInitView.classList.add("hidden");
-    elements.gatchaResultView.classList.remove("hidden");
+    renderGatchaUidView();
     setGatchaMessage("");
   } catch (error) {
     setGatchaMessage(error.message, true);
@@ -596,36 +615,82 @@ function setGatchaMessage(message, isError = false) {
   elements.gatchaMessage.classList.toggle("is-error", Boolean(isError));
 }
 
-function gatchaCooldownRemainingSeconds() {
-  return Math.max(0, Math.ceil((state.gatchaCooldownUntil - Date.now()) / 1000));
-}
-
-function startGatchaCooldown() {
-  state.gatchaCooldownUntil = Date.now() + gatchaCooldownMs;
-  syncGatchaCooldownButtons();
-  if (state.gatchaCooldownTimer) {
-    clearInterval(state.gatchaCooldownTimer);
+function setGatchaUidMessage(message, isError = false) {
+  if (!elements.gatchaUidMessage) {
+    return;
   }
-  state.gatchaCooldownTimer = setInterval(() => {
-    syncGatchaCooldownButtons();
-    if (gatchaCooldownRemainingSeconds() <= 0) {
-      clearInterval(state.gatchaCooldownTimer);
-      state.gatchaCooldownTimer = null;
-    }
-  }, 250);
+  elements.gatchaUidMessage.textContent = message || "";
+  elements.gatchaUidMessage.classList.toggle("is-error", Boolean(isError));
 }
 
-function syncGatchaCooldownButtons() {
-  const remainingSeconds = gatchaCooldownRemainingSeconds();
-  const coolingDown = remainingSeconds > 0;
-  const cooldownText = `等待 ${remainingSeconds}s`;
+function renderGatchaUidView() {
+  const showUid = Boolean(state.gatchaUidVisible);
+  const hasCandidate = Boolean(state.gatchaCandidate);
+  if (elements.gatchaCandidateTitle && state.gatchaCandidate?.title) {
+    elements.gatchaCandidateTitle.textContent = state.gatchaCandidate.title;
+  }
+  elements.gatchaUidView?.classList.toggle("hidden", !showUid);
+  elements.gatchaInitView?.classList.toggle("hidden", showUid || hasCandidate);
+  elements.gatchaResultView?.classList.toggle("hidden", showUid || !hasCandidate);
+  if (elements.gatchaUidToggle) {
+    elements.gatchaUidToggle.textContent = showUid ? "返回抽卡" : "添加 UID";
+    elements.gatchaUidToggle.setAttribute("aria-pressed", String(showUid));
+  }
   if (elements.gatchaButton) {
-    elements.gatchaButton.disabled = coolingDown;
-    elements.gatchaButton.textContent = coolingDown ? cooldownText : "试试运气";
+    elements.gatchaButton.disabled = false;
+    elements.gatchaButton.textContent = "试试运气";
   }
   if (elements.gatchaRetryButton) {
-    elements.gatchaRetryButton.disabled = coolingDown;
-    elements.gatchaRetryButton.textContent = coolingDown ? cooldownText : "重新再来";
+    elements.gatchaRetryButton.disabled = false;
+    elements.gatchaRetryButton.textContent = "重新再来";
+  }
+  if (elements.gatchaUidInput) {
+    elements.gatchaUidInput.disabled = state.gatchaUidSaving;
+  }
+  if (elements.addGatchaUidButton) {
+    elements.addGatchaUidButton.disabled = state.gatchaUidSaving;
+    elements.addGatchaUidButton.textContent = state.gatchaUidSaving ? "处理中" : "添加";
+  }
+}
+
+async function handleGatchaUidSubmit(event) {
+  event.preventDefault();
+  const uid = String(elements.gatchaUidInput?.value || "").trim();
+  if (!uid) {
+    setGatchaUidMessage("请输入 UID", true);
+    return;
+  }
+  if (state.gatchaUidSaving) {
+    return;
+  }
+
+  state.gatchaUidSaving = true;
+  renderGatchaUidView();
+  setGatchaUidMessage("正在检测 UID...");
+  try {
+    const preview = await previewGatchaUid(uid);
+    const ownerName = preview?.name || `UID ${preview?.uid || uid}`;
+    const modeLabel = preview?.cache_mode_label || (preview?.cache_mode === "incremental" ? "最新" : "所有");
+    const followedPrefix = preview?.already_followed ? "已在关注列表中，" : "";
+    setGatchaUidMessage(`${followedPrefix}检测到 UP 主：${ownerName}`);
+
+    if (!window.confirm(`确认拉取 UP 主：${ownerName} 的${modeLabel}稿件？`)) {
+      setGatchaUidMessage("已取消添加 UID。");
+      return;
+    }
+
+    const normalizedUid = preview?.uid || uid;
+    setGatchaUidMessage(`正在拉取 UP 主：${ownerName} 的稿件...`);
+    const result = await addGatchaUid(normalizedUid);
+    setGatchaUidMessage(gatchaUidResultMessage(result, normalizedUid));
+    if (elements.gatchaUidInput) {
+      elements.gatchaUidInput.value = "";
+    }
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaUidSaving = false;
+    renderGatchaUidView();
   }
 }
 
@@ -647,6 +712,7 @@ function render() {
   renderHistory(Array.isArray(data.history) ? data.history : []);
   syncListView();
   renderLayoutMode();
+  renderGatchaUidView();
 }
 
 function renderRequesterSelect(sessionUsers) {
@@ -1122,8 +1188,7 @@ async function confirmBindingSheet() {
     }
     if (intent.source === "gatcha") {
       state.gatchaCandidate = null;
-      elements.gatchaResultView.classList.add("hidden");
-      elements.gatchaInitView.classList.remove("hidden");
+      renderGatchaUidView();
     }
     setFormMessage(intent.position === "next" ? "已按绑定关系顶歌到下一首" : "已按绑定关系加入点歌列表");
   } catch (error) {
@@ -1526,8 +1591,7 @@ async function addByUrl(url, position = "tail") {
     hideSearchResults();
     elements.searchQuery.value = "";
     state.gatchaCandidate = null;
-    elements.gatchaResultView.classList.add("hidden");
-    elements.gatchaInitView.classList.remove("hidden");
+    renderGatchaUidView();
     setFormMessage("点歌成功。");
   } catch (error) {
     if (error.code === "manual_binding_required") {
@@ -1762,6 +1826,13 @@ elements.remoteVolumeMuteButton?.addEventListener("click", async () => {
 
 elements.gatchaButton.addEventListener("click", handleGatchaDraw);
 elements.gatchaRetryButton.addEventListener("click", handleGatchaDraw);
+
+elements.gatchaUidToggle?.addEventListener("click", () => {
+  state.gatchaUidVisible = !state.gatchaUidVisible;
+  renderGatchaUidView();
+});
+
+elements.gatchaUidForm?.addEventListener("submit", handleGatchaUidSubmit);
 
 elements.gatchaConfirmButton.addEventListener("click", async () => {
   if (!state.gatchaCandidate?.url) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -2619,7 +2619,8 @@ select:disabled {
   min-height: 29px;
 }
 
-.gatcha-cookie-toggle {
+.gatcha-uid-toggle,
+.search-cookie-toggle {
   flex: 0 0 auto;
   white-space: nowrap;
 }
@@ -2642,6 +2643,10 @@ select:disabled {
 }
 
 .gatcha-stage.is-cookie-view .gatcha-stage-inner {
+  transform: rotateY(180deg);
+}
+
+.gatcha-stage.is-uid-view .gatcha-stage-inner {
   transform: rotateY(180deg);
 }
 
@@ -2670,24 +2675,36 @@ select:disabled {
   pointer-events: auto;
 }
 
-.gatcha-cookie-view {
+.gatcha-stage.is-uid-view .gatcha-face-front {
+  pointer-events: none;
+}
+
+.gatcha-stage.is-uid-view .gatcha-face-back {
+  pointer-events: auto;
+}
+
+.gatcha-cookie-view,
+.gatcha-uid-view {
   display: grid;
   align-content: start;
   padding-top: 2px;
 }
 
-.gatcha-cookie-view .cookie-config-bar {
+.gatcha-cookie-view .cookie-config-bar,
+.gatcha-uid-view .gatcha-uid-bar {
   align-content: start;
   height: auto;
 }
 
-.gatcha-cookie-view .cookie-inputs {
+.gatcha-cookie-view .cookie-inputs,
+.gatcha-uid-view .gatcha-uid-form {
   display: grid;
   gap: 12px;
   align-items: stretch;
 }
 
-.gatcha-panel.is-cookie-view .request-head h2 {
+.gatcha-panel.is-cookie-view .request-head h2,
+.gatcha-panel.is-uid-view .request-head h2 {
   color: var(--ink);
 }
 
@@ -2721,7 +2738,9 @@ select:disabled {
   color: var(--muted);
 }
 
-.gatcha-cookie-view .gatcha-message:empty {
+.gatcha-cookie-view .gatcha-message:empty,
+.gatcha-uid-view .gatcha-message:empty,
+.search-cookie-view .gatcha-message:empty {
   display: none;
 }
 
@@ -2796,13 +2815,25 @@ select:disabled {
   padding: 0 18px;
 }
 
-.gatcha-cookie-view .next-button {
+.gatcha-cookie-view .next-button,
+.gatcha-uid-view .next-button,
+.search-cookie-view .next-button {
   width: 100%;
 }
 
 .cookie-config-bar {
   display: grid;
   gap: 14px;
+}
+
+.gatcha-uid-bar {
+  display: grid;
+  gap: 12px;
+}
+
+.gatcha-refresh-button {
+  width: 100%;
+  min-height: 40px;
 }
 
 .sub-card {
@@ -2813,6 +2844,46 @@ select:disabled {
   display: grid;
   gap: 14px;
   align-content: start;
+}
+
+.search-stage {
+  perspective: 1800px;
+}
+
+.search-stage-inner {
+  display: grid;
+  transform-style: preserve-3d;
+  transition: transform 420ms ease;
+}
+
+.search-stage.is-cookie-view .search-stage-inner {
+  transform: rotateY(180deg);
+}
+
+.search-face {
+  grid-area: 1 / 1;
+  display: grid;
+  gap: 14px;
+  align-content: start;
+  min-height: 148px;
+  backface-visibility: hidden;
+  pointer-events: none;
+}
+
+.search-face-front {
+  pointer-events: auto;
+}
+
+.search-face-back {
+  transform: rotateY(180deg);
+}
+
+.search-stage.is-cookie-view .search-face-front {
+  pointer-events: none;
+}
+
+.search-stage.is-cookie-view .search-face-back {
+  pointer-events: auto;
 }
 
 .search-sub-card,
@@ -2848,7 +2919,9 @@ select:disabled {
   font-size: inherit;
 }
 
-.bottom-grid .gatcha-cookie-view .cookie-inputs {
+.bottom-grid .gatcha-cookie-view .cookie-inputs,
+.bottom-grid .search-cookie-view .cookie-inputs,
+.bottom-grid .gatcha-uid-view .gatcha-uid-form {
   display: grid;
   align-items: stretch;
 }
@@ -2941,7 +3014,8 @@ select:disabled {
 
 @media (max-width: 760px) {
   .search-inputs,
-  .cookie-inputs {
+  .cookie-inputs,
+  .gatcha-uid-form {
     flex-direction: column;
     align-items: stretch;
   }
@@ -2955,7 +3029,8 @@ select:disabled {
   }
 
   .search-result-item .next-button,
-  .cookie-sub-card .next-button {
+  .cookie-sub-card .next-button,
+  .gatcha-uid-view .next-button {
     width: 100%;
   }
 }

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -180,6 +180,23 @@ class CacheManagerPolicyTest(unittest.TestCase):
         self.assertFalse(item_dir.exists())
         self.assertFalse(log_path.exists())
 
+    def test_remove_cache_dir_ignores_windows_missing_path_race(self):
+        log_dir = Path(self.temp_dir.name) / "logs"
+        missing_error = OSError(3, "系统找不到指定的路径。")
+        missing_error.winerror = 3
+
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir), patch("bilikara.cache.LOG_DIR", log_dir), patch(
+            "bilikara.cache.shutil.rmtree",
+            side_effect=missing_error,
+        ) as rmtree_mock:
+            manager = CacheManager(self.store, max_cache_items=3)
+            try:
+                manager._remove_cache_dir("song-a")
+            finally:
+                manager.shutdown()
+
+        rmtree_mock.assert_called_once_with(self.cache_dir / "song-a", ignore_errors=True)
+
     def test_enrich_snapshot_includes_cache_activity_timestamp(self):
         with patch("bilikara.cache.CACHE_DIR", self.cache_dir):
             manager = CacheManager(self.store, max_cache_items=3)

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -1,4 +1,5 @@
 import json
+import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -504,6 +505,8 @@ class PlaylistStoreTest(unittest.TestCase):
         self.assertTrue(self.backup_file.exists())
         gatcha_file = self.state_file.parent / "gatcha_cache.json"
         gatcha_file.write_text("{}", encoding="utf-8")
+        gatcha_uid_file = self.state_file.parent / "gatcha_uids.json"
+        gatcha_uid_file.write_text("{}", encoding="utf-8")
         played_file = self.session_archive_dir / "played-keep.json"
         played_file.parent.mkdir(parents=True, exist_ok=True)
         played_file.write_text("{}", encoding="utf-8")
@@ -511,6 +514,7 @@ class PlaylistStoreTest(unittest.TestCase):
         self.store.reset_runtime_data()
 
         self.assertTrue(gatcha_file.exists())
+        self.assertTrue(gatcha_uid_file.exists())
         self.assertTrue(played_file.exists())
         self.assertFalse(self.backup_file.exists())
         self.assertEqual(self.store.playback_mode, "local")
@@ -717,6 +721,201 @@ class BilibiliParserTest(unittest.TestCase):
                 bilibili_module.MISSING_BILIBILI_COOKIE_MESSAGE,
             ):
                 bilibili_module.fetch_gatcha_candidate()
+
+    def test_gatcha_uid_snapshot_creates_default_uid_file(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module.cfg, "GATCHA_UIDS", ["1", "2", "1"]),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+            ):
+                snapshot = bilibili_module.gatcha_uid_snapshot()
+
+            self.assertEqual(snapshot["uids"], ["1", "2"])
+            self.assertEqual(json.loads(uid_file.read_text(encoding="utf-8"))["uids"], ["1", "2"])
+
+    def test_gatcha_uid_rejects_video_ids_instead_of_guessing_digits(self):
+        with self.assertRaisesRegex(bilibili_module.BilibiliError, "不要输入 BV/av 视频号"):
+            bilibili_module._normalize_gatcha_uid("BV1xx411c7mD")
+
+        with self.assertRaisesRegex(bilibili_module.BilibiliError, "不要输入 BV/av 视频号"):
+            bilibili_module._normalize_gatcha_uid("https://www.bilibili.com/video/BV1xx411c7mD")
+
+    def test_preview_gatcha_uid_fetches_owner_and_cache_mode(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+            cache_file = data_dir / "gatcha_cache.json"
+            uid_file.write_text(json.dumps({"uids": ["42"]}), encoding="utf-8")
+            cache_file.write_text(
+                json.dumps(
+                    {
+                        "uids": {
+                            "42": [
+                                {
+                                    "mid": "42",
+                                    "bvid": "BVOLD",
+                                    "title": "old karaoke",
+                                    "url": "https://www.bilibili.com/video/BVOLD",
+                                }
+                            ]
+                        },
+                        "updated_at": 1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+                patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
+                patch.object(bilibili_module, "effective_bilibili_cookie", return_value="cookie"),
+                patch.object(
+                    bilibili_module,
+                    "_request_gatcha_uid_profile",
+                    return_value={
+                        "uid": "42",
+                        "name": "example-up",
+                        "space_url": "https://space.bilibili.com/42",
+                    },
+                ),
+            ):
+                preview = bilibili_module.preview_gatcha_uid("https://space.bilibili.com/42")
+
+            self.assertEqual(preview["uid"], "42")
+            self.assertEqual(preview["name"], "example-up")
+            self.assertTrue(preview["already_followed"])
+            self.assertEqual(preview["cache_mode"], "incremental")
+            self.assertEqual(preview["cache_mode_label"], "最新")
+
+    def test_refresh_gatcha_cache_incremental_for_existing_and_full_for_missing_uid(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+            cache_file = data_dir / "gatcha_cache.json"
+            uid_file.write_text(json.dumps({"uids": ["1", "2"]}), encoding="utf-8")
+            cache_file.write_text(
+                json.dumps(
+                    {
+                        "uids": {
+                            "1": [
+                                {
+                                    "mid": "1",
+                                    "bvid": "BVOLD",
+                                    "title": "old karaoke",
+                                    "url": "https://www.bilibili.com/video/BVOLD",
+                                }
+                            ]
+                        },
+                        "updated_at": 1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            calls: list[tuple[str, object, bool]] = []
+
+            def fake_fetch(mid, *, on_progress=None, max_pages=None):
+                calls.append((mid, max_pages, on_progress is not None))
+                if mid == "1":
+                    return [
+                        {
+                            "mid": "1",
+                            "bvid": "BVNEW",
+                            "title": "new karaoke",
+                            "url": "https://www.bilibili.com/video/BVNEW",
+                        },
+                        {
+                            "mid": "1",
+                            "bvid": "BVOLD",
+                            "title": "old karaoke",
+                            "url": "https://www.bilibili.com/video/BVOLD",
+                        },
+                    ]
+                entries = [
+                    {
+                        "mid": "2",
+                        "bvid": "BV2A",
+                        "title": "first karaoke",
+                        "url": "https://www.bilibili.com/video/BV2A",
+                    },
+                    {
+                        "mid": "2",
+                        "bvid": "BV2B",
+                        "title": "second karaoke",
+                        "url": "https://www.bilibili.com/video/BV2B",
+                    },
+                ]
+                if on_progress is not None:
+                    on_progress(entries[:1])
+                return entries
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+                patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
+                patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", threading.Lock()),
+                patch.object(bilibili_module, "effective_bilibili_cookie", return_value="cookie"),
+                patch.object(bilibili_module, "_fetch_gatcha_videos_for_uid", side_effect=fake_fetch),
+            ):
+                bilibili_module.refresh_gatcha_cache()
+
+            self.assertEqual(calls, [("1", 1, False), ("2", None, True)])
+            cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
+            self.assertEqual([entry["bvid"] for entry in cache_payload["uids"]["1"]], ["BVNEW", "BVOLD"])
+            self.assertEqual([entry["bvid"] for entry in cache_payload["uids"]["2"]], ["BV2A", "BV2B"])
+
+    def test_add_gatcha_uid_persists_uid_and_refreshes_added_uid(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+            cache_file = data_dir / "gatcha_cache.json"
+            uid_file.write_text(json.dumps({"uids": ["1"]}), encoding="utf-8")
+            calls: list[str] = []
+
+            def fake_fetch(mid, *, on_progress=None, max_pages=None):
+                calls.append(mid)
+                entries = [
+                    {
+                        "mid": mid,
+                        "bvid": "BVADDED42",
+                        "title": "added test karaoke",
+                        "url": "https://www.bilibili.com/video/BVADDED42",
+                    }
+                ]
+                if on_progress is not None:
+                    on_progress(entries)
+                return entries
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+                patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
+                patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", threading.Lock()),
+                patch.object(bilibili_module, "effective_bilibili_cookie", return_value="cookie"),
+                patch.object(
+                    bilibili_module,
+                    "_request_gatcha_uid_profile",
+                    return_value={
+                        "uid": "42",
+                        "name": "example-up",
+                        "space_url": "https://space.bilibili.com/42",
+                    },
+                ),
+                patch.object(bilibili_module, "_fetch_gatcha_videos_for_uid", side_effect=fake_fetch),
+            ):
+                result = bilibili_module.add_gatcha_uid("https://space.bilibili.com/42")
+
+            self.assertTrue(result["added"])
+            self.assertEqual(result["uid"], "42")
+            self.assertIn("42", calls)
+            self.assertEqual(calls.count("42"), 1)
+            self.assertEqual(json.loads(uid_file.read_text(encoding="utf-8"))["uids"], ["1", "42"])
+            cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
+            self.assertEqual(cache_payload["uids"]["42"][0]["bvid"], "BVADDED42")
 
     @patch("bilikara.bilibili.request_json")
     def test_fetch_video_item(self, mock_request_json):


### PR DESCRIPTION
# 中文

## Summary
优化并扩展 gatcha 功能、缓存更新逻辑、UID 关注管理、Remote 端同步支持，以及 dev smoke test 与 cache retry 稳定性修复。

## Changes

### Gatcha 功能增强
- 将硬编码 gatcha UID 列表改为持久化存储到 `data/gatcha_uids.json`，首次自动迁移默认 UID 列表 :contentReference[oaicite:0]{index=0}
- 新增 UI 内“添加关注 UID”功能，支持用户动态维护关注 UP 主列表
- 添加 UID 时支持：
  - 仅允许纯 UID 或 UP 空间链接输入（拦截 BV/错误输入）
  - 拉取前检索并显示 UP 主名称
  - 增加二次确认弹窗：确认拉取 UP 主稿件后再执行
  - 添加后仅单独拉取新 UID 投稿并写入 `gatcha_cache`
- 新增手动更新按钮（Host 端），支持用户主动刷新稿件缓存
- 移除 gatcha 15 秒抽卡 cooldown/CD 机制，取消按钮倒计时和禁用逻辑

### Gatcha Cache 更新逻辑重构
- 登录 / 添加 cookie / WebUI 检测 BBDown 登录状态 / 点击手动更新时触发 UID 顺序更新
- 若 `gatcha_cache` 已存在当前 UID：
  - 仅拉取第一页
  - 基于 BV 号做增量合并，仅追加新稿件
- 若 UID 不存在缓存：
  - 顺序拉取全部页数做全量初始化
- 修复测试 mock 数据误写入真实 `gatcha_cache.json` 问题
- 修复导入模块触发后台更新副作用

### UI / Remote 支持
- Cookie 翻页入口移动到搜索模块
- 原 gatcha 翻面位置改为 UID 维护入口
- Remote 页面同步新增“添加 UID”功能（不包含手动更新按钮）
- Remote 端同步去除残留 15 秒抽卡 CD

### Dev Smoke Test 改进
- 歌曲切换倒计时测试：
  - 从“结束前 5 秒”调整为“结束前 3 秒”
  - seek 后动态重新读取时间，避免跳到真正结尾导致暂停
- 提升 gatcha 脏数据容错：
  - 随机候选扩充
  - 失效视频自动跳过，不中断 smoke test
  - playlist resort 探针同样容错处理

### Cache / Retry 稳定性修复
- 修复 Windows 下 re-cache 删除目录 race 导致 `WinError 3`
- 新增 `_safe_rmtree()` 安全删除逻辑
- 应用于 cache retry / orphan 清理 / force refresh 等路径
- 增加对应回归测试

## Tests
- `py -B -m unittest tests.test_store_and_bilibili tests.test_server`
- `py -B -m unittest tests.test_cache`
- `py -B -c ... scripts/dev_smoke_test.py`
- `git diff --check`

---
# English

## Summary
Enhance and harden gatcha with persistent UID management, incremental cache refresh, Remote-side UID support, smoke test resilience improvements, and Windows cache retry stability fixes.

## Changes

### Gatcha Enhancements
- Moved hardcoded gatcha UID ranges into persisted `data/gatcha_uids.json` with automatic bootstrap from legacy defaults :contentReference[oaicite:1]{index=1}
- Added in-UI “follow UID” management for dynamically maintaining tracked creators
- New UID add flow now includes:
  - Accept numeric UID or creator-space URL only (reject BV/video misuse)
  - Preview and fetch creator name before adding
  - Two-step confirmation before fetching posts
  - Fetch only the newly added UID into `gatcha_cache`
- Added manual refresh action (Host side) for on-demand updates
- Removed gatcha 15-second cooldown, countdown state, and button disabling

### Gatcha Cache Refresh Logic
- Trigger ordered UID refresh on login / cookie add / detected BBDown login on WebUI startup / manual refresh
- If a UID already exists in `gatcha_cache`:
  - Fetch page 1 only
  - Incrementally merge only unseen BV entries
- If a UID is not cached:
  - Perform full multi-page initialization fetch
- Fixed accidental mock data leaking into real `gatcha_cache.json`
- Fixed import-time side effects that triggered unintended background refreshes

### UI / Remote Support
- Moved cookie pagination UI into search module
- Replaced original gatcha flip area with UID maintenance controls
- Added matching “add UID” flow to Remote UI (without manual refresh)
- Removed lingering 15-second gatcha cooldown from Remote

### Dev Smoke Test Improvements
- Transition countdown test:
  - Moved seek target from 5s before end to 3s before end
  - Re-read playback position after seek loops to avoid landing at song end
- Improved dirty-data tolerance:
  - Expanded random gatcha candidate pool
  - Skip broken/unavailable song candidates instead of failing smoke test
  - Added same tolerance to playlist resort probe song logic

### Cache / Retry Stability Fixes
- Fixed Windows `WinError 3` race during re-cache directory cleanup
- Added `_safe_rmtree()` for resilient cache deletion
- Applied to retry, orphan cleanup, and forced refresh paths
- Added regression coverage

## Tests
- `py -B -m unittest tests.test_store_and_bilibili tests.test_server`
- `py -B -m unittest tests.test_cache`
- `py -B -c ... scripts/dev_smoke_test.py`
- `git diff --check`

