### PR TITLE
Feature&fix:Add follow-browse UI, improve binding actions, and harden smoke/cache behavior(加了关注列表浏览替换原cookie输入，多p绑定页面显示优化，测试脚本修复音视频长度不一致导致seek异常的问题)

### DIFF
--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -10,7 +10,7 @@ import re
 import random
 import hashlib
 import time
-from .config import BILIBILI_HEADERS, GATCHA_UIDS, GATCHA_KEYWORDS
+from .config import BILIBILI_HEADERS, GATCHA_KEYWORDS
 from dataclasses import dataclass
 from .models import PlaylistItem
 import bilikara.config as cfg  
@@ -18,6 +18,10 @@ import bilikara.config as cfg
 VIDEO_PATH_RE = re.compile(r"/video/(?P<vid>(BV[0-9A-Za-z]+|av\d+))", re.IGNORECASE)
 BV_RE = re.compile(r"^(BV[0-9A-Za-z]+)$", re.IGNORECASE)
 AV_RE = re.compile(r"^(av\d+)$", re.IGNORECASE)
+SPACE_UID_RE = re.compile(
+    r"^(?:https?://)?space\.bilibili\.com/(?P<uid>\d+)(?:[/?#].*)?$",
+    re.IGNORECASE,
+)
 SHORT_HOSTS = {"b23.tv", "bili2233.cn"}
 DURATION_TOLERANCE_SECONDS = 3
 WBI_MIXIN_TABLE = [
@@ -30,12 +34,17 @@ _WBI_CACHE = {
     "keys": None,
     "last_update": 0
 }
+_GATCHA_PROFILE_CACHE: dict[str, tuple[float, dict]] = {}
+_GATCHA_PROFILE_CACHE_LOCK = threading.Lock()
 _GATCHA_CACHE_LOCK = threading.Lock()
+_GATCHA_UIDS_LOCK = threading.Lock()
 _GATCHA_REFRESH_LOCK = threading.Lock()
 _GATCHA_REQUEST_LOCK = threading.Lock()
 _GATCHA_LAST_REQUEST_AT = 0.0
 _GATCHA_CACHE_FILE = cfg.DATA_DIR / "gatcha_cache.json"
+_GATCHA_UIDS_FILE = cfg.DATA_DIR / "gatcha_uids.json"
 GATCHA_RETRY_DELAY_SECONDS = 5
+GATCHA_PROFILE_CACHE_TTL_SECONDS = 300
 MISSING_BILIBILI_COOKIE_MESSAGE = "请登录 Bilibili 账号或输入 Cookie"
 _COOKIE_REQUIRED_KEYS = {"sessdata", "bili_jct"}
 _COOKIE_PREFERRED_ORDER = (
@@ -131,6 +140,107 @@ def cookie_from_bbdown_data() -> str:
 
 def effective_bilibili_cookie() -> str:
     return cookie_from_bbdown_data() or str(cfg.COOKIE or "").strip()
+
+
+def _normalize_gatcha_uid(raw_mid: object) -> str:
+    text = str(raw_mid or "").strip()
+    if not text:
+        raise BilibiliError("UID 不能为空")
+
+    if text.isdigit():
+        uid = text
+    else:
+        match = SPACE_UID_RE.match(text)
+        if not match:
+            lower_text = text.lower()
+            if BV_RE.match(text) or AV_RE.match(text) or "/video/" in lower_text:
+                raise BilibiliError("请输入 Bilibili UID 或 UP 主空间链接，不要输入 BV/av 视频号")
+            raise BilibiliError("请输入纯数字 UID 或 UP 主空间链接")
+        uid = match.group("uid")
+
+    uid = uid.lstrip("0") or "0"
+    if not uid.isdigit() or int(uid) <= 0:
+        raise BilibiliError("Bilibili UID 必须是正整数")
+    return uid
+
+
+def _normalize_gatcha_uid_list(raw_uids: object) -> list[str]:
+    if not isinstance(raw_uids, list):
+        return []
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_mid in raw_uids:
+        try:
+            mid = _normalize_gatcha_uid(raw_mid)
+        except BilibiliError:
+            continue
+        if mid in seen:
+            continue
+        seen.add(mid)
+        normalized.append(mid)
+    return normalized
+
+
+def _default_gatcha_uids() -> list[str]:
+    return _normalize_gatcha_uid_list(getattr(cfg, "GATCHA_UIDS", []))
+
+
+def _save_gatcha_uid_payload(uid_payload: dict) -> None:
+    cfg.DATA_DIR.mkdir(parents=True, exist_ok=True)
+    temp_path = _GATCHA_UIDS_FILE.with_suffix(".tmp")
+    with temp_path.open("w", encoding="utf-8") as handle:
+        json.dump(uid_payload, handle, ensure_ascii=False, indent=2)
+    temp_path.replace(_GATCHA_UIDS_FILE)
+
+
+def _load_gatcha_uid_payload() -> dict:
+    if not _GATCHA_UIDS_FILE.exists():
+        payload = {"uids": _default_gatcha_uids(), "updated_at": time.time()}
+        _save_gatcha_uid_payload(payload)
+        return payload
+
+    try:
+        with _GATCHA_UIDS_FILE.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        payload = {"uids": _default_gatcha_uids(), "updated_at": time.time()}
+        _save_gatcha_uid_payload(payload)
+        return payload
+
+    if isinstance(payload, list):
+        normalized_payload = {
+            "uids": _normalize_gatcha_uid_list(payload),
+            "updated_at": time.time(),
+        }
+        _save_gatcha_uid_payload(normalized_payload)
+        return normalized_payload
+
+    if not isinstance(payload, dict):
+        payload = {"uids": _default_gatcha_uids(), "updated_at": time.time()}
+        _save_gatcha_uid_payload(payload)
+        return payload
+
+    return {
+        "uids": _normalize_gatcha_uid_list(payload.get("uids")),
+        "updated_at": float(payload.get("updated_at") or 0),
+    }
+
+
+def gatcha_uid_snapshot() -> dict:
+    with _GATCHA_UIDS_LOCK:
+        payload = _load_gatcha_uid_payload()
+    uids = payload.get("uids") if isinstance(payload, dict) else []
+    if not isinstance(uids, list):
+        uids = []
+    return {
+        "uids": list(uids),
+        "count": len(uids),
+        "updated_at": float(payload.get("updated_at") or 0),
+    }
+
+
+def _configured_gatcha_uids() -> list[str]:
+    return gatcha_uid_snapshot()["uids"]
 
 @dataclass
 class VideoReference:
@@ -262,15 +372,61 @@ def _request_gatcha_page(mid: str, page_number: int, page_size: int = 50) -> dic
         raise
 
 
+def _request_gatcha_uid_profile(mid: str) -> dict:
+    normalized_mid = str(mid).strip()
+    now = time.time()
+    with _GATCHA_PROFILE_CACHE_LOCK:
+        cached_at, cached_profile = _GATCHA_PROFILE_CACHE.get(normalized_mid, (0.0, {}))
+        if cached_profile and now - cached_at < GATCHA_PROFILE_CACHE_TTL_SECONDS:
+            return dict(cached_profile)
+
+    try:
+        img_key, sub_key = get_cached_wbi_keys()
+    except Exception as exc:
+        raise BilibiliError(f"WBI keys failed: {exc}") from exc
+
+    signed_params = enc_wbi({"mid": normalized_mid}, img_key, sub_key)
+    query_string = urllib.parse.urlencode(signed_params)
+    url = f"https://api.bilibili.com/x/space/wbi/acc/info?{query_string}"
+    _wait_for_gatcha_request_slot()
+    payload = request_json(url)
+    try:
+        code = int(payload.get("code") or 0)
+    except (TypeError, ValueError):
+        code = 0
+    if code != 0:
+        message = str(payload.get("message") or "UP 主信息获取失败")
+        raise BilibiliError(message)
+
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise BilibiliError("UP 主信息获取失败")
+    owner_mid = str(data.get("mid") or normalized_mid).strip()
+    owner_name = str(data.get("name") or "").strip()
+    if not owner_mid.isdigit() or int(owner_mid) <= 0 or not owner_name:
+        raise BilibiliError("没有找到这个 UID 对应的 UP 主")
+    profile = {
+        "uid": owner_mid.lstrip("0") or "0",
+        "name": owner_name,
+        "space_url": f"https://space.bilibili.com/{owner_mid}",
+    }
+    with _GATCHA_PROFILE_CACHE_LOCK:
+        _GATCHA_PROFILE_CACHE[normalized_mid] = (time.time(), dict(profile))
+        _GATCHA_PROFILE_CACHE[profile["uid"]] = (time.time(), dict(profile))
+    return profile
+
+
 def _fetch_gatcha_videos_for_uid(
     mid: str,
     *,
     on_progress: callable | None = None,
+    max_pages: int | None = None,
 ) -> list[dict]:
     page_size = 50
     page_number = 1
     all_entries: list[dict] = []
     seen_bvids: set[str] = set()
+    page_limit = max(1, int(max_pages)) if max_pages is not None else None
 
     while True:
         while True:
@@ -294,12 +450,120 @@ def _fetch_gatcha_videos_for_uid(
         if on_progress is not None:
             on_progress(list(all_entries))
 
+        if page_limit is not None and page_number >= page_limit:
+            break
+
         vlist = data.get("list", {}).get("vlist", [])
         if not isinstance(vlist, list) or len(vlist) < page_size:
             break
         page_number += 1
 
     return all_entries
+
+
+def _dedupe_gatcha_entries(raw_entries: object) -> list[dict]:
+    if not isinstance(raw_entries, list):
+        return []
+    entries: list[dict] = []
+    seen_bvids: set[str] = set()
+    for raw_entry in raw_entries:
+        if not isinstance(raw_entry, dict):
+            continue
+        bvid = str(raw_entry.get("bvid") or "").strip()
+        if not bvid or bvid in seen_bvids:
+            continue
+        seen_bvids.add(bvid)
+        entries.append(dict(raw_entry))
+    return entries
+
+
+def preview_gatcha_uid(raw_mid: object) -> dict:
+    if not effective_bilibili_cookie():
+        raise BilibiliError(MISSING_BILIBILI_COOKIE_MESSAGE)
+
+    mid = _normalize_gatcha_uid(raw_mid)
+    profile = _request_gatcha_uid_profile(mid)
+    mid = str(profile["uid"])
+
+    with _GATCHA_UIDS_LOCK:
+        uid_payload = _load_gatcha_uid_payload()
+    followed_uids = uid_payload.get("uids") if isinstance(uid_payload, dict) else []
+    if not isinstance(followed_uids, list):
+        followed_uids = []
+
+    with _GATCHA_CACHE_LOCK:
+        cache_payload = _load_gatcha_cache()
+    uid_cache = cache_payload.get("uids") if isinstance(cache_payload, dict) else {}
+    if not isinstance(uid_cache, dict):
+        uid_cache = {}
+    existing_entries = _dedupe_gatcha_entries(uid_cache.get(mid, []))
+    cache_mode = "incremental" if existing_entries else "full"
+
+    return {
+        "uid": mid,
+        "name": str(profile.get("name") or ""),
+        "space_url": str(profile.get("space_url") or f"https://space.bilibili.com/{mid}"),
+        "already_followed": mid in followed_uids,
+        "cache_mode": cache_mode,
+        "cache_mode_label": "最新" if cache_mode == "incremental" else "所有",
+        "cached_count": len(existing_entries),
+    }
+
+
+def _merge_incremental_gatcha_entries(existing_entries: object, fresh_entries: object) -> tuple[list[dict], int]:
+    existing = _dedupe_gatcha_entries(existing_entries)
+    seen_bvids = {str(entry.get("bvid") or "").strip() for entry in existing}
+    new_entries: list[dict] = []
+    for fresh_entry in _dedupe_gatcha_entries(fresh_entries):
+        bvid = str(fresh_entry.get("bvid") or "").strip()
+        if not bvid or bvid in seen_bvids:
+            continue
+        seen_bvids.add(bvid)
+        new_entries.append(fresh_entry)
+    return new_entries + existing, len(new_entries)
+
+
+def _refresh_gatcha_uid_cache(cache_payload: dict, mid: str, *, force_full: bool = False) -> dict:
+    if not isinstance(cache_payload.get("uids"), dict):
+        cache_payload["uids"] = {}
+
+    existing_entries = _dedupe_gatcha_entries(cache_payload["uids"].get(mid, []))
+    if existing_entries and not force_full:
+        fresh_entries = _fetch_gatcha_videos_for_uid(mid, max_pages=1)
+        merged_entries, added_count = _merge_incremental_gatcha_entries(existing_entries, fresh_entries)
+        cache_payload["uids"][mid] = merged_entries
+        cache_payload["updated_at"] = time.time()
+        with _GATCHA_CACHE_LOCK:
+            _save_gatcha_cache(cache_payload)
+        return {
+            "uid": mid,
+            "mode": "incremental",
+            "added_count": added_count,
+            "total_count": len(merged_entries),
+        }
+
+    cache_payload["uids"][mid] = []
+    cache_payload["updated_at"] = time.time()
+    with _GATCHA_CACHE_LOCK:
+        _save_gatcha_cache(cache_payload)
+
+    def _save_mid_progress(entries: list[dict]) -> None:
+        cache_payload["uids"][mid] = _dedupe_gatcha_entries(entries)
+        cache_payload["updated_at"] = time.time()
+        with _GATCHA_CACHE_LOCK:
+            _save_gatcha_cache(cache_payload)
+
+    fetched_entries = _fetch_gatcha_videos_for_uid(mid, on_progress=_save_mid_progress)
+    cache_payload["uids"][mid] = _dedupe_gatcha_entries(fetched_entries)
+    cache_payload["updated_at"] = time.time()
+    with _GATCHA_CACHE_LOCK:
+        _save_gatcha_cache(cache_payload)
+    return {
+        "uid": mid,
+        "mode": "full",
+        "added_count": len(cache_payload["uids"][mid]),
+        "total_count": len(cache_payload["uids"][mid]),
+    }
 
 
 def refresh_gatcha_cache() -> dict:
@@ -315,34 +579,19 @@ def refresh_gatcha_cache() -> dict:
         cache_payload["uids"] = {}
 
     cache_payload["updated_at"] = time.time()
-    for raw_mid in GATCHA_UIDS:
+    for raw_mid in _configured_gatcha_uids():
         mid = str(raw_mid).strip()
         if not mid:
             continue
-        existing_entries = cache_payload["uids"].get(mid, [])
-        if isinstance(existing_entries, list) and any(isinstance(entry, dict) for entry in existing_entries):
-            continue
-        cache_payload["uids"][mid] = []
-        with _GATCHA_CACHE_LOCK:
-            _save_gatcha_cache(cache_payload)
-
-        def _save_mid_progress(entries: list[dict]) -> None:
-            cache_payload["uids"][mid] = entries
-            cache_payload["updated_at"] = time.time()
-            with _GATCHA_CACHE_LOCK:
-                _save_gatcha_cache(cache_payload)
-
-        cache_payload["uids"][mid] = _fetch_gatcha_videos_for_uid(mid, on_progress=_save_mid_progress)
-        cache_payload["updated_at"] = time.time()
-        with _GATCHA_CACHE_LOCK:
-            _save_gatcha_cache(cache_payload)
+        _refresh_gatcha_uid_cache(cache_payload, mid)
     return cache_payload
 
 
-def refresh_gatcha_cache_in_background() -> None:
+def refresh_gatcha_cache_in_background() -> bool:
+    if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
+        return False
+
     def _worker() -> None:
-        if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
-            return
         try:
             refresh_gatcha_cache()
         except Exception:
@@ -351,6 +600,43 @@ def refresh_gatcha_cache_in_background() -> None:
             _GATCHA_REFRESH_LOCK.release()
 
     threading.Thread(target=_worker, daemon=True, name="gatcha-cache-refresh").start()
+    return True
+
+
+def add_gatcha_uid(raw_mid: object) -> dict:
+    preview = preview_gatcha_uid(raw_mid)
+    mid = preview["uid"]
+    with _GATCHA_UIDS_LOCK:
+        uid_payload = _load_gatcha_uid_payload()
+        uids = uid_payload.get("uids") if isinstance(uid_payload, dict) else []
+        if not isinstance(uids, list):
+            uids = []
+        added = False
+        if mid in uids:
+            uids = list(uids)
+        else:
+            uids.append(mid)
+            uid_payload["uids"] = uids
+            uid_payload["updated_at"] = time.time()
+            _save_gatcha_uid_payload(uid_payload)
+            added = True
+
+    _GATCHA_REFRESH_LOCK.acquire()
+    try:
+        with _GATCHA_CACHE_LOCK:
+            cache_payload = _load_gatcha_cache()
+        cache_result = _refresh_gatcha_uid_cache(cache_payload, mid)
+    finally:
+        _GATCHA_REFRESH_LOCK.release()
+
+    return {
+        "uid": mid,
+        "name": preview["name"],
+        "space_url": preview["space_url"],
+        "added": added,
+        "uids": list(uids),
+        "cache": cache_result,
+    }
 
 
 def _local_gatcha_candidates() -> list[dict]:
@@ -359,7 +645,7 @@ def _local_gatcha_candidates() -> list[dict]:
 
     candidates: list[dict] = []
     uid_payload = cache_payload.get("uids") or {}
-    for raw_mid in GATCHA_UIDS:
+    for raw_mid in _configured_gatcha_uids():
         entries = uid_payload.get(str(raw_mid), [])
         if not isinstance(entries, list):
             continue
@@ -373,7 +659,7 @@ def _local_gatcha_candidates_by_uid() -> dict[str, list[dict]]:
 
     grouped_candidates: dict[str, list[dict]] = {}
     uid_payload = cache_payload.get("uids") or {}
-    for raw_mid in GATCHA_UIDS:
+    for raw_mid in _configured_gatcha_uids():
         mid = str(raw_mid).strip()
         if not mid:
             continue

--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -193,9 +193,38 @@ def _save_gatcha_uid_payload(uid_payload: dict) -> None:
     temp_path.replace(_GATCHA_UIDS_FILE)
 
 
+def _normalize_gatcha_profile(raw_uid: object, raw_profile: object) -> dict | None:
+    try:
+        uid = _normalize_gatcha_uid(raw_uid)
+    except BilibiliError:
+        return None
+    if not isinstance(raw_profile, dict):
+        return None
+    name = str(raw_profile.get("name") or "").strip()
+    if not name:
+        return None
+    return {
+        "uid": uid,
+        "name": name,
+        "space_url": str(raw_profile.get("space_url") or f"https://space.bilibili.com/{uid}"),
+    }
+
+
+def _normalize_gatcha_profiles(raw_profiles: object) -> dict[str, dict]:
+    profiles: dict[str, dict] = {}
+    if not isinstance(raw_profiles, dict):
+        return profiles
+    for raw_uid, raw_profile in raw_profiles.items():
+        profile = _normalize_gatcha_profile(raw_uid, raw_profile)
+        if profile is None:
+            continue
+        profiles[str(profile["uid"])] = profile
+    return profiles
+
+
 def _load_gatcha_uid_payload() -> dict:
     if not _GATCHA_UIDS_FILE.exists():
-        payload = {"uids": _default_gatcha_uids(), "updated_at": time.time()}
+        payload = {"uids": _default_gatcha_uids(), "profiles": {}, "updated_at": time.time()}
         _save_gatcha_uid_payload(payload)
         return payload
 
@@ -203,25 +232,29 @@ def _load_gatcha_uid_payload() -> dict:
         with _GATCHA_UIDS_FILE.open("r", encoding="utf-8") as handle:
             payload = json.load(handle)
     except (OSError, json.JSONDecodeError):
-        payload = {"uids": _default_gatcha_uids(), "updated_at": time.time()}
+        payload = {"uids": _default_gatcha_uids(), "profiles": {}, "updated_at": time.time()}
         _save_gatcha_uid_payload(payload)
         return payload
 
     if isinstance(payload, list):
         normalized_payload = {
             "uids": _normalize_gatcha_uid_list(payload),
+            "profiles": {},
             "updated_at": time.time(),
         }
         _save_gatcha_uid_payload(normalized_payload)
         return normalized_payload
 
     if not isinstance(payload, dict):
-        payload = {"uids": _default_gatcha_uids(), "updated_at": time.time()}
+        payload = {"uids": _default_gatcha_uids(), "profiles": {}, "updated_at": time.time()}
         _save_gatcha_uid_payload(payload)
         return payload
 
+    profiles = _normalize_gatcha_profiles(payload.get("profiles"))
+
     return {
         "uids": _normalize_gatcha_uid_list(payload.get("uids")),
+        "profiles": profiles,
         "updated_at": float(payload.get("updated_at") or 0),
     }
 
@@ -235,6 +268,7 @@ def gatcha_uid_snapshot() -> dict:
     return {
         "uids": list(uids),
         "count": len(uids),
+        "profiles": dict(payload.get("profiles") or {}),
         "updated_at": float(payload.get("updated_at") or 0),
     }
 
@@ -273,20 +307,22 @@ class ManualBindingRequiredError(BilibiliError):
 
 def _load_gatcha_cache() -> dict:
     if not _GATCHA_CACHE_FILE.exists():
-        return {"uids": {}, "updated_at": 0}
+        return {"uids": {}, "profiles": {}, "updated_at": 0}
     try:
         with _GATCHA_CACHE_FILE.open("r", encoding="utf-8") as handle:
             payload = json.load(handle)
     except (OSError, json.JSONDecodeError):
-        return {"uids": {}, "updated_at": 0}
+        return {"uids": {}, "profiles": {}, "updated_at": 0}
 
     if not isinstance(payload, dict):
-        return {"uids": {}, "updated_at": 0}
+        return {"uids": {}, "profiles": {}, "updated_at": 0}
     uids = payload.get("uids")
     if not isinstance(uids, dict):
         uids = {}
+    profiles = _normalize_gatcha_profiles(payload.get("profiles"))
     return {
         "uids": uids,
+        "profiles": profiles,
         "updated_at": float(payload.get("updated_at") or 0),
     }
 
@@ -327,13 +363,18 @@ def _extract_gatcha_entries(mid: str, payload: dict) -> list[dict]:
         title = str(video.get("title") or "").strip()
         if not bvid or not title or not _matches_gatcha_keywords(title):
             continue
+        owner_name = str(video.get("author") or video.get("owner_name") or "").strip()
+        entry = {
+            "mid": str(mid),
+            "bvid": bvid,
+            "title": title,
+            "url": f"https://www.bilibili.com/video/{bvid}",
+        }
+        if owner_name:
+            entry["owner_name"] = owner_name
+            entry["owner_url"] = f"https://space.bilibili.com/{mid}"
         entries.append(
-            {
-                "mid": str(mid),
-                "bvid": bvid,
-                "title": title,
-                "url": f"https://www.bilibili.com/video/{bvid}",
-            }
+            entry
         )
     return entries
 
@@ -414,6 +455,42 @@ def _request_gatcha_uid_profile(mid: str) -> dict:
         _GATCHA_PROFILE_CACHE[normalized_mid] = (time.time(), dict(profile))
         _GATCHA_PROFILE_CACHE[profile["uid"]] = (time.time(), dict(profile))
     return profile
+
+
+def _persist_gatcha_uid_profile(profile: dict) -> dict | None:
+    normalized = _normalize_gatcha_profile(profile.get("uid"), profile)
+    if normalized is None:
+        return None
+
+    with _GATCHA_UIDS_LOCK:
+        uid_payload = _load_gatcha_uid_payload()
+        profiles = uid_payload.get("profiles")
+        if not isinstance(profiles, dict):
+            profiles = {}
+        uid = str(normalized["uid"])
+        if profiles.get(uid) == normalized:
+            return normalized
+        profiles[uid] = normalized
+        uid_payload["profiles"] = profiles
+        uid_payload["updated_at"] = time.time()
+        try:
+            _save_gatcha_uid_payload(uid_payload)
+        except OSError:
+            return normalized
+    return normalized
+
+
+def _resolve_gatcha_uid_profile(mid: str, known_profiles: dict | None = None) -> dict | None:
+    known = known_profiles.get(mid) if isinstance(known_profiles, dict) else None
+    normalized_known = _normalize_gatcha_profile(mid, known)
+    if normalized_known is not None:
+        return normalized_known
+
+    try:
+        profile = _request_gatcha_uid_profile(mid)
+    except Exception:
+        return None
+    return _persist_gatcha_uid_profile(profile)
 
 
 def _fetch_gatcha_videos_for_uid(
@@ -570,19 +647,36 @@ def refresh_gatcha_cache() -> dict:
     if not effective_bilibili_cookie():
         raise BilibiliError(MISSING_BILIBILI_COOKIE_MESSAGE)
 
+    with _GATCHA_UIDS_LOCK:
+        uid_payload = _load_gatcha_uid_payload()
+    configured_uids = uid_payload.get("uids") if isinstance(uid_payload, dict) else []
+    if not isinstance(configured_uids, list):
+        configured_uids = []
+    known_profiles = uid_payload.get("profiles") if isinstance(uid_payload, dict) else {}
+    if not isinstance(known_profiles, dict):
+        known_profiles = {}
+
     with _GATCHA_CACHE_LOCK:
         cache_payload = _load_gatcha_cache()
 
     if not isinstance(cache_payload, dict):
-        cache_payload = {"uids": {}, "updated_at": 0}
+        cache_payload = {"uids": {}, "profiles": {}, "updated_at": 0}
     if not isinstance(cache_payload.get("uids"), dict):
         cache_payload["uids"] = {}
+    cache_profiles = cache_payload.get("profiles")
+    if not isinstance(cache_profiles, dict):
+        cache_profiles = {}
+    cache_payload["profiles"] = cache_profiles
 
     cache_payload["updated_at"] = time.time()
-    for raw_mid in _configured_gatcha_uids():
+    for raw_mid in configured_uids:
         mid = str(raw_mid).strip()
         if not mid:
             continue
+        profile = _resolve_gatcha_uid_profile(mid, known_profiles)
+        if profile is not None:
+            cache_profiles[str(profile["uid"])] = profile
+            known_profiles[str(profile["uid"])] = profile
         _refresh_gatcha_uid_cache(cache_payload, mid)
     return cache_payload
 
@@ -617,14 +711,32 @@ def add_gatcha_uid(raw_mid: object) -> dict:
         else:
             uids.append(mid)
             uid_payload["uids"] = uids
-            uid_payload["updated_at"] = time.time()
-            _save_gatcha_uid_payload(uid_payload)
             added = True
+        profiles = uid_payload.get("profiles")
+        if not isinstance(profiles, dict):
+            profiles = {}
+        profiles[mid] = {
+            "uid": mid,
+            "name": preview["name"],
+            "space_url": preview["space_url"],
+        }
+        uid_payload["profiles"] = profiles
+        uid_payload["updated_at"] = time.time()
+        _save_gatcha_uid_payload(uid_payload)
 
     _GATCHA_REFRESH_LOCK.acquire()
     try:
         with _GATCHA_CACHE_LOCK:
             cache_payload = _load_gatcha_cache()
+        cache_profiles = cache_payload.get("profiles") if isinstance(cache_payload, dict) else {}
+        if not isinstance(cache_profiles, dict):
+            cache_profiles = {}
+        cache_profiles[mid] = {
+            "uid": mid,
+            "name": preview["name"],
+            "space_url": preview["space_url"],
+        }
+        cache_payload["profiles"] = cache_profiles
         cache_result = _refresh_gatcha_uid_cache(cache_payload, mid)
     finally:
         _GATCHA_REFRESH_LOCK.release()
@@ -696,6 +808,95 @@ def search_gatcha_cache(query: str, *, limit: int = 30) -> list[dict]:
         if len(results) >= max(1, int(limit)):
             break
     return results
+
+
+def _gatcha_entry_payload(entry: dict) -> dict:
+    return {
+        "mid": str(entry.get("mid") or ""),
+        "bvid": str(entry.get("bvid") or ""),
+        "title": str(entry.get("title") or ""),
+        "url": str(entry.get("url") or ""),
+    }
+
+
+def _profile_from_cached_entries(mid: str, entries: list[dict]) -> dict:
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        owner_name = str(entry.get("owner_name") or entry.get("author") or "").strip()
+        if owner_name:
+            return {
+                "uid": mid,
+                "name": owner_name,
+                "space_url": str(entry.get("owner_url") or f"https://space.bilibili.com/{mid}"),
+            }
+    return {
+        "uid": mid,
+        "name": f"UID {mid}",
+        "space_url": f"https://space.bilibili.com/{mid}",
+    }
+
+
+def browse_gatcha_cache(uid: str = "", query: str = "") -> dict:
+    with _GATCHA_UIDS_LOCK:
+        uid_payload = _load_gatcha_uid_payload()
+    configured_uids = uid_payload.get("uids") if isinstance(uid_payload, dict) else []
+    if not isinstance(configured_uids, list):
+        configured_uids = []
+    profiles = uid_payload.get("profiles") if isinstance(uid_payload, dict) else {}
+    if not isinstance(profiles, dict):
+        profiles = {}
+
+    with _GATCHA_CACHE_LOCK:
+        cache_payload = _load_gatcha_cache()
+    cached_by_uid = cache_payload.get("uids") if isinstance(cache_payload, dict) else {}
+    if not isinstance(cached_by_uid, dict):
+        cached_by_uid = {}
+    cache_profiles = cache_payload.get("profiles") if isinstance(cache_payload, dict) else {}
+    if not isinstance(cache_profiles, dict):
+        cache_profiles = {}
+
+    owners: list[dict] = []
+    for raw_mid in configured_uids:
+        mid = str(raw_mid).strip()
+        if not mid:
+            continue
+        entries = _dedupe_gatcha_entries(cached_by_uid.get(mid, []))
+        profile = profiles.get(mid) if isinstance(profiles.get(mid), dict) else {}
+        if not profile or not str(profile.get("name") or "").strip():
+            profile = cache_profiles.get(mid) if isinstance(cache_profiles.get(mid), dict) else {}
+        if not profile or not str(profile.get("name") or "").strip():
+            profile = _profile_from_cached_entries(mid, entries)
+        owners.append(
+            {
+                "uid": mid,
+                "name": str(profile.get("name") or f"UID {mid}"),
+                "space_url": str(profile.get("space_url") or f"https://space.bilibili.com/{mid}"),
+                "count": len(entries),
+            }
+        )
+
+    selected_uid = str(uid or "").strip()
+    if selected_uid and selected_uid not in {owner["uid"] for owner in owners}:
+        selected_uid = ""
+
+    items: list[dict] = []
+    normalized_query = str(query or "").strip().lower()
+    if selected_uid:
+        entries = _dedupe_gatcha_entries(cached_by_uid.get(selected_uid, []))
+        for entry in entries:
+            title = str(entry.get("title") or "")
+            if normalized_query and normalized_query not in title.lower():
+                continue
+            items.append(_gatcha_entry_payload(entry))
+
+    return {
+        "owners": owners,
+        "selected_uid": selected_uid,
+        "query": str(query or "").strip(),
+        "items": items,
+        "updated_at": float(cache_payload.get("updated_at") or 0) if isinstance(cache_payload, dict) else 0,
+    }
 
 
 

--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -43,6 +43,7 @@ _GATCHA_REQUEST_LOCK = threading.Lock()
 _GATCHA_LAST_REQUEST_AT = 0.0
 _GATCHA_CACHE_FILE = cfg.DATA_DIR / "gatcha_cache.json"
 _GATCHA_UIDS_FILE = cfg.DATA_DIR / "gatcha_uids.json"
+_GATCHA_CACHE_SCHEMA_VERSION = 2
 GATCHA_RETRY_DELAY_SECONDS = 5
 GATCHA_PROFILE_CACHE_TTL_SECONDS = 300
 MISSING_BILIBILI_COOKIE_MESSAGE = "请登录 Bilibili 账号或输入 Cookie"
@@ -305,22 +306,49 @@ class ManualBindingRequiredError(BilibiliError):
         super().__init__("该视频包含多个分P，请先选择视频和音频绑定关系")
 
 
-def _load_gatcha_cache() -> dict:
+def _empty_gatcha_cache_payload() -> dict:
+    return {"schema_version": _GATCHA_CACHE_SCHEMA_VERSION, "uids": {}, "profiles": {}, "updated_at": 0}
+
+
+def _is_legacy_gatcha_cache_payload(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    if not isinstance(payload.get("uids"), dict):
+        return False
+    if "profiles" not in payload:
+        return True
+    if not isinstance(payload.get("profiles"), dict):
+        return True
+    return False
+
+
+def _clear_legacy_gatcha_cache_file() -> None:
+    try:
+        _GATCHA_CACHE_FILE.unlink(missing_ok=True)
+    except OSError:
+        return
+
+
+def _load_gatcha_cache(*, reset_legacy: bool = False) -> dict:
     if not _GATCHA_CACHE_FILE.exists():
-        return {"uids": {}, "profiles": {}, "updated_at": 0}
+        return _empty_gatcha_cache_payload()
     try:
         with _GATCHA_CACHE_FILE.open("r", encoding="utf-8") as handle:
             payload = json.load(handle)
     except (OSError, json.JSONDecodeError):
-        return {"uids": {}, "profiles": {}, "updated_at": 0}
+        return _empty_gatcha_cache_payload()
 
     if not isinstance(payload, dict):
-        return {"uids": {}, "profiles": {}, "updated_at": 0}
+        return _empty_gatcha_cache_payload()
+    if reset_legacy and _is_legacy_gatcha_cache_payload(payload):
+        _clear_legacy_gatcha_cache_file()
+        return _empty_gatcha_cache_payload()
     uids = payload.get("uids")
     if not isinstance(uids, dict):
         uids = {}
     profiles = _normalize_gatcha_profiles(payload.get("profiles"))
     return {
+        "schema_version": _GATCHA_CACHE_SCHEMA_VERSION,
         "uids": uids,
         "profiles": profiles,
         "updated_at": float(payload.get("updated_at") or 0),
@@ -329,6 +357,7 @@ def _load_gatcha_cache() -> dict:
 
 def _save_gatcha_cache(cache_payload: dict) -> None:
     cfg.DATA_DIR.mkdir(parents=True, exist_ok=True)
+    cache_payload["schema_version"] = _GATCHA_CACHE_SCHEMA_VERSION
     temp_path = _GATCHA_CACHE_FILE.with_suffix(".tmp")
     with temp_path.open("w", encoding="utf-8") as handle:
         json.dump(cache_payload, handle, ensure_ascii=False, indent=2)
@@ -657,10 +686,10 @@ def refresh_gatcha_cache() -> dict:
         known_profiles = {}
 
     with _GATCHA_CACHE_LOCK:
-        cache_payload = _load_gatcha_cache()
+        cache_payload = _load_gatcha_cache(reset_legacy=True)
 
     if not isinstance(cache_payload, dict):
-        cache_payload = {"uids": {}, "profiles": {}, "updated_at": 0}
+        cache_payload = _empty_gatcha_cache_payload()
     if not isinstance(cache_payload.get("uids"), dict):
         cache_payload["uids"] = {}
     cache_profiles = cache_payload.get("profiles")

--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -586,7 +586,7 @@ class CacheManager:
                 )
                 try:
                     self._ensure_bbdown(force_refresh=True)
-                    shutil.rmtree(item_dir, ignore_errors=True)
+                    self._safe_rmtree(item_dir)
                     item_dir.mkdir(parents=True, exist_ok=True)
                     self._cache_item_multi(item_id, item, allow_refresh_retry=False)
                     return
@@ -1986,7 +1986,7 @@ class CacheManager:
         for child in CACHE_DIR.iterdir():
             if child.name not in valid_ids:
                 if child.is_dir():
-                    shutil.rmtree(child, ignore_errors=True)
+                    self._safe_rmtree(child)
                 else:
                     child.unlink(missing_ok=True)
                 self._remove_item_log(child.name)
@@ -1994,7 +1994,7 @@ class CacheManager:
     def _clear_cache_root(self) -> None:
         for child in CACHE_DIR.iterdir():
             if child.is_dir():
-                shutil.rmtree(child, ignore_errors=True)
+                self._safe_rmtree(child)
             else:
                 child.unlink(missing_ok=True)
         self._clear_log_root()
@@ -2072,7 +2072,7 @@ class CacheManager:
         self._record_item_activity(item_id)
 
     def _remove_cache_dir(self, item_id: str) -> None:
-        shutil.rmtree(CACHE_DIR / item_id, ignore_errors=True)
+        self._safe_rmtree(CACHE_DIR / item_id)
         self._remove_item_log(item_id)
 
     def _remove_item_log(self, item_id: str) -> None:
@@ -2083,9 +2083,16 @@ class CacheManager:
             return
         for child in self.log_dir.iterdir():
             if child.is_dir():
-                shutil.rmtree(child, ignore_errors=True)
+                self._safe_rmtree(child)
             else:
                 child.unlink(missing_ok=True)
+
+    @staticmethod
+    def _safe_rmtree(path: Path) -> None:
+        try:
+            shutil.rmtree(path, ignore_errors=True)
+        except OSError:
+            return
 
     def _record_item_activity(self, item_id: str) -> None:
         with self.lock:

--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -1988,7 +1988,7 @@ class CacheManager:
                 if child.is_dir():
                     self._safe_rmtree(child)
                 else:
-                    child.unlink(missing_ok=True)
+                    self._safe_unlink(child)
                 self._remove_item_log(child.name)
 
     def _clear_cache_root(self) -> None:
@@ -1996,10 +1996,11 @@ class CacheManager:
             if child.is_dir():
                 self._safe_rmtree(child)
             else:
-                child.unlink(missing_ok=True)
+                self._safe_unlink(child)
         self._clear_log_root()
 
-    def _path_size(self, path: Path) -> int:
+    @staticmethod
+    def _path_size(path: Path) -> int:
         if not path.exists():
             return 0
         if path.is_file():
@@ -2009,13 +2010,16 @@ class CacheManager:
                 return 0
 
         total = 0
-        for child in path.rglob("*"):
-            if not child.is_file():
-                continue
-            try:
-                total += child.stat().st_size
-            except OSError:
-                continue
+        try:
+            for child in path.rglob("*"):
+                if not child.is_file():
+                    continue
+                try:
+                    total += child.stat().st_size
+                except OSError:
+                    continue
+        except OSError:
+            return total
         return total
 
     def _ensure_item_cached(self, item) -> None:
@@ -2076,7 +2080,7 @@ class CacheManager:
         self._remove_item_log(item_id)
 
     def _remove_item_log(self, item_id: str) -> None:
-        self._item_log_path(item_id).unlink(missing_ok=True)
+        self._safe_unlink(self._item_log_path(item_id))
 
     def _clear_log_root(self) -> None:
         if not self.log_dir.exists():
@@ -2085,12 +2089,19 @@ class CacheManager:
             if child.is_dir():
                 self._safe_rmtree(child)
             else:
-                child.unlink(missing_ok=True)
+                self._safe_unlink(child)
 
     @staticmethod
     def _safe_rmtree(path: Path) -> None:
         try:
             shutil.rmtree(path, ignore_errors=True)
+        except OSError:
+            return
+
+    @staticmethod
+    def _safe_unlink(path: Path) -> None:
+        try:
+            path.unlink(missing_ok=True)
         except OSError:
             return
 

--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -17,11 +17,13 @@ from .bilibili import (
     BilibiliError,
     ManualBindingRequiredError,
     MISSING_BILIBILI_COOKIE_MESSAGE,
+    add_gatcha_uid,
     effective_bilibili_cookie,
     fetch_gatcha_candidate,
     fetch_owner_info,
     fetch_video_item,
-    refresh_gatcha_cache,
+    gatcha_uid_snapshot,
+    preview_gatcha_uid,
     refresh_gatcha_cache_in_background,
     search_gatcha_cache,
 )
@@ -506,6 +508,12 @@ class BilikaraHandler(BaseHTTPRequestHandler):
             except Exception as e:
                 self._write_json({"ok": False, "error": str(e)})
             return
+        if route == "/api/gatcha/uids":
+            try:
+                self._write_json({"ok": True, "data": gatcha_uid_snapshot()})
+            except Exception as e:
+                self._write_json({"ok": False, "error": str(e)})
+            return
         if route.startswith("/media/"):
             self._serve_media(route)
             return
@@ -640,6 +648,20 @@ class BilikaraHandler(BaseHTTPRequestHandler):
                 self._require_id(body)
                 CONTEXT.retry_cache_item(body["item_id"], force=bool(body.get("force")))
                 self._write_json({"ok": True, "data": CONTEXT.snapshot()})
+                return
+            if route == "/api/gatcha/uids/add":
+                result = add_gatcha_uid(body.get("uid"))
+                self._write_json({"ok": True, "data": result})
+                return
+            if route == "/api/gatcha/uids/preview":
+                result = preview_gatcha_uid(body.get("uid"))
+                self._write_json({"ok": True, "data": result})
+                return
+            if route == "/api/gatcha/refresh":
+                if not effective_bilibili_cookie():
+                    raise ValueError(MISSING_BILIBILI_COOKIE_MESSAGE)
+                started = refresh_gatcha_cache_in_background()
+                self._write_json({"ok": True, "data": {"started": started}})
                 return
             if route == "/api/player/audio-variant":
                 self._require_id(body)
@@ -973,6 +995,8 @@ def _serve(
     actual_port = _find_available_port(host, port) if auto_select_port else port
     server = ThreadingHTTPServer((host, actual_port), BilikaraHandler)
     CONTEXT.bind_server(server, shutdown_on_last_client=shutdown_on_last_client)
+    if CONTEXT.cache_manager.bbdown_login_status().get("logged_in"):
+        refresh_gatcha_cache_in_background()
     browser_host = "127.0.0.1" if host == "0.0.0.0" else host
     url = f"http://{browser_host}:{actual_port}"
     print(f"{status_label} running on {url}")

--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -18,6 +18,7 @@ from .bilibili import (
     ManualBindingRequiredError,
     MISSING_BILIBILI_COOKIE_MESSAGE,
     add_gatcha_uid,
+    browse_gatcha_cache,
     effective_bilibili_cookie,
     fetch_gatcha_candidate,
     fetch_owner_info,
@@ -208,6 +209,7 @@ class AppContext:
         action: str,
         item_id: str = "",
         delta_seconds: int = 0,
+        target_seconds: float | None = None,
     ) -> dict[str, object]:
         with self._player_control_lock:
             self._player_control_seq += 1
@@ -216,6 +218,7 @@ class AppContext:
                 "action": action,
                 "item_id": item_id,
                 "delta_seconds": delta_seconds,
+                "target_seconds": target_seconds,
                 "issued_at": time.time(),
             }
             command = dict(self._player_control_command)
@@ -241,15 +244,32 @@ class AppContext:
         item_id: str,
         is_paused: bool,
         current_time: float = 0.0,
+        duration: float | None = None,
     ) -> None:
         normalized_item_id = str(item_id or "").strip()
         if not normalized_item_id:
             return
+        normalized_duration = 0.0
+        if duration is not None:
+            try:
+                normalized_duration = max(0.0, float(duration or 0.0))
+            except (TypeError, ValueError):
+                normalized_duration = 0.0
         with self._player_status_lock:
+            previous_duration = 0.0
+            if (
+                isinstance(self._player_status, dict)
+                and str(self._player_status.get("item_id") or "").strip() == normalized_item_id
+            ):
+                try:
+                    previous_duration = max(0.0, float(self._player_status.get("duration") or 0.0))
+                except (TypeError, ValueError):
+                    previous_duration = 0.0
             self._player_status = {
                 "item_id": normalized_item_id,
                 "is_paused": bool(is_paused),
                 "current_time": max(0.0, float(current_time or 0.0)),
+                "duration": normalized_duration or previous_duration,
                 "updated_at": time.time(),
             }
         if (not is_paused) or float(current_time or 0.0) > 0:
@@ -508,6 +528,15 @@ class BilikaraHandler(BaseHTTPRequestHandler):
             except Exception as e:
                 self._write_json({"ok": False, "error": str(e)})
             return
+        if route == "/api/gatcha/browse":
+            route_query = parse_qs(urlparse(self.path).query)
+            selected_uid = route_query.get("uid", [""])[0]
+            search_query = route_query.get("q", [""])[0]
+            try:
+                self._write_json({"ok": True, "data": browse_gatcha_cache(selected_uid, search_query)})
+            except Exception as e:
+                self._write_json({"ok": False, "error": str(e)})
+            return
         if route == "/api/gatcha/uids":
             try:
                 self._write_json({"ok": True, "data": gatcha_uid_snapshot()})
@@ -675,17 +704,23 @@ class BilikaraHandler(BaseHTTPRequestHandler):
             if route == "/api/player/control":
                 action = str(body.get("action") or "").strip()
                 item_id = str(body.get("item_id") or "").strip()
-                if action not in {"toggle-play", "seek-relative"}:
+                if action not in {"toggle-play", "seek-relative", "seek-absolute"}:
                     raise ValueError("invalid player control action")
                 delta_seconds = int(body.get("delta_seconds") or 0)
+                target_seconds = None
                 if action == "seek-relative" and delta_seconds == 0:
                     raise ValueError("missing delta_seconds")
                 if action == "seek-relative" and abs(delta_seconds) > 300:
                     raise ValueError("delta_seconds too large")
+                if action == "seek-absolute":
+                    target_seconds = float(body.get("target_seconds") or 0.0)
+                    if target_seconds < 0:
+                        raise ValueError("target_seconds must be non-negative")
                 CONTEXT.issue_player_control(
                     action=action,
                     item_id=item_id,
                     delta_seconds=delta_seconds,
+                    target_seconds=target_seconds,
                 )
                 self._write_json({"ok": True, "data": CONTEXT.snapshot()})
                 return
@@ -704,10 +739,14 @@ class BilikaraHandler(BaseHTTPRequestHandler):
                 if not isinstance(is_paused, bool):
                     raise ValueError("is_paused must be boolean")
                 current_time = float(body.get("current_time") or 0.0)
+                duration = None
+                if "duration" in body:
+                    duration = float(body.get("duration") or 0.0)
                 CONTEXT.update_player_status(
                     item_id=item_id,
                     is_paused=is_paused,
                     current_time=current_time,
+                    duration=duration,
                 )
                 self._write_json({"ok": True})
                 return

--- a/bilikara/store.py
+++ b/bilikara/store.py
@@ -787,7 +787,7 @@ class PlaylistStore:
 
     def _delete_runtime_json_files_unlocked(self) -> None:
         data_dir = self.state_file.parent
-        keep_names = {"gatcha_cache.json"}
+        keep_names = {"gatcha_cache.json", "gatcha_uids.json"}
         for path in data_dir.glob("*.json"):
             if path.name in keep_names:
                 continue

--- a/scripts/dev_smoke_test.py
+++ b/scripts/dev_smoke_test.py
@@ -35,6 +35,7 @@ DEFAULT_BBDOWN_TIMEOUT_SECONDS = 300
 DEFAULT_CACHE_TIMEOUT_SECONDS = 420
 DEFAULT_VISUAL_PAUSE_SECONDS = 5
 DEFAULT_TRANSITION_VISUAL_SECONDS = 18
+DEFAULT_TRANSITION_TAIL_SECONDS = 3.0
 
 
 class ApiError(RuntimeError):
@@ -345,7 +346,7 @@ class SmokeRunner:
         if song_urls:
             print_info(f"Using song URLs from command line: {len(song_urls)}")
         else:
-            song_urls = self.pick_gatcha_song_urls(3)
+            song_urls = self.pick_gatcha_song_urls(8)
         if not song_urls and not self.args.non_interactive:
             raw = input("Gatcha did not return a usable URL. Enter a Bilibili URL for song testing, or leave blank to skip: ").strip()
             if raw:
@@ -371,13 +372,20 @@ class SmokeRunner:
             print_ok(f"Multi-page search item added: {multi_item.get('display_title')} ({multi_item.get('id')})")
 
         regular_count = 2 if multi_item else 3
-        regular_urls = self.urls_for_count(song_urls, regular_count)
+        regular_urls = list(song_urls) if len(song_urls) >= regular_count else self.urls_for_count(song_urls, regular_count)
         top_song_added = False
-        for index, url in enumerate(regular_urls, start=1):
+        regular_added_count = 0
+        for url in regular_urls:
+            if regular_added_count >= regular_count:
+                break
             has_current = bool((self.get_state().get("current_item") or {}).get("id"))
             position = "next" if has_current and not top_song_added else "tail"
             before_ids = self.item_ids(self.get_state())
-            state = self.add_song(url, requester, position=position)
+            try:
+                state = self.add_song(url, requester, position=position)
+            except ApiError as exc:
+                print_warn(f"Skipping unusable song candidate: {url}: {exc}")
+                continue
             if position == "next":
                 top_song_added = True
             item = self.find_item_not_in_ids(state, before_ids) or self.find_newest_item(state, prefer_playlist=True)
@@ -385,14 +393,18 @@ class SmokeRunner:
                 continue
             added_items.append(item)
             self.created_item_ids.append(str(item.get("id") or ""))
+            regular_added_count += 1
             if position == "next":
                 print_ok(f"Top-song request succeeded: {item.get('display_title')} ({item.get('id')})")
-            elif index == 1 and not multi_item:
+            elif regular_added_count == 1 and not multi_item:
                 print_ok(f"Current song request succeeded: {item.get('display_title')} ({item.get('id')})")
             else:
-                print_ok(f"Queued song #{index}: {item.get('display_title')} ({item.get('id')})")
+                print_ok(f"Queued song #{regular_added_count}: {item.get('display_title')} ({item.get('id')})")
 
-        self.exercise_playlist_resort(regular_urls)
+        if regular_added_count < regular_count:
+            print_warn(f"Only added {regular_added_count}/{regular_count} regular song candidates; continuing with available items")
+
+        self.exercise_playlist_resort(song_urls)
         restore_cache_max = self.expand_cache_window_for_items(len(added_items))
         try:
             self.focus_created_items_for_cache_window(added_items)
@@ -652,16 +664,23 @@ class SmokeRunner:
         temp_users = [f"Cycle{suffix}A", f"Cycle{suffix}B"]
         temp_items: list[dict[str, Any]] = []
         added_users: list[str] = []
-        urls = self.urls_for_count(song_urls, len(temp_users))
+        urls = self.urls_for_count(song_urls, max(len(temp_users), min(len(song_urls), len(temp_users) * 4)))
 
         try:
             for user_name in temp_users:
                 self.add_user(user_name)
                 added_users.append(user_name)
 
-            for user_name, url in zip(temp_users, urls):
+            for url in urls:
+                if len(temp_items) >= len(temp_users):
+                    break
+                user_name = temp_users[len(temp_items)]
                 before_ids = self.item_ids(self.get_state())
-                state = self.add_song(url, user_name, position="tail")
+                try:
+                    state = self.add_song(url, user_name, position="tail")
+                except ApiError as exc:
+                    print_warn(f"Skipping unusable resort probe candidate for {user_name}: {url}: {exc}")
+                    continue
                 item = self.find_item_not_in_ids(state, before_ids) or self.find_newest_item(state, prefer_playlist=True)
                 if not item:
                     continue
@@ -845,12 +864,12 @@ class SmokeRunner:
             original_delay = int((state.get("player_settings") or {}).get("song_advance_delay_seconds") or 0)
             self.api_post("/api/player/advance-delay", {"delay_seconds": 5})
             try:
-                if self.seek_current_item_near_end(current_id, tail_seconds=2.0):
-                    print_ok("Requested Remote seek near the end of the current song for transition UI testing")
+                if self.seek_current_item_near_end(current_id, tail_seconds=DEFAULT_TRANSITION_TAIL_SECONDS):
+                    print_ok("Requested Remote seek to 3s before the end of the current song for transition UI testing")
                 else:
                     print_warn("Could not confirm a near-end seek; transition UI may require fallback next-song")
                 self.visual_checkpoint(
-                    "Watch the Host player now. Playback should already be near the end so the in-player countdown can stay visible without leaving fullscreen.",
+                    "Watch the Host player now. Playback should be about 3s before the end so the in-player countdown can stay visible without leaving fullscreen.",
                     seconds=self.args.transition_visual_pause,
                 )
                 state_after_seek = self.get_state()
@@ -893,17 +912,20 @@ class SmokeRunner:
         target_time = max(0.0, duration_seconds - max(0.5, tail_seconds))
         remaining = target_time - current_time
         if remaining <= 0.5:
-            print_ok(f"Playback is already near the end: current={current_time:.1f}s duration={duration_seconds:.1f}s")
+            print_ok(
+                f"Playback is already near the transition target: "
+                f"current={current_time:.1f}s target={target_time:.1f}s duration={duration_seconds:.1f}s"
+            )
             return True
         print_info(
-            f"Seeking near end for transition test: current={current_time:.1f}s "
+            f"Seeking to {tail_seconds:.1f}s before the end for transition test: current={current_time:.1f}s "
             f"target={target_time:.1f}s duration={duration_seconds:.1f}s"
         )
 
         estimated_time = current_time
-        while target_time - estimated_time > 0.5:
+        while target_time - estimated_time > 1.0:
             remaining = target_time - estimated_time
-            delta_seconds = int(min(300, max(1, math.ceil(remaining))))
+            delta_seconds = int(min(300, max(1, math.floor(remaining))))
             seek_state = self.api_post(
                 "/api/player/control",
                 {"action": "seek-relative", "item_id": item_id, "delta_seconds": delta_seconds},
@@ -914,16 +936,23 @@ class SmokeRunner:
             if seq and not self.wait_for_player_control_ack(seq):
                 print_warn(f"Timed out waiting for seek command ack: seq={seq} delta={delta_seconds}")
                 return False
-            estimated_time += delta_seconds
             time.sleep(0.4)
+            estimated_time += delta_seconds
+            observed_state = self.get_state()
+            observed_status_time = self.player_current_time_seconds(observed_state, item_id)
+            if observed_status_time > 0:
+                estimated_time = max(estimated_time, observed_status_time)
 
         observed_time = self.wait_for_player_time_at_least(
             item_id,
-            min_seconds=max(0.0, target_time - 3.0),
+            min_seconds=max(0.0, target_time - 1.0),
             timeout=8.0,
         )
         if observed_time is not None:
-            print_ok(f"Player reported near-end playback: current={observed_time:.1f}s duration={duration_seconds:.1f}s")
+            print_ok(
+                f"Player reported near-end playback: "
+                f"current={observed_time:.1f}s target={target_time:.1f}s duration={duration_seconds:.1f}s"
+            )
         else:
             print_info(
                 f"Seek commands were acknowledged; last estimated playback was about "

--- a/scripts/dev_smoke_test.py
+++ b/scripts/dev_smoke_test.py
@@ -5,7 +5,6 @@ import argparse
 import base64
 from dataclasses import dataclass
 import json
-import math
 import os
 from pathlib import Path
 import queue
@@ -36,6 +35,9 @@ DEFAULT_CACHE_TIMEOUT_SECONDS = 420
 DEFAULT_VISUAL_PAUSE_SECONDS = 5
 DEFAULT_TRANSITION_VISUAL_SECONDS = 18
 DEFAULT_TRANSITION_TAIL_SECONDS = 3.0
+DEFAULT_TRANSITION_SEEK_TOLERANCE_SECONDS = 1.25
+DEFAULT_TRANSITION_END_GUARD_SECONDS = 0.75
+DEFAULT_SMOKE_VIDEO_QUALITY_PREFIX = "480P"
 
 
 class ApiError(RuntimeError):
@@ -65,6 +67,12 @@ class ServerHandle:
         if self.context is not None:
             self.context.shutdown()
         self.server.server_close()
+
+
+@dataclass
+class PlayerTimeWindowResult:
+    status: str
+    current_time: float | None = None
 
 
 class SmokeRunner:
@@ -153,9 +161,59 @@ class SmokeRunner:
 
     def check_static_pages(self) -> None:
         print_header("Static pages and assets")
-        for path in ["/", "/remote", "/app.js", "/styles.css", "/remote.js", "/remote-queue.js"]:
+        static_bodies: dict[str, bytes] = {}
+        for path in ["/", "/remote", "/app.js", "/styles.css", "/remote.js", "/remote.css", "/remote-queue.js"]:
             body = self.http_get(path, expect_json=False)
+            static_bodies[path] = body
             print_ok(f"GET {path} ({len(body)} bytes)")
+        self.check_recent_feature_static_surface(static_bodies)
+
+    def check_recent_feature_static_surface(self, static_bodies: dict[str, bytes]) -> None:
+        print_header("Recent UI surface checks")
+        expected_tokens = {
+            "/": [
+                "search-cookie-toggle",
+                "follow-up-grid",
+                "follow-song-results",
+                "binding-modal-confirm",
+            ],
+            "/remote": [
+                "follow-browse-toggle",
+                "follow-up-grid",
+                "follow-song-results",
+                "binding-sheet-actions",
+            ],
+            "/app.js": [
+                "fetchGatchaBrowse",
+                "followSongResults",
+                "handleAddByUrl",
+            ],
+            "/remote.js": [
+                "fetchGatchaBrowse",
+                "followSongResults",
+                "addByUrl",
+            ],
+            "/styles.css": [
+                "grid-template-rows: auto auto minmax(0, 1fr) auto",
+                ".selection-modal-actions",
+                ".follow-up-grid",
+            ],
+            "/remote.css": [
+                "flex-direction: column",
+                ".binding-sheet-actions",
+                ".follow-up-grid",
+            ],
+        }
+        for path, tokens in expected_tokens.items():
+            body = static_bodies.get(path)
+            if body is None:
+                continue
+            text = body.decode("utf-8", errors="replace")
+            missing = [token for token in tokens if token not in text]
+            if missing:
+                raise RuntimeError(f"{path} missing recent UI token(s): {missing}")
+            elif tokens:
+                print_ok(f"{path} includes recent follow/binding UI hooks")
 
     def check_remote_surface(self) -> None:
         print_header("Remote page surface")
@@ -164,6 +222,7 @@ class SmokeRunner:
         result = self.http_get(f"/api/gatcha/search?q={urllib.parse.quote(GATCHA_MULTI_PAGE_QUERY)}", remote=True)
         items = ((result.get("data") or {}).get("items") or []) if isinstance(result, dict) else []
         print_ok(f"Remote gatcha search API works for multi-page keyword: {len(items)} results")
+        self.check_follow_browse_api("Remote follow browse", remote=True)
         self.visual_checkpoint("Remote page should be open in another browser tab. Check queue, search, and control layout there.")
 
     def check_bbdown_login(self) -> None:
@@ -316,6 +375,44 @@ class SmokeRunner:
         print_ok("Player settings restored to the pre-test values")
         self.visual_checkpoint("Service Settings should keep its layout; values may have changed briefly and then restored.")
 
+    def smoke_download_quality(self, cache_policy: dict[str, Any]) -> str:
+        choices = cache_policy.get("video_quality_choices") or []
+        for choice in choices:
+            value = str((choice or {}).get("value") or "").strip()
+            if value.startswith(DEFAULT_SMOKE_VIDEO_QUALITY_PREFIX):
+                return value
+        return ""
+
+    def set_smoke_download_quality(self) -> dict[str, Any]:
+        state = self.get_state()
+        original_policy = dict(state.get("cache_policy") or {})
+        target_quality = self.smoke_download_quality(original_policy)
+        if not target_quality:
+            print_skip("Smoke download quality", "No 480P video quality choice was available")
+            return {}
+
+        policy_payload: dict[str, Any] = {"video_quality": target_quality}
+        state = self.api_post("/api/cache-policy", policy_payload)
+        policy = state.get("cache_policy") or {}
+        print_ok(f"Smoke download video quality set to {policy.get('video_quality')} before song downloads")
+
+        restore_payload: dict[str, Any] = {}
+        if "video_quality" in original_policy:
+            restore_payload["video_quality"] = original_policy["video_quality"]
+        if "audio_hires" in original_policy:
+            restore_payload["audio_hires"] = bool(original_policy.get("audio_hires"))
+        return restore_payload
+
+    def restore_smoke_download_quality(self, policy_payload: dict[str, Any]) -> None:
+        if not policy_payload:
+            return
+        state = self.api_post("/api/cache-policy", policy_payload)
+        policy = state.get("cache_policy") or {}
+        print_ok(
+            "Restored download quality policy: "
+            f"quality={policy.get('video_quality')} hires={policy.get('audio_hires')}"
+        )
+
     def check_users(self) -> None:
         print_header("Local user management")
         suffix = str(int(time.time()))[-6:]
@@ -364,6 +461,13 @@ class SmokeRunner:
                 self.add_user(requester)
                 self.created_user_names.append(requester)
 
+        restore_smoke_policy = self.set_smoke_download_quality()
+        try:
+            self.check_song_download_flow(song_urls, requester)
+        finally:
+            self.restore_smoke_download_quality(restore_smoke_policy)
+
+    def check_song_download_flow(self, song_urls: list[str], requester: str) -> None:
         added_items: list[dict[str, Any]] = []
         multi_item = self.check_search_multi_page_binding(requester)
         if multi_item:
@@ -904,14 +1008,31 @@ class SmokeRunner:
         if not item:
             print_skip("Transition seek", f"Current item was not found: {item_id}")
             return False
-        duration_seconds = self.item_duration_seconds(item)
+        metadata_duration_seconds = self.item_duration_seconds(item)
+        observed_duration_seconds = self.wait_for_player_duration_seconds(item_id, timeout=6.0)
+        duration_seconds = observed_duration_seconds or metadata_duration_seconds
         if duration_seconds <= 0:
             print_skip("Transition seek", f"Current item duration is unavailable: {item_id}")
             return False
-        current_time = self.player_current_time_seconds(state, item_id)
+        duration_source = "player media" if observed_duration_seconds else "item metadata"
+        current_time = self.player_current_time_seconds(self.get_state(), item_id)
+        tolerance_seconds = DEFAULT_TRANSITION_SEEK_TOLERANCE_SECONDS
+        end_guard_seconds = DEFAULT_TRANSITION_END_GUARD_SECONDS
         target_time = max(0.0, duration_seconds - max(0.5, tail_seconds))
         remaining = target_time - current_time
         if remaining <= 0.5:
+            if current_time >= max(0.0, duration_seconds - end_guard_seconds):
+                print_warn(
+                    f"Playback is already at the media end: "
+                    f"current={current_time:.1f}s duration={duration_seconds:.1f}s"
+                )
+                return False
+            if current_time > target_time + tolerance_seconds:
+                print_warn(
+                    f"Playback is already past the transition target: "
+                    f"current={current_time:.1f}s target={target_time:.1f}s duration={duration_seconds:.1f}s"
+                )
+                return False
             print_ok(
                 f"Playback is already near the transition target: "
                 f"current={current_time:.1f}s target={target_time:.1f}s duration={duration_seconds:.1f}s"
@@ -919,46 +1040,60 @@ class SmokeRunner:
             return True
         print_info(
             f"Seeking to {tail_seconds:.1f}s before the end for transition test: current={current_time:.1f}s "
-            f"target={target_time:.1f}s duration={duration_seconds:.1f}s"
+            f"target={target_time:.1f}s duration={duration_seconds:.1f}s source={duration_source}"
         )
 
-        estimated_time = current_time
-        while target_time - estimated_time > 1.0:
-            remaining = target_time - estimated_time
-            delta_seconds = int(min(300, max(1, math.floor(remaining))))
-            seek_state = self.api_post(
-                "/api/player/control",
-                {"action": "seek-relative", "item_id": item_id, "delta_seconds": delta_seconds},
-                remote=True,
-            )
-            command = seek_state.get("player_control_command") or {}
-            seq = int(command.get("seq") or 0)
-            if seq and not self.wait_for_player_control_ack(seq):
-                print_warn(f"Timed out waiting for seek command ack: seq={seq} delta={delta_seconds}")
-                return False
-            time.sleep(0.4)
-            estimated_time += delta_seconds
-            observed_state = self.get_state()
-            observed_status_time = self.player_current_time_seconds(observed_state, item_id)
-            if observed_status_time > 0:
-                estimated_time = max(estimated_time, observed_status_time)
+        seek_state = self.api_post(
+            "/api/player/control",
+            {"action": "seek-absolute", "item_id": item_id, "target_seconds": target_time},
+            remote=True,
+        )
+        command = seek_state.get("player_control_command") or {}
+        seq = int(command.get("seq") or 0)
+        if seq and not self.wait_for_player_control_ack(seq):
+            print_warn(f"Timed out waiting for absolute seek command ack: seq={seq} target={target_time:.1f}s")
+            return False
 
-        observed_time = self.wait_for_player_time_at_least(
+        window_result = self.wait_for_player_time_in_transition_window(
             item_id,
-            min_seconds=max(0.0, target_time - 1.0),
+            target_seconds=target_time,
+            duration_seconds=duration_seconds,
+            tolerance_seconds=tolerance_seconds,
+            end_guard_seconds=end_guard_seconds,
             timeout=8.0,
         )
-        if observed_time is not None:
+        if window_result.status == "ok" and window_result.current_time is not None:
             print_ok(
                 f"Player reported near-end playback: "
-                f"current={observed_time:.1f}s target={target_time:.1f}s duration={duration_seconds:.1f}s"
+                f"current={window_result.current_time:.1f}s target={target_time:.1f}s duration={duration_seconds:.1f}s"
             )
-        else:
-            print_info(
-                f"Seek commands were acknowledged; last estimated playback was about "
-                f"{min(estimated_time, duration_seconds):.1f}s / {duration_seconds:.1f}s"
-            )
-        return True
+            return True
+
+        observed_text = (
+            f"{window_result.current_time:.1f}s"
+            if window_result.current_time is not None
+            else "unavailable"
+        )
+        print_warn(
+            f"Player did not land in the transition window after seek: "
+            f"status={window_result.status} current={observed_text} "
+            f"target={target_time:.1f}s duration={duration_seconds:.1f}s"
+        )
+        return False
+
+    def wait_for_player_duration_seconds(self, item_id: str, *, timeout: float) -> float | None:
+        deadline = time.time() + timeout
+        last_seen: float | None = None
+        while time.time() < deadline:
+            state = self.get_state(timeout=10)
+            duration = self.player_duration_seconds(state, item_id)
+            if duration > 0:
+                return duration
+            status = self.player_status_for_item(state, item_id)
+            if status is not None:
+                last_seen = duration
+            time.sleep(0.5)
+        return last_seen if last_seen and last_seen > 0 else None
 
     def wait_for_player_control_ack(self, seq: int, *, timeout: float = 8.0) -> bool:
         if seq <= 0:
@@ -974,20 +1109,47 @@ class SmokeRunner:
             time.sleep(0.2)
         return False
 
-    def wait_for_player_time_at_least(self, item_id: str, *, min_seconds: float, timeout: float) -> float | None:
+    def wait_for_player_time_in_transition_window(
+        self,
+        item_id: str,
+        *,
+        target_seconds: float,
+        duration_seconds: float,
+        tolerance_seconds: float,
+        end_guard_seconds: float,
+        timeout: float,
+    ) -> PlayerTimeWindowResult:
         deadline = time.time() + timeout
         last_seen: float | None = None
+        min_seconds = max(0.0, target_seconds - tolerance_seconds)
+        max_seconds = min(
+            max(0.0, duration_seconds - end_guard_seconds),
+            target_seconds + tolerance_seconds,
+        )
+        if max_seconds < min_seconds:
+            max_seconds = min_seconds
         while time.time() < deadline:
             state = self.get_state(timeout=10)
+            current_id = str((state.get("current_item") or {}).get("id") or "")
+            if current_id != item_id:
+                return PlayerTimeWindowResult("item-changed", last_seen)
             status = self.player_status_for_item(state, item_id)
             if status is None:
-                time.sleep(0.5)
+                time.sleep(0.25)
                 continue
-            last_seen = max(0.0, float(status.get("current_time") or 0.0))
-            if last_seen >= min_seconds:
-                return last_seen
-            time.sleep(0.5)
-        return last_seen if last_seen is not None and last_seen >= min_seconds else None
+            try:
+                last_seen = max(0.0, float(status.get("current_time") or 0.0))
+            except (TypeError, ValueError):
+                time.sleep(0.25)
+                continue
+            if last_seen >= max(0.0, duration_seconds - end_guard_seconds):
+                return PlayerTimeWindowResult("ended", last_seen)
+            if min_seconds <= last_seen <= max_seconds:
+                return PlayerTimeWindowResult("ok", last_seen)
+            if last_seen > max_seconds:
+                return PlayerTimeWindowResult("overshot", last_seen)
+            time.sleep(0.25)
+        return PlayerTimeWindowResult("timeout", last_seen)
 
     @staticmethod
     def player_status_for_item(state: dict[str, Any], item_id: str) -> dict[str, Any] | None:
@@ -1005,6 +1167,16 @@ class SmokeRunner:
             return 0.0
         try:
             return max(0.0, float(status.get("current_time") or 0.0))
+        except (TypeError, ValueError):
+            return 0.0
+
+    @classmethod
+    def player_duration_seconds(cls, state: dict[str, Any], item_id: str) -> float:
+        status = cls.player_status_for_item(state, item_id)
+        if status is None:
+            return 0.0
+        try:
+            return max(0.0, float(status.get("duration") or 0.0))
         except (TypeError, ValueError):
             return 0.0
 
@@ -1066,6 +1238,8 @@ class SmokeRunner:
         except ApiError as exc:
             print_warn(f"Gatcha search returned an error: {exc}")
 
+        self.check_follow_browse_api("Host follow browse", remote=False)
+
         try:
             result = self.http_get("/api/gatcha/candidate", timeout=30)
             if result.get("ok"):
@@ -1074,6 +1248,54 @@ class SmokeRunner:
                 print_warn(f"Gatcha candidate returned no song: {result.get('error')}")
         except Exception as exc:  # noqa: BLE001
             print_warn(f"Gatcha candidate skipped/failed: {exc}")
+
+    def check_follow_browse_api(self, label: str, *, remote: bool) -> None:
+        try:
+            result = self.http_get("/api/gatcha/browse", timeout=30, remote=remote)
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"{label} API failed: {exc}") from exc
+        if not isinstance(result, dict) or not result.get("ok"):
+            raise RuntimeError(f"{label} API returned an error: {result.get('error') if isinstance(result, dict) else result}")
+        data = result.get("data") if isinstance(result, dict) else {}
+        owners = data.get("owners") if isinstance(data, dict) else []
+        if not isinstance(owners, list):
+            raise RuntimeError(f"{label} returned a non-list owners payload")
+        print_ok(f"{label} owner grid API works: {len(owners)} owners")
+        if not owners:
+            print_skip(label, "No followed UID owners are configured")
+            return
+
+        owner = next(
+            (
+                entry for entry in owners
+                if isinstance(entry, dict) and str(entry.get("uid") or "").strip()
+            ),
+            None,
+        )
+        if not owner:
+            raise RuntimeError(f"{label} returned owners without UID values")
+        uid = str(owner.get("uid") or "").strip()
+        owner_name = str(owner.get("name") or "").strip() or f"UID {uid}"
+        try:
+            count = int(owner.get("count") or 0)
+        except (TypeError, ValueError):
+            count = 0
+        selected = self.http_get(f"/api/gatcha/browse?uid={urllib.parse.quote(uid)}", timeout=30, remote=remote)
+        selected_data = selected.get("data") if isinstance(selected, dict) else {}
+        items = selected_data.get("items") if isinstance(selected_data, dict) else []
+        items = items if isinstance(items, list) else []
+        print_ok(f"{label} selected owner API works: {owner_name} ({uid}) items={len(items)} cached_count={count}")
+        if items:
+            first_title = str((items[0] or {}).get("title") or "").strip()
+            if first_title:
+                query = urllib.parse.quote(first_title[:8])
+                filtered = self.http_get(
+                    f"/api/gatcha/browse?uid={urllib.parse.quote(uid)}&q={query}",
+                    timeout=30,
+                    remote=remote,
+                )
+                filtered_items = (((filtered.get("data") or {}).get("items") or []) if isinstance(filtered, dict) else [])
+                print_ok(f"{label} per-owner search works: {len(filtered_items)} result(s) for title prefix")
 
     def check_destructive_maintenance(self) -> None:
         print_header("Destructive data maintenance APIs")

--- a/static/app.js
+++ b/static/app.js
@@ -1,7 +1,6 @@
 const pollIntervalMs = 1000;
 const bannerAutoHideMs = 5000;
 const stalledRetrySeconds = 5;
-const gatchaCooldownMs = 15000;
 const localPlayerSyncIntervalMs = 120;
 const localPlayerHardSyncThresholdSeconds = 0.08;
 const localPlayerForceSyncEpsilonSeconds = 0.015;
@@ -33,7 +32,8 @@ const state = {
   remoteAccessRenderSignature: "",
   cacheSettingsRenderSignature: "",
   bbdownLoginRenderSignature: "",
-  gatchaCookieFaceRenderSignature: "",
+  searchCookieFaceRenderSignature: "",
+  gatchaUidFaceRenderSignature: "",
   historyRenderSignature: "",
   playlistEmptyRenderSignature: "",
   cacheSliderRenderSignature: "",
@@ -99,9 +99,10 @@ const state = {
   bindingIntent: null,
   retryActivityById: {},
   gatchaCandidate: null,
-  gatchaCooldownUntil: 0,
-  gatchaCooldownTimer: null,
-  gatchaCookieVisible: false,
+  searchCookieVisible: false,
+  gatchaUidVisible: false,
+  gatchaUidSaving: false,
+  gatchaRefreshSaving: false,
   bbdownLoginRequesting: false,
   appToastTimer: null,
   layoutMode: "full",
@@ -203,14 +204,21 @@ const elements = {
   remotePopoverQrPlaceholder: document.getElementById("remote-popover-qr-placeholder"),
   remotePopoverUrlLink: document.getElementById("remote-popover-url-link"),
   remotePopoverUrlHint: document.getElementById("remote-popover-url-hint"),
+  searchPanel: document.getElementById("search-panel"),
+  searchTag: document.getElementById("search-tag"),
+  searchTitle: document.getElementById("search-title"),
+  searchCookieToggle: document.getElementById("search-cookie-toggle"),
+  searchStage: document.getElementById("search-stage"),
+  searchMainView: document.getElementById("search-main-view"),
+  searchCookieView: document.getElementById("search-cookie-view"),
   gatchaPanel: document.getElementById("gatcha-panel"),
   gatchaTag: document.getElementById("gatcha-tag"),
   gatchaTitle: document.getElementById("gatcha-title"),
   gatchaStage: document.getElementById("gatcha-stage"),
   gatchaButton: document.getElementById("gatcha-button"),
-  gatchaCookieToggle: document.getElementById("gatcha-cookie-toggle"),
+  gatchaUidToggle: document.getElementById("gatcha-uid-toggle"),
   gatchaMainView: document.getElementById("gatcha-main-view"),
-  gatchaCookieView: document.getElementById("gatcha-cookie-view"),
+  gatchaUidView: document.getElementById("gatcha-uid-view"),
   gatchaConfirmButton: document.getElementById("gatcha-confirm-button"),
   gatchaRetryButton: document.getElementById("gatcha-retry-button"),
   gatchaMessage: document.getElementById("gatcha-message"),
@@ -226,6 +234,11 @@ const elements = {
   cookieJct: document.getElementById("cookie-jct"),
   saveCookieButton: document.getElementById("save-cookie-button"),
   cookieMessage: document.getElementById("cookie-message"),
+  gatchaUidForm: document.getElementById("gatcha-uid-form"),
+  gatchaUidInput: document.getElementById("gatcha-uid-input"),
+  addGatchaUidButton: document.getElementById("add-gatcha-uid-button"),
+  refreshGatchaCacheButton: document.getElementById("refresh-gatcha-cache-button"),
+  gatchaUidMessage: document.getElementById("gatcha-uid-message"),
 };
 
 function setFormMessage(message, isError = false) {
@@ -736,6 +749,47 @@ async function searchGatchaCache(query) {
   return Array.isArray(payload.data?.items) ? payload.data.items : [];
 }
 
+async function previewGatchaUid(uid) {
+  return apiPost("/api/gatcha/uids/preview", { uid: String(uid || "").trim() });
+}
+
+async function addGatchaUid(uid) {
+  return apiPost("/api/gatcha/uids/add", { uid: String(uid || "").trim() });
+}
+
+async function refreshGatchaCache() {
+  return apiPost("/api/gatcha/refresh");
+}
+
+function gatchaUidResultMessage(result, fallbackUid = "") {
+  const cache = result?.cache || {};
+  const addedCount = Number(cache.added_count || 0);
+  const totalCount = Number(cache.total_count || 0);
+  const modeLabel = cache.mode === "incremental" ? "最新" : "所有";
+  const ownerLabel = result?.name ? `UP 主 ${result.name}` : `UID ${result?.uid || fallbackUid}`;
+  const listAction = result?.added ? "已添加" : "已在关注列表中";
+  return `${ownerLabel} ${listAction}，已拉取${modeLabel}稿件，新增 ${addedCount} 条，缓存共 ${totalCount} 条。`;
+}
+
+async function confirmGatchaUidAdd(intent) {
+  closeConfirm();
+  state.gatchaUidSaving = true;
+  renderGatchaUidFace();
+  setGatchaUidMessage(`正在拉取 UP 主：${intent.name || intent.uid} 的稿件...`);
+  try {
+    const result = await addGatchaUid(intent.uid);
+    setGatchaUidMessage(gatchaUidResultMessage(result, intent.uid));
+    if (elements.gatchaUidInput) {
+      elements.gatchaUidInput.value = "";
+    }
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaUidSaving = false;
+    renderGatchaUidFace();
+  }
+}
+
 function hideSearchResults() {
   elements.searchResults.innerHTML = "";
   elements.searchResults.classList.add("hidden");
@@ -781,10 +835,6 @@ function renderSearchResults(items) {
 }
 
 async function handleGatchaDraw() {
-  if (gatchaCooldownRemainingSeconds() > 0) {
-    syncGatchaCooldownButtons();
-    return;
-  }
   setGatchaMessage("正在连接 B 站寻找幸运投稿...");
   try {
     const response = await fetch("/api/gatcha/candidate", { headers: clientHeaders() });
@@ -795,7 +845,6 @@ async function handleGatchaDraw() {
 
     state.gatchaCandidate = payload.data;
     elements.gatchaCandidateTitle.textContent = state.gatchaCandidate.title;
-    startGatchaCooldown();
     
     // 切换界面
     elements.gatchaInitView.classList.add("hidden");
@@ -822,54 +871,59 @@ function setCookieMessage(message, isError = false) {
   elements.cookieMessage.classList.toggle("is-error", Boolean(isError));
 }
 
-function renderGatchaCookieFace() {
-  const showCookie = Boolean(state.gatchaCookieVisible);
-  const signature = showCookie ? "cookie" : "gatcha";
-  if (signature === state.gatchaCookieFaceRenderSignature) {
+function setGatchaUidMessage(message, isError = false) {
+  if (!elements.gatchaUidMessage) {
     return;
   }
-  state.gatchaCookieFaceRenderSignature = signature;
+  elements.gatchaUidMessage.textContent = message || "";
+  elements.gatchaUidMessage.classList.toggle("is-error", Boolean(isError));
+}
 
-  setClassToggle(elements.gatchaPanel, "is-cookie-view", showCookie);
-  setClassToggle(elements.gatchaStage, "is-cookie-view", showCookie);
-  setTextContent(elements.gatchaTag, showCookie ? "Cookie Config" : "gatcha Draw");
-  setTextContent(elements.gatchaTitle, showCookie ? "Cookie" : "试试运气");
-  setTextContent(elements.gatchaCookieToggle, showCookie ? "返回抽卡" : "输入 Cookie");
-  if (elements.gatchaCookieToggle?.getAttribute("aria-pressed") !== String(showCookie)) {
-    elements.gatchaCookieToggle.setAttribute("aria-pressed", String(showCookie));
+function renderSearchCookieFace() {
+  const showCookie = Boolean(state.searchCookieVisible);
+  const signature = showCookie ? "cookie" : "search";
+  if (signature === state.searchCookieFaceRenderSignature) {
+    return;
+  }
+  state.searchCookieFaceRenderSignature = signature;
+
+  setClassToggle(elements.searchPanel, "is-cookie-view", showCookie);
+  setClassToggle(elements.searchStage, "is-cookie-view", showCookie);
+  setTextContent(elements.searchTag, showCookie ? "Cookie Config" : "Local Search");
+  setTextContent(elements.searchTitle, showCookie ? "Cookie" : "搜索");
+  setTextContent(elements.searchCookieToggle, showCookie ? "返回搜索" : "输入 Cookie");
+  if (elements.searchCookieToggle?.getAttribute("aria-pressed") !== String(showCookie)) {
+    elements.searchCookieToggle.setAttribute("aria-pressed", String(showCookie));
   }
 }
 
-function gatchaCooldownRemainingSeconds() {
-  return Math.max(0, Math.ceil((state.gatchaCooldownUntil - Date.now()) / 1000));
-}
-
-function startGatchaCooldown() {
-  state.gatchaCooldownUntil = Date.now() + gatchaCooldownMs;
-  syncGatchaCooldownButtons();
-  if (state.gatchaCooldownTimer) {
-    clearInterval(state.gatchaCooldownTimer);
+function renderGatchaUidFace() {
+  const showUid = Boolean(state.gatchaUidVisible);
+  const signature = JSON.stringify({
+    showUid,
+    saving: state.gatchaUidSaving,
+    refreshing: state.gatchaRefreshSaving,
+  });
+  if (signature === state.gatchaUidFaceRenderSignature) {
+    return;
   }
-  state.gatchaCooldownTimer = setInterval(() => {
-    syncGatchaCooldownButtons();
-    if (gatchaCooldownRemainingSeconds() <= 0) {
-      clearInterval(state.gatchaCooldownTimer);
-      state.gatchaCooldownTimer = null;
-    }
-  }, 250);
-}
+  state.gatchaUidFaceRenderSignature = signature;
 
-function syncGatchaCooldownButtons() {
-  const remainingSeconds = gatchaCooldownRemainingSeconds();
-  const coolingDown = remainingSeconds > 0;
-  const cooldownText = `等待 ${remainingSeconds}s`;
-  if (elements.gatchaButton) {
-    elements.gatchaButton.disabled = coolingDown;
-    elements.gatchaButton.textContent = coolingDown ? cooldownText : "试试运气";
+  setClassToggle(elements.gatchaPanel, "is-uid-view", showUid);
+  setClassToggle(elements.gatchaStage, "is-uid-view", showUid);
+  setTextContent(elements.gatchaTag, showUid ? "Follow UID" : "gatcha Draw");
+  setTextContent(elements.gatchaTitle, showUid ? "关注 UID" : "试试运气");
+  setTextContent(elements.gatchaUidToggle, showUid ? "返回抽卡" : "添加 UID");
+  if (elements.gatchaUidToggle?.getAttribute("aria-pressed") !== String(showUid)) {
+    elements.gatchaUidToggle.setAttribute("aria-pressed", String(showUid));
   }
-  if (elements.gatchaRetryButton) {
-    elements.gatchaRetryButton.disabled = coolingDown;
-    elements.gatchaRetryButton.textContent = coolingDown ? cooldownText : "重新再来";
+  if (elements.addGatchaUidButton) {
+    elements.addGatchaUidButton.disabled = state.gatchaUidSaving;
+    elements.addGatchaUidButton.textContent = state.gatchaUidSaving ? "处理中" : "添加";
+  }
+  if (elements.refreshGatchaCacheButton) {
+    elements.refreshGatchaCacheButton.disabled = state.gatchaRefreshSaving;
+    elements.refreshGatchaCacheButton.textContent = state.gatchaRefreshSaving ? "更新中" : "手动更新";
   }
 }
 
@@ -931,7 +985,8 @@ function render() {
     Boolean(data.session_flags?.auto_restored_backup),
   );
   syncListStageView();
-  renderGatchaCookieFace();
+  renderSearchCookieFace();
+  renderGatchaUidFace();
   renderConfirmPopover();
   state.lastPollRenderSignature = renderSignatureForData(data);
 }
@@ -4457,6 +4512,10 @@ elements.confirmOk.addEventListener("click", async () => {
       render();
       return;
     }
+    if (intent.type === "gatcha-uid-add" && intent.uid) {
+      await confirmGatchaUidAdd(intent);
+      return;
+    }
     if (intent.type === "duplicate-add" && intent.url) {
       state.data = await submitAddRequest(intent.url, intent.position || "tail", {
         requesterName: intent.requesterName || selectedRequesterName(),
@@ -4494,6 +4553,8 @@ document.addEventListener("click", (event) => {
       event.target.closest("#current-cache-retry-button") ||
       event.target.closest("#player-reset-button") ||
       event.target.closest("#add-form") ||
+      event.target.closest("#gatcha-uid-form") ||
+      event.target.closest("#refresh-gatcha-cache-button") ||
       event.target.closest("#history-list")
     ) {
       return;
@@ -4675,9 +4736,14 @@ elements.listStage.addEventListener("wheel", (event) => {
 elements.gatchaButton.addEventListener("click", handleGatchaDraw);
 elements.gatchaRetryButton.addEventListener("click", handleGatchaDraw);
 
-elements.gatchaCookieToggle?.addEventListener("click", () => {
-  state.gatchaCookieVisible = !state.gatchaCookieVisible;
-  renderGatchaCookieFace();
+elements.searchCookieToggle?.addEventListener("click", () => {
+  state.searchCookieVisible = !state.searchCookieVisible;
+  renderSearchCookieFace();
+});
+
+elements.gatchaUidToggle?.addEventListener("click", () => {
+  state.gatchaUidVisible = !state.gatchaUidVisible;
+  renderGatchaUidFace();
 });
 
 elements.gatchaConfirmButton.addEventListener("click", async () => {
@@ -4729,6 +4795,54 @@ elements.gatchaConfirmButton.addEventListener("click", async () => {
       return;
     }
     setGatchaMessage(error.message, true);
+  }
+});
+
+elements.gatchaUidForm?.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const uid = String(elements.gatchaUidInput?.value || "").trim();
+  if (!uid) {
+    setGatchaUidMessage("请输入 UID", true);
+    return;
+  }
+
+  state.gatchaUidSaving = true;
+  renderGatchaUidFace();
+  setGatchaUidMessage("正在检测 UID...");
+  try {
+    const preview = await previewGatchaUid(uid);
+    const ownerName = preview?.name || `UID ${preview?.uid || uid}`;
+    const modeLabel = preview?.cache_mode_label || (preview?.cache_mode === "incremental" ? "最新" : "所有");
+    const followedPrefix = preview?.already_followed ? "已在关注列表中，" : "";
+    const point = anchorPointForEvent(event, elements.addGatchaUidButton);
+    openConfirm({
+      type: "gatcha-uid-add",
+      uid: preview?.uid || uid,
+      name: ownerName,
+      message: `确认拉取 UP 主：${ownerName} 的${modeLabel}稿件？`,
+      ...point,
+    });
+    setGatchaUidMessage(`${followedPrefix}检测到 UP 主：${ownerName}`);
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaUidSaving = false;
+    renderGatchaUidFace();
+  }
+});
+
+elements.refreshGatchaCacheButton?.addEventListener("click", async () => {
+  state.gatchaRefreshSaving = true;
+  renderGatchaUidFace();
+  setGatchaUidMessage("正在后台更新抽卡缓存...");
+  try {
+    const result = await refreshGatchaCache();
+    setGatchaUidMessage(result?.started === false ? "抽卡缓存已经在更新中。" : "已开始更新抽卡缓存。");
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaRefreshSaving = false;
+    renderGatchaUidFace();
   }
 });
 

--- a/static/app.js
+++ b/static/app.js
@@ -100,6 +100,10 @@ const state = {
   retryActivityById: {},
   gatchaCandidate: null,
   searchCookieVisible: false,
+  followBrowseData: null,
+  followBrowseSelectedUid: "",
+  followBrowseLoading: false,
+  followBrowseRenderSignature: "",
   gatchaUidVisible: false,
   gatchaUidSaving: false,
   gatchaRefreshSaving: false,
@@ -230,10 +234,17 @@ const elements = {
   searchButton: document.getElementById("search-button"),
   searchMessage: document.getElementById("search-message"),
   searchResults: document.getElementById("search-results"),
-  cookieSessdata: document.getElementById("cookie-sessdata"),
-  cookieJct: document.getElementById("cookie-jct"),
-  saveCookieButton: document.getElementById("save-cookie-button"),
-  cookieMessage: document.getElementById("cookie-message"),
+  followUpListView: document.getElementById("follow-up-list-view"),
+  followUpGrid: document.getElementById("follow-up-grid"),
+  followUpItemsView: document.getElementById("follow-up-items-view"),
+  followBrowseBack: document.getElementById("follow-browse-back"),
+  followBrowseTitle: document.getElementById("follow-browse-title"),
+  followBrowseCount: document.getElementById("follow-browse-count"),
+  followSearchForm: document.getElementById("follow-search-form"),
+  followSearchQuery: document.getElementById("follow-search-query"),
+  followSearchButton: document.getElementById("follow-search-button"),
+  followSongResults: document.getElementById("follow-song-results"),
+  followBrowseMessage: document.getElementById("follow-browse-message"),
   gatchaUidForm: document.getElementById("gatcha-uid-form"),
   gatchaUidInput: document.getElementById("gatcha-uid-input"),
   addGatchaUidButton: document.getElementById("add-gatcha-uid-button"),
@@ -749,6 +760,28 @@ async function searchGatchaCache(query) {
   return Array.isArray(payload.data?.items) ? payload.data.items : [];
 }
 
+async function fetchGatchaBrowse(uid = "", query = "") {
+  const params = new URLSearchParams();
+  const normalizedUid = String(uid || "").trim();
+  const normalizedQuery = String(query || "").trim();
+  if (normalizedUid) {
+    params.set("uid", normalizedUid);
+  }
+  if (normalizedQuery) {
+    params.set("q", normalizedQuery);
+  }
+  const queryString = params.toString();
+  const response = await fetch(`/api/gatcha/browse${queryString ? `?${queryString}` : ""}`, {
+    cache: "no-store",
+    headers: clientHeaders(),
+  });
+  const payload = await response.json();
+  if (!response.ok || !payload.ok) {
+    throw new Error(payload.error || "Browse failed");
+  }
+  return payload.data || { owners: [], items: [] };
+}
+
 async function previewGatchaUid(uid) {
   return apiPost("/api/gatcha/uids/preview", { uid: String(uid || "").trim() });
 }
@@ -795,15 +828,18 @@ function hideSearchResults() {
   elements.searchResults.classList.add("hidden");
 }
 
-function renderSearchResults(items) {
-  elements.searchResults.innerHTML = "";
-  elements.searchResults.classList.remove("hidden");
+function renderSearchResultItems(container, items, emptyText = "No cached matches found.") {
+  if (!container) {
+    return;
+  }
+  container.innerHTML = "";
+  container.classList.remove("hidden");
 
   if (!items.length) {
     const empty = document.createElement("div");
     empty.className = "search-empty";
-    empty.textContent = "No cached matches found.";
-    elements.searchResults.appendChild(empty);
+    empty.textContent = emptyText;
+    container.appendChild(empty);
     return;
   }
 
@@ -830,8 +866,137 @@ function renderSearchResults(items) {
 
     meta.append(title, url);
     row.append(meta, button);
-    elements.searchResults.appendChild(row);
+    container.appendChild(row);
   });
+}
+
+function renderSearchResults(items) {
+  renderSearchResultItems(elements.searchResults, items);
+}
+
+function selectedFollowOwner() {
+  const owners = Array.isArray(state.followBrowseData?.owners) ? state.followBrowseData.owners : [];
+  return owners.find((owner) => String(owner.uid || "") === state.followBrowseSelectedUid) || null;
+}
+
+function ownerNameFromStateByUid(uid) {
+  const normalizedUid = String(uid || "").trim();
+  if (!normalizedUid || !state.data) {
+    return "";
+  }
+  const entries = [
+    state.data.current_item,
+    ...(Array.isArray(state.data.playlist) ? state.data.playlist : []),
+    ...(Array.isArray(state.data.history) ? state.data.history : []),
+  ];
+  for (const entry of entries) {
+    if (String(entry?.owner_mid || "").trim() !== normalizedUid) {
+      continue;
+    }
+    const ownerName = String(entry?.owner_name || "").trim();
+    if (ownerName) {
+      return ownerName;
+    }
+  }
+  return "";
+}
+
+function followOwnerDisplayName(owner) {
+  const uid = String(owner?.uid || "").trim();
+  const ownerName = String(owner?.name || "").trim();
+  const stateOwnerName = ownerNameFromStateByUid(uid);
+  if (ownerName && ownerName !== `UID ${uid}`) {
+    return ownerName;
+  }
+  return stateOwnerName || ownerName || `UID ${uid}`;
+}
+
+function renderFollowBrowse() {
+  if (!elements.followUpGrid || !elements.followSongResults) {
+    return;
+  }
+  const owners = Array.isArray(state.followBrowseData?.owners) ? state.followBrowseData.owners : [];
+  const items = Array.isArray(state.followBrowseData?.items) ? state.followBrowseData.items : [];
+  const signature = JSON.stringify({
+    loading: state.followBrowseLoading,
+    selected: state.followBrowseSelectedUid,
+    owners,
+    items,
+  });
+  if (signature === state.followBrowseRenderSignature) {
+    return;
+  }
+  state.followBrowseRenderSignature = signature;
+
+  const hasSelectedUid = Boolean(state.followBrowseSelectedUid);
+  elements.followUpListView?.classList.toggle("hidden", hasSelectedUid);
+  elements.followUpItemsView?.classList.toggle("hidden", !hasSelectedUid);
+
+  if (!hasSelectedUid) {
+    elements.followUpGrid.innerHTML = "";
+    if (!owners.length) {
+      const empty = document.createElement("div");
+      empty.className = "search-empty";
+      empty.textContent = state.followBrowseLoading ? "正在读取关注缓存..." : "还没有可浏览的关注 UID。";
+      elements.followUpGrid.appendChild(empty);
+    } else {
+      owners.forEach((owner) => {
+        const displayName = followOwnerDisplayName(owner);
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "follow-up-button";
+        button.dataset.uid = String(owner.uid || "");
+        button.title = displayName;
+
+        const name = document.createElement("span");
+        name.className = "follow-up-name";
+        name.textContent = displayName;
+
+        const count = document.createElement("span");
+        count.className = "follow-up-count";
+        count.textContent = `${Number(owner.count || 0)} 首`;
+
+        button.append(name, count);
+        elements.followUpGrid.appendChild(button);
+      });
+    }
+    setFollowBrowseMessage(state.followBrowseLoading ? "正在读取关注列表..." : "");
+    return;
+  }
+
+  const owner = selectedFollowOwner();
+  if (elements.followBrowseTitle) {
+    elements.followBrowseTitle.textContent = followOwnerDisplayName(owner) || `UID ${state.followBrowseSelectedUid}`;
+  }
+  if (elements.followBrowseCount) {
+    const totalCount = Number(owner?.count || items.length || 0);
+    elements.followBrowseCount.textContent = `${items.length}/${totalCount} 首`;
+  }
+  renderSearchResultItems(
+    elements.followSongResults,
+    items,
+    state.followBrowseLoading ? "正在读取稿件..." : "这个 UP 的缓存稿件里没有匹配结果。",
+  );
+  setFollowBrowseMessage(state.followBrowseLoading ? "正在读取稿件..." : "");
+}
+
+async function loadFollowBrowse({ uid = state.followBrowseSelectedUid, query = "", keepQuery = false } = {}) {
+  state.followBrowseLoading = true;
+  state.followBrowseSelectedUid = String(uid || "").trim();
+  renderFollowBrowse();
+  try {
+    const nextData = await fetchGatchaBrowse(state.followBrowseSelectedUid, query);
+    state.followBrowseData = nextData;
+    state.followBrowseSelectedUid = String(nextData.selected_uid || state.followBrowseSelectedUid || "");
+    if (!keepQuery && elements.followSearchQuery) {
+      elements.followSearchQuery.value = String(nextData.query || "");
+    }
+  } catch (error) {
+    setFollowBrowseMessage(error.message, true);
+  } finally {
+    state.followBrowseLoading = false;
+    renderFollowBrowse();
+  }
 }
 
 async function handleGatchaDraw() {
@@ -863,12 +1028,12 @@ function setGatchaMessage(message, isError = false) {
   elements.gatchaMessage.classList.toggle("is-error", Boolean(isError));
 }
 
-function setCookieMessage(message, isError = false) {
-  if (!elements.cookieMessage) {
+function setFollowBrowseMessage(message, isError = false) {
+  if (!elements.followBrowseMessage) {
     return;
   }
-  elements.cookieMessage.textContent = message || "";
-  elements.cookieMessage.classList.toggle("is-error", Boolean(isError));
+  elements.followBrowseMessage.textContent = message || "";
+  elements.followBrowseMessage.classList.toggle("is-error", Boolean(isError));
 }
 
 function setGatchaUidMessage(message, isError = false) {
@@ -881,7 +1046,11 @@ function setGatchaUidMessage(message, isError = false) {
 
 function renderSearchCookieFace() {
   const showCookie = Boolean(state.searchCookieVisible);
-  const signature = showCookie ? "cookie" : "search";
+  const signature = JSON.stringify({
+    face: showCookie ? "browse" : "search",
+    selected: state.followBrowseSelectedUid,
+    loading: state.followBrowseLoading,
+  });
   if (signature === state.searchCookieFaceRenderSignature) {
     return;
   }
@@ -889,11 +1058,14 @@ function renderSearchCookieFace() {
 
   setClassToggle(elements.searchPanel, "is-cookie-view", showCookie);
   setClassToggle(elements.searchStage, "is-cookie-view", showCookie);
-  setTextContent(elements.searchTag, showCookie ? "Cookie Config" : "Local Search");
-  setTextContent(elements.searchTitle, showCookie ? "Cookie" : "搜索");
-  setTextContent(elements.searchCookieToggle, showCookie ? "返回搜索" : "输入 Cookie");
+  setTextContent(elements.searchTag, showCookie ? "Follow Browse" : "Local Search");
+  setTextContent(elements.searchTitle, showCookie ? "关注列表" : "搜索");
+  setTextContent(elements.searchCookieToggle, showCookie ? "返回搜索" : "关注浏览");
   if (elements.searchCookieToggle?.getAttribute("aria-pressed") !== String(showCookie)) {
     elements.searchCookieToggle.setAttribute("aria-pressed", String(showCookie));
+  }
+  if (showCookie) {
+    renderFollowBrowse();
   }
 }
 
@@ -2681,9 +2853,11 @@ function renderPlayer(currentItem, playbackMode) {
   state.localPlayerSyncTimer = window.setInterval(() => {
     if (isSplitPlayerSeekSettling(video, audio)) {
       settleSplitPlayerSeek(video, audio);
+      reportCurrentVideoStatus();
       return;
     }
     syncSplitPlayer(video, audio, currentAvOffsetSeconds(), false);
+    reportCurrentVideoStatus();
   }, localPlayerSyncIntervalMs);
 
   window.setTimeout(() => {
@@ -2732,12 +2906,18 @@ function applyRemotePlayerControl(command, currentItem, playbackMode) {
           state.localShouldBePlaying = false;
           video.pause();
         }
-      } else if (action === "seek-relative") {
+      } else if (action === "seek-relative" || action === "seek-absolute") {
         const deltaSeconds = Number(command?.delta_seconds || 0);
-        if (Number.isFinite(deltaSeconds) && deltaSeconds !== 0) {
+        const targetSeconds = Number(command?.target_seconds ?? 0);
+        if (
+          (action === "seek-relative" && Number.isFinite(deltaSeconds) && deltaSeconds !== 0)
+          || (action === "seek-absolute" && Number.isFinite(targetSeconds))
+        ) {
           const resumeAfterSeek = !video.paused || state.localShouldBePlaying;
           const duration = Number.isFinite(video.duration) ? video.duration : Number.POSITIVE_INFINITY;
-          const nextTime = Math.max(0, Number(video.currentTime || 0) + deltaSeconds);
+          const nextTime = action === "seek-absolute"
+            ? Math.max(0, targetSeconds)
+            : Math.max(0, Number(video.currentTime || 0) + deltaSeconds);
           const clampedNextTime = Number.isFinite(duration)
             ? Math.min(nextTime, duration)
             : nextTime;
@@ -2782,10 +2962,12 @@ function reportPlayerStatus(itemId, video) {
   }
 
   const currentTime = Number(video.currentTime || 0);
+  const duration = Number.isFinite(video.duration) ? Number(video.duration) : 0;
   const signature = [
     normalizedItemId,
     video.paused ? "paused" : "playing",
     Math.round(currentTime),
+    Math.round(duration),
   ].join("|");
   if (signature === state.lastReportedPlayerStatusSignature) {
     return;
@@ -2796,6 +2978,7 @@ function reportPlayerStatus(itemId, video) {
     item_id: normalizedItemId,
     is_paused: video.paused,
     current_time: currentTime,
+    duration,
   }).catch(() => {});
 }
 
@@ -4739,6 +4922,67 @@ elements.gatchaRetryButton.addEventListener("click", handleGatchaDraw);
 elements.searchCookieToggle?.addEventListener("click", () => {
   state.searchCookieVisible = !state.searchCookieVisible;
   renderSearchCookieFace();
+  if (state.searchCookieVisible && !state.followBrowseLoading) {
+    state.followBrowseSelectedUid = "";
+    if (elements.followSearchQuery) {
+      elements.followSearchQuery.value = "";
+    }
+    loadFollowBrowse({ uid: "", query: "" });
+  }
+});
+
+elements.followUpGrid?.addEventListener("click", async (event) => {
+  const button = event.target.closest("button[data-uid]");
+  if (!button) {
+    return;
+  }
+  const uid = String(button.dataset.uid || "").trim();
+  if (!uid) {
+    return;
+  }
+  state.followBrowseSelectedUid = uid;
+  if (elements.followSearchQuery) {
+    elements.followSearchQuery.value = "";
+  }
+  await loadFollowBrowse({ uid, query: "" });
+});
+
+elements.followBrowseBack?.addEventListener("click", () => {
+  state.followBrowseSelectedUid = "";
+  if (elements.followSearchQuery) {
+    elements.followSearchQuery.value = "";
+  }
+  renderFollowBrowse();
+  renderSearchCookieFace();
+});
+
+elements.followSearchForm?.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const query = String(elements.followSearchQuery?.value || "").trim();
+  await loadFollowBrowse({
+    uid: state.followBrowseSelectedUid,
+    query,
+    keepQuery: true,
+  });
+});
+
+elements.followSongResults?.addEventListener("click", async (event) => {
+  const button = event.target.closest("button[data-url]");
+  if (!button) {
+    return;
+  }
+
+  const url = String(button.dataset.url || "").trim();
+  if (!url) {
+    return;
+  }
+
+  button.disabled = true;
+  try {
+    await handleAddByUrl(url, "tail", anchorPointForEvent(event, button));
+  } finally {
+    button.disabled = false;
+  }
 });
 
 elements.gatchaUidToggle?.addEventListener("click", () => {
@@ -4846,23 +5090,6 @@ elements.refreshGatchaCacheButton?.addEventListener("click", async () => {
   }
 });
 
-elements.saveCookieButton.addEventListener("click", async () => {
-  const sessdata = elements.cookieSessdata.value.trim();
-  const jct = elements.cookieJct.value.trim();
-
-  setCookieMessage("正在更新 Cookie 配置...");
-  try {
-    await apiPost("/api/config/cookie", {
-      sessdata: sessdata,
-      bili_jct: jct
-    });
-    setCookieMessage("Cookie 已更新，正在拉取稿件信息（第一次拉取稿件数量会影响拉取时间）");
-    elements.cookieSessdata.value = "";
-    elements.cookieJct.value = "";
-  } catch (error) {
-    setCookieMessage(error.message, true);
-  }
-});
 
 async function startPolling() {
   hydrateLocalPreferences();

--- a/static/index.html
+++ b/static/index.html
@@ -373,22 +373,49 @@
               </div>
             </section>
 
-            <section class="list-card sub-card search-sub-card">
+            <section class="list-card sub-card search-sub-card" id="search-panel">
               <div class="search-card">
                 <div class="search-sub-card-head">
                   <div>
-                    <p class="section-tag">Local Search</p>
-                    <h2>搜索</h2>
+                    <p class="section-tag" id="search-tag">Local Search</p>
+                    <h2 id="search-title">搜索</h2>
+                  </div>
+                  <button type="button" id="search-cookie-toggle" class="toolbar-button ghost search-cookie-toggle">
+                    输入 Cookie
+                  </button>
+                </div>
+
+                <div id="search-stage" class="search-stage">
+                  <div class="search-stage-inner">
+                    <div id="search-main-view" class="search-face search-face-front">
+                      <form id="search-form" class="search-inputs">
+                        <div class="input-group">
+                          <input type="text" id="search-query" placeholder="搜索本地歌曲目录 (需要登录或者 cookie)" autocomplete="off">
+                        </div>
+                        <button type="submit" id="search-button" class="next-button">搜索</button>
+                      </form>
+                      <p class="search-message" id="search-message" role="status"></p>
+                      <div id="search-results" class="search-results hidden"></div>
+                    </div>
+
+                    <div id="search-cookie-view" class="search-face search-face-back search-cookie-view">
+                      <div class="cookie-config-bar">
+                        <div class="cookie-inputs">
+                          <div class="input-group">
+                            <label>SESSDATA</label>
+                            <input type="text" id="cookie-sessdata" placeholder="从浏览器获取的 SESSDATA">
+                          </div>
+                          <div class="input-group">
+                            <label>bili_jct</label>
+                            <input type="text" id="cookie-jct" placeholder="从浏览器获取的 bili_jct">
+                          </div>
+                          <button type="button" id="save-cookie-button" class="next-button">更新配置</button>
+                        </div>
+                        <p class="gatcha-message" id="cookie-message" role="status"></p>
+                      </div>
+                    </div>
                   </div>
                 </div>
-                <form id="search-form" class="search-inputs">
-                  <div class="input-group">
-                    <input type="text" id="search-query" placeholder="搜索本地歌曲目录 (需要登录或者 cookie)" autocomplete="off">
-                  </div>
-                  <button type="submit" id="search-button" class="next-button">搜索</button>
-                </form>
-                <p class="search-message" id="search-message" role="status"></p>
-                <div id="search-results" class="search-results hidden"></div>
               </div>
             </section>
             
@@ -398,8 +425,8 @@
                  <p class="section-tag" id="gatcha-tag">gatcha Draw</p>
                  <h2 id="gatcha-title">试试运气</h2>
                 </div>
-                <button type="button" id="gatcha-cookie-toggle" class="toolbar-button ghost gatcha-cookie-toggle">
-                  输入 Cookie
+                <button type="button" id="gatcha-uid-toggle" class="toolbar-button ghost gatcha-uid-toggle">
+                  添加 UID
                 </button>
               </div>
       
@@ -423,20 +450,19 @@
                     </div>
                   </div>
 
-                  <div id="gatcha-cookie-view" class="gatcha-face gatcha-face-back gatcha-cookie-view">
-                    <div class="cookie-config-bar">
-                      <div class="cookie-inputs">
+                  <div id="gatcha-uid-view" class="gatcha-face gatcha-face-back gatcha-uid-view">
+                    <div class="gatcha-uid-bar">
+                      <form id="gatcha-uid-form" class="gatcha-uid-form">
                         <div class="input-group">
-                          <label>SESSDATA</label>
-                          <input type="text" id="cookie-sessdata" placeholder="从浏览器获取的 SESSDATA">
+                          <label>UID</label>
+                          <input type="text" id="gatcha-uid-input" placeholder="UID 或 UP 主空间链接">
                         </div>
-                        <div class="input-group">
-                          <label>bili_jct</label>
-                          <input type="text" id="cookie-jct" placeholder="从浏览器获取的 bili_jct">
-                        </div>
-                        <button type="button" id="save-cookie-button" class="next-button">更新配置</button>
-                      </div>
-                      <p class="gatcha-message" id="cookie-message" role="status"></p>
+                        <button type="submit" id="add-gatcha-uid-button" class="next-button">添加</button>
+                      </form>
+                      <button type="button" id="refresh-gatcha-cache-button" class="toolbar-button gatcha-refresh-button">
+                        手动更新
+                      </button>
+                      <p class="gatcha-message" id="gatcha-uid-message" role="status"></p>
                     </div>
                   </div>
                 </div>

--- a/static/index.html
+++ b/static/index.html
@@ -381,7 +381,7 @@
                     <h2 id="search-title">搜索</h2>
                   </div>
                   <button type="button" id="search-cookie-toggle" class="toolbar-button ghost search-cookie-toggle">
-                    输入 Cookie
+                    关注浏览
                   </button>
                 </div>
 
@@ -399,19 +399,30 @@
                     </div>
 
                     <div id="search-cookie-view" class="search-face search-face-back search-cookie-view">
-                      <div class="cookie-config-bar">
-                        <div class="cookie-inputs">
-                          <div class="input-group">
-                            <label>SESSDATA</label>
-                            <input type="text" id="cookie-sessdata" placeholder="从浏览器获取的 SESSDATA">
-                          </div>
-                          <div class="input-group">
-                            <label>bili_jct</label>
-                            <input type="text" id="cookie-jct" placeholder="从浏览器获取的 bili_jct">
-                          </div>
-                          <button type="button" id="save-cookie-button" class="next-button">更新配置</button>
+                      <div class="follow-browser" id="follow-browser">
+                        <div id="follow-up-list-view" class="follow-up-list-view">
+                          <div id="follow-up-grid" class="follow-up-grid" role="list"></div>
                         </div>
-                        <p class="gatcha-message" id="cookie-message" role="status"></p>
+                        <div id="follow-up-items-view" class="follow-up-items-view hidden">
+                          <div class="follow-browser-head">
+                            <button type="button" id="follow-browse-back" class="toolbar-button ghost">返回</button>
+                            <div class="follow-browser-title-block">
+                              <h3 id="follow-browse-title">UP 主稿件</h3>
+                              <p id="follow-browse-count" class="follow-browser-count">0 首</p>
+                            </div>
+                          </div>
+                          <form id="follow-search-form" class="follow-search-form">
+                            <input
+                              type="text"
+                              id="follow-search-query"
+                              placeholder="在这个 UP 的缓存稿件里搜索"
+                              autocomplete="off"
+                            >
+                            <button type="submit" id="follow-search-button" class="next-button">搜索</button>
+                          </form>
+                          <div id="follow-song-results" class="search-results"></div>
+                        </div>
+                        <p class="gatcha-message" id="follow-browse-message" role="status"></p>
                       </div>
                     </div>
                   </div>

--- a/static/remote.css
+++ b/static/remote.css
@@ -1060,6 +1060,12 @@ select:disabled {
   text-align: center;
 }
 
+.gatcha-uid-toggle {
+  min-height: 40px;
+  padding-inline: 12px;
+  white-space: nowrap;
+}
+
 .gatcha-icon {
   font-size: 32px;
 }
@@ -1083,6 +1089,23 @@ select:disabled {
 #gatcha-candidate-title {
   font-size: 16px;
   line-height: 1.4;
+}
+
+.gatcha-uid-view {
+  text-align: left;
+}
+
+.gatcha-uid-form {
+  display: grid;
+  gap: 10px;
+}
+
+.gatcha-uid-form .primary-button {
+  min-height: 48px;
+}
+
+.gatcha-uid-view .gatcha-message {
+  text-align: center;
 }
 
 .queue-item,

--- a/static/remote.css
+++ b/static/remote.css
@@ -698,13 +698,15 @@ h1 {
   right: 0;
   bottom: 0;
   max-height: min(82vh, 760px);
+  display: flex;
+  flex-direction: column;
   padding: 14px 16px calc(18px + env(safe-area-inset-bottom));
   border-radius: 24px 24px 0 0;
   background: rgba(255, 252, 247, 0.98);
   box-shadow: 0 -18px 40px rgba(79, 56, 39, 0.18);
   transform: translateY(100%);
   transition: transform 0.28s ease;
-  overflow: auto;
+  overflow: hidden;
 }
 
 .binding-sheet.is-open .binding-sheet-backdrop {
@@ -735,12 +737,15 @@ h1 {
 }
 
 .binding-sheet-section {
+  flex: 0 1 auto;
+  min-height: 0;
   margin-top: 18px;
   display: grid;
   gap: 10px;
 }
 
 .binding-accordion {
+  min-height: 0;
   gap: 12px;
 }
 
@@ -770,7 +775,7 @@ h1 {
 }
 
 .binding-accordion-panel {
-  max-height: 240px;
+  max-height: clamp(140px, 24vh, 240px);
   overflow-y: auto;
   overscroll-behavior: contain;
   padding-right: 4px;
@@ -808,10 +813,15 @@ h1 {
 }
 
 .binding-sheet-actions {
+  flex: 0 0 auto;
   margin-top: 18px;
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
+  padding-top: 14px;
+  padding-bottom: calc(2px + env(safe-area-inset-bottom));
+  border-top: 1px solid rgba(67, 53, 41, 0.08);
+  background: #fffcf7;
 }
 
 .request-form {
@@ -1064,6 +1074,94 @@ select:disabled {
   min-height: 40px;
   padding-inline: 12px;
   white-space: nowrap;
+}
+
+.follow-browse-toggle {
+  min-height: 40px;
+  padding-inline: 12px;
+  white-space: nowrap;
+}
+
+.follow-browser {
+  display: grid;
+  gap: 12px;
+}
+
+.follow-browser.hidden {
+  display: none;
+}
+
+.follow-up-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
+  gap: 10px;
+}
+
+.follow-up-button {
+  display: grid;
+  min-height: 72px;
+  gap: 6px;
+  align-content: center;
+  padding: 10px;
+  border: 1px solid rgba(67, 53, 41, 0.1);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.76);
+  color: var(--text);
+  text-align: left;
+  box-shadow: 0 10px 22px rgba(67, 53, 41, 0.06);
+}
+
+.follow-up-button:active {
+  transform: translateY(1px);
+}
+
+.follow-up-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.follow-up-count {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.follow-browser-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.follow-browser-title {
+  min-width: 0;
+}
+
+.follow-browser-title h3 {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 16px;
+}
+
+#follow-browse-count {
+  display: block;
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.follow-search-form {
+  display: grid;
+  gap: 10px;
+}
+
+.follow-search-form .primary-button {
+  min-height: 44px;
 }
 
 .gatcha-icon {

--- a/static/remote.html
+++ b/static/remote.html
@@ -189,6 +189,9 @@
       <section class="panel gatcha-panel">
         <div class="panel-head">
           <p class="panel-tag">Gatcha Draw</p>
+          <button type="button" id="gatcha-uid-toggle" class="secondary-button gatcha-uid-toggle" aria-pressed="false">
+            添加 UID
+          </button>
         </div>
         <div id="gatcha-init-view" class="gatcha-content">
           <div class="gatcha-icon">🎲</div>
@@ -203,6 +206,19 @@
             <button type="button" id="gatcha-confirm-button" class="primary-button">确定点歌</button>
             <button type="button" id="gatcha-retry-button" class="secondary-button">重新再来</button>
           </div>
+        </div>
+        <div id="gatcha-uid-view" class="gatcha-content gatcha-uid-view hidden">
+          <form id="gatcha-uid-form" class="request-form gatcha-uid-form">
+            <input
+              type="text"
+              id="gatcha-uid-input"
+              placeholder="UID 或 UP 主空间链接"
+              aria-label="UID 或 UP 主空间链接"
+              autocomplete="off"
+            />
+            <button type="submit" id="add-gatcha-uid-button" class="primary-button">添加</button>
+          </form>
+          <p class="gatcha-message" id="gatcha-uid-message" role="status"></p>
         </div>
       </section>
 

--- a/static/remote.html
+++ b/static/remote.html
@@ -171,6 +171,9 @@
       <section class="panel search-panel">
         <div class="panel-head">
           <p class="panel-tag">Local Search</p>
+          <button type="button" id="follow-browse-toggle" class="secondary-button follow-browse-toggle" aria-pressed="false">
+            关注浏览
+          </button>
         </div>
         <form id="search-form" class="request-form">
           <input
@@ -184,6 +187,31 @@
           </div>
         </form>
         <div id="search-results" class="search-results hidden"></div>
+        <div id="follow-browse-view" class="follow-browser hidden">
+          <div id="follow-up-list-view">
+            <div id="follow-up-grid" class="follow-up-grid"></div>
+          </div>
+          <div id="follow-up-items-view" class="hidden">
+            <div class="follow-browser-head">
+              <button type="button" id="follow-browse-back" class="secondary-button">返回</button>
+              <div class="follow-browser-title">
+                <h3 id="follow-browse-title">关注列表</h3>
+                <span id="follow-browse-count"></span>
+              </div>
+            </div>
+            <form id="follow-search-form" class="request-form follow-search-form">
+              <input
+                type="text"
+                id="follow-search-query"
+                placeholder="搜索该 UP 的缓存稿件"
+                autocomplete="off"
+              />
+              <button type="submit" id="follow-search-button" class="primary-button">搜索</button>
+            </form>
+            <div id="follow-song-results" class="search-results"></div>
+          </div>
+          <p class="gatcha-message" id="follow-browse-message" role="status"></p>
+        </div>
       </section>
 
       <section class="panel gatcha-panel">

--- a/static/remote.js
+++ b/static/remote.js
@@ -1,5 +1,4 @@
 const audioVariantSwitchDebounceMs = 350;
-const gatchaCooldownMs = 15000;
 const playerSettingsEchoSuppressMs = 1800;
 const remoteVolumeCommitDebounceMs = 160;
 const viewportScaleResetDelaysMs = [0, 120, 360];
@@ -39,8 +38,8 @@ const state = {
   eventStreamReconnectTimer: null,
   eventStreamRetryMs: eventStreamInitialRetryMs,
   gatchaCandidate: null,
-  gatchaCooldownUntil: 0,
-  gatchaCooldownTimer: null,
+  gatchaUidVisible: false,
+  gatchaUidSaving: false,
   layoutMode: "full",
   remoteAccessRenderSignature: "",
   remoteQrPopoverOpen: false,
@@ -96,6 +95,7 @@ const elements = {
   addNextButton: document.getElementById("add-next-button"),
   resortPlaylistButton: document.getElementById("resort-playlist-button"),
   refreshButton: document.getElementById("refresh-button"),
+  gatchaUidToggle: document.getElementById("gatcha-uid-toggle"),
   gatchaButton: document.getElementById("gatcha-button"),
   gatchaConfirmButton: document.getElementById("gatcha-confirm-button"),
   gatchaRetryButton: document.getElementById("gatcha-retry-button"),
@@ -103,6 +103,11 @@ const elements = {
   gatchaInitView: document.getElementById("gatcha-init-view"),
   gatchaResultView: document.getElementById("gatcha-result-view"),
   gatchaCandidateTitle: document.getElementById("gatcha-candidate-title"),
+  gatchaUidView: document.getElementById("gatcha-uid-view"),
+  gatchaUidForm: document.getElementById("gatcha-uid-form"),
+  gatchaUidInput: document.getElementById("gatcha-uid-input"),
+  addGatchaUidButton: document.getElementById("add-gatcha-uid-button"),
+  gatchaUidMessage: document.getElementById("gatcha-uid-message"),
   listTag: document.getElementById("list-tag"),
   listTitle: document.getElementById("list-title"),
   listCount: document.getElementById("list-count"),
@@ -521,6 +526,24 @@ async function searchGatchaCache(query) {
   return Array.isArray(payload.data?.items) ? payload.data.items : [];
 }
 
+async function previewGatchaUid(uid) {
+  return apiPost("/api/gatcha/uids/preview", { uid: String(uid || "").trim() });
+}
+
+async function addGatchaUid(uid) {
+  return apiPost("/api/gatcha/uids/add", { uid: String(uid || "").trim() });
+}
+
+function gatchaUidResultMessage(result, fallbackUid = "") {
+  const cache = result?.cache || {};
+  const addedCount = Number(cache.added_count || 0);
+  const totalCount = Number(cache.total_count || 0);
+  const modeLabel = cache.mode === "incremental" ? "最新" : "所有";
+  const ownerLabel = result?.name ? `UP 主 ${result.name}` : `UID ${result?.uid || fallbackUid}`;
+  const listAction = result?.added ? "已添加" : "已在关注列表中";
+  return `${ownerLabel} ${listAction}，已拉取${modeLabel}稿件，新增 ${addedCount} 条，缓存共 ${totalCount} 条。`;
+}
+
 function hideSearchResults() {
   elements.searchResults.innerHTML = "";
   elements.searchResults.classList.add("hidden");
@@ -565,10 +588,8 @@ function renderSearchResults(items) {
 }
 
 async function handleGatchaDraw() {
-  if (gatchaCooldownRemainingSeconds() > 0) {
-    syncGatchaCooldownButtons();
-    return;
-  }
+  state.gatchaUidVisible = false;
+  renderGatchaUidView();
   setGatchaMessage("正在随机抽取一首歌曲...");
   try {
     const response = await fetch("/api/gatcha/candidate", { headers: clientHeaders() });
@@ -579,9 +600,7 @@ async function handleGatchaDraw() {
 
     state.gatchaCandidate = payload.data;
     elements.gatchaCandidateTitle.textContent = state.gatchaCandidate.title;
-    startGatchaCooldown();
-    elements.gatchaInitView.classList.add("hidden");
-    elements.gatchaResultView.classList.remove("hidden");
+    renderGatchaUidView();
     setGatchaMessage("");
   } catch (error) {
     setGatchaMessage(error.message, true);
@@ -596,36 +615,82 @@ function setGatchaMessage(message, isError = false) {
   elements.gatchaMessage.classList.toggle("is-error", Boolean(isError));
 }
 
-function gatchaCooldownRemainingSeconds() {
-  return Math.max(0, Math.ceil((state.gatchaCooldownUntil - Date.now()) / 1000));
-}
-
-function startGatchaCooldown() {
-  state.gatchaCooldownUntil = Date.now() + gatchaCooldownMs;
-  syncGatchaCooldownButtons();
-  if (state.gatchaCooldownTimer) {
-    clearInterval(state.gatchaCooldownTimer);
+function setGatchaUidMessage(message, isError = false) {
+  if (!elements.gatchaUidMessage) {
+    return;
   }
-  state.gatchaCooldownTimer = setInterval(() => {
-    syncGatchaCooldownButtons();
-    if (gatchaCooldownRemainingSeconds() <= 0) {
-      clearInterval(state.gatchaCooldownTimer);
-      state.gatchaCooldownTimer = null;
-    }
-  }, 250);
+  elements.gatchaUidMessage.textContent = message || "";
+  elements.gatchaUidMessage.classList.toggle("is-error", Boolean(isError));
 }
 
-function syncGatchaCooldownButtons() {
-  const remainingSeconds = gatchaCooldownRemainingSeconds();
-  const coolingDown = remainingSeconds > 0;
-  const cooldownText = `等待 ${remainingSeconds}s`;
+function renderGatchaUidView() {
+  const showUid = Boolean(state.gatchaUidVisible);
+  const hasCandidate = Boolean(state.gatchaCandidate);
+  if (elements.gatchaCandidateTitle && state.gatchaCandidate?.title) {
+    elements.gatchaCandidateTitle.textContent = state.gatchaCandidate.title;
+  }
+  elements.gatchaUidView?.classList.toggle("hidden", !showUid);
+  elements.gatchaInitView?.classList.toggle("hidden", showUid || hasCandidate);
+  elements.gatchaResultView?.classList.toggle("hidden", showUid || !hasCandidate);
+  if (elements.gatchaUidToggle) {
+    elements.gatchaUidToggle.textContent = showUid ? "返回抽卡" : "添加 UID";
+    elements.gatchaUidToggle.setAttribute("aria-pressed", String(showUid));
+  }
   if (elements.gatchaButton) {
-    elements.gatchaButton.disabled = coolingDown;
-    elements.gatchaButton.textContent = coolingDown ? cooldownText : "试试运气";
+    elements.gatchaButton.disabled = false;
+    elements.gatchaButton.textContent = "试试运气";
   }
   if (elements.gatchaRetryButton) {
-    elements.gatchaRetryButton.disabled = coolingDown;
-    elements.gatchaRetryButton.textContent = coolingDown ? cooldownText : "重新再来";
+    elements.gatchaRetryButton.disabled = false;
+    elements.gatchaRetryButton.textContent = "重新再来";
+  }
+  if (elements.gatchaUidInput) {
+    elements.gatchaUidInput.disabled = state.gatchaUidSaving;
+  }
+  if (elements.addGatchaUidButton) {
+    elements.addGatchaUidButton.disabled = state.gatchaUidSaving;
+    elements.addGatchaUidButton.textContent = state.gatchaUidSaving ? "处理中" : "添加";
+  }
+}
+
+async function handleGatchaUidSubmit(event) {
+  event.preventDefault();
+  const uid = String(elements.gatchaUidInput?.value || "").trim();
+  if (!uid) {
+    setGatchaUidMessage("请输入 UID", true);
+    return;
+  }
+  if (state.gatchaUidSaving) {
+    return;
+  }
+
+  state.gatchaUidSaving = true;
+  renderGatchaUidView();
+  setGatchaUidMessage("正在检测 UID...");
+  try {
+    const preview = await previewGatchaUid(uid);
+    const ownerName = preview?.name || `UID ${preview?.uid || uid}`;
+    const modeLabel = preview?.cache_mode_label || (preview?.cache_mode === "incremental" ? "最新" : "所有");
+    const followedPrefix = preview?.already_followed ? "已在关注列表中，" : "";
+    setGatchaUidMessage(`${followedPrefix}检测到 UP 主：${ownerName}`);
+
+    if (!window.confirm(`确认拉取 UP 主：${ownerName} 的${modeLabel}稿件？`)) {
+      setGatchaUidMessage("已取消添加 UID。");
+      return;
+    }
+
+    const normalizedUid = preview?.uid || uid;
+    setGatchaUidMessage(`正在拉取 UP 主：${ownerName} 的稿件...`);
+    const result = await addGatchaUid(normalizedUid);
+    setGatchaUidMessage(gatchaUidResultMessage(result, normalizedUid));
+    if (elements.gatchaUidInput) {
+      elements.gatchaUidInput.value = "";
+    }
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaUidSaving = false;
+    renderGatchaUidView();
   }
 }
 
@@ -647,6 +712,7 @@ function render() {
   renderHistory(Array.isArray(data.history) ? data.history : []);
   syncListView();
   renderLayoutMode();
+  renderGatchaUidView();
 }
 
 function renderRequesterSelect(sessionUsers) {
@@ -1122,8 +1188,7 @@ async function confirmBindingSheet() {
     }
     if (intent.source === "gatcha") {
       state.gatchaCandidate = null;
-      elements.gatchaResultView.classList.add("hidden");
-      elements.gatchaInitView.classList.remove("hidden");
+      renderGatchaUidView();
     }
     setFormMessage(intent.position === "next" ? "已按绑定关系顶歌到下一首" : "已按绑定关系加入点歌列表");
   } catch (error) {
@@ -1526,8 +1591,7 @@ async function addByUrl(url, position = "tail") {
     hideSearchResults();
     elements.searchQuery.value = "";
     state.gatchaCandidate = null;
-    elements.gatchaResultView.classList.add("hidden");
-    elements.gatchaInitView.classList.remove("hidden");
+    renderGatchaUidView();
     setFormMessage("点歌成功。");
   } catch (error) {
     if (error.code === "manual_binding_required") {
@@ -1762,6 +1826,13 @@ elements.remoteVolumeMuteButton?.addEventListener("click", async () => {
 
 elements.gatchaButton.addEventListener("click", handleGatchaDraw);
 elements.gatchaRetryButton.addEventListener("click", handleGatchaDraw);
+
+elements.gatchaUidToggle?.addEventListener("click", () => {
+  state.gatchaUidVisible = !state.gatchaUidVisible;
+  renderGatchaUidView();
+});
+
+elements.gatchaUidForm?.addEventListener("submit", handleGatchaUidSubmit);
 
 elements.gatchaConfirmButton.addEventListener("click", async () => {
   if (!state.gatchaCandidate?.url) {

--- a/static/remote.js
+++ b/static/remote.js
@@ -40,6 +40,11 @@ const state = {
   gatchaCandidate: null,
   gatchaUidVisible: false,
   gatchaUidSaving: false,
+  followBrowseVisible: false,
+  followBrowseData: null,
+  followBrowseSelectedUid: "",
+  followBrowseLoading: false,
+  followBrowseRenderSignature: "",
   layoutMode: "full",
   remoteAccessRenderSignature: "",
   remoteQrPopoverOpen: false,
@@ -92,6 +97,19 @@ const elements = {
   searchQuery: document.getElementById("search-query"),
   searchButton: document.getElementById("search-button"),
   searchResults: document.getElementById("search-results"),
+  followBrowseToggle: document.getElementById("follow-browse-toggle"),
+  followBrowseView: document.getElementById("follow-browse-view"),
+  followUpListView: document.getElementById("follow-up-list-view"),
+  followUpGrid: document.getElementById("follow-up-grid"),
+  followUpItemsView: document.getElementById("follow-up-items-view"),
+  followBrowseBack: document.getElementById("follow-browse-back"),
+  followBrowseTitle: document.getElementById("follow-browse-title"),
+  followBrowseCount: document.getElementById("follow-browse-count"),
+  followSearchForm: document.getElementById("follow-search-form"),
+  followSearchQuery: document.getElementById("follow-search-query"),
+  followSearchButton: document.getElementById("follow-search-button"),
+  followSongResults: document.getElementById("follow-song-results"),
+  followBrowseMessage: document.getElementById("follow-browse-message"),
   addNextButton: document.getElementById("add-next-button"),
   resortPlaylistButton: document.getElementById("resort-playlist-button"),
   refreshButton: document.getElementById("refresh-button"),
@@ -526,6 +544,28 @@ async function searchGatchaCache(query) {
   return Array.isArray(payload.data?.items) ? payload.data.items : [];
 }
 
+async function fetchGatchaBrowse(uid = "", query = "") {
+  const params = new URLSearchParams();
+  const normalizedUid = String(uid || "").trim();
+  const normalizedQuery = String(query || "").trim();
+  if (normalizedUid) {
+    params.set("uid", normalizedUid);
+  }
+  if (normalizedQuery) {
+    params.set("q", normalizedQuery);
+  }
+  const queryString = params.toString();
+  const response = await fetch(`/api/gatcha/browse${queryString ? `?${queryString}` : ""}`, {
+    cache: "no-store",
+    headers: clientHeaders(),
+  });
+  const payload = await response.json();
+  if (!response.ok || !payload.ok) {
+    throw new Error(payload.error || "关注浏览失败");
+  }
+  return payload.data || { owners: [], items: [] };
+}
+
 async function previewGatchaUid(uid) {
   return apiPost("/api/gatcha/uids/preview", { uid: String(uid || "").trim() });
 }
@@ -585,6 +625,190 @@ function renderSearchResults(items) {
     row.append(meta, button);
     elements.searchResults.appendChild(row);
   });
+}
+
+function setFollowBrowseMessage(message, isError = false) {
+  if (!elements.followBrowseMessage) {
+    return;
+  }
+  elements.followBrowseMessage.textContent = message || "";
+  elements.followBrowseMessage.classList.toggle("is-error", Boolean(isError));
+}
+
+function selectedFollowOwner() {
+  const owners = Array.isArray(state.followBrowseData?.owners) ? state.followBrowseData.owners : [];
+  return owners.find((owner) => String(owner.uid || "") === state.followBrowseSelectedUid) || null;
+}
+
+function ownerNameFromStateByUid(uid) {
+  const normalizedUid = String(uid || "").trim();
+  if (!normalizedUid || !state.data) {
+    return "";
+  }
+  const entries = [
+    state.data.current_item,
+    ...(Array.isArray(state.data.playlist) ? state.data.playlist : []),
+    ...(Array.isArray(state.data.history) ? state.data.history : []),
+  ];
+  for (const entry of entries) {
+    if (String(entry?.owner_mid || "").trim() !== normalizedUid) {
+      continue;
+    }
+    const ownerName = String(entry?.owner_name || "").trim();
+    if (ownerName) {
+      return ownerName;
+    }
+  }
+  return "";
+}
+
+function followOwnerDisplayName(owner) {
+  const uid = String(owner?.uid || "").trim();
+  const ownerName = String(owner?.name || "").trim();
+  const stateOwnerName = ownerNameFromStateByUid(uid);
+  if (ownerName && ownerName !== `UID ${uid}`) {
+    return ownerName;
+  }
+  return stateOwnerName || ownerName || `UID ${uid}`;
+}
+
+function renderFollowSongResults(items, emptyText) {
+  if (!elements.followSongResults) {
+    return;
+  }
+  elements.followSongResults.innerHTML = "";
+  elements.followSongResults.classList.remove("hidden");
+
+  if (!items.length) {
+    const empty = document.createElement("div");
+    empty.className = "search-empty";
+    empty.textContent = emptyText;
+    elements.followSongResults.appendChild(empty);
+    return;
+  }
+
+  items.forEach((item) => {
+    const row = document.createElement("div");
+    row.className = "search-result-item";
+
+    const meta = document.createElement("div");
+    const title = document.createElement("div");
+    title.className = "search-result-title";
+    title.textContent = String(item.title || "");
+
+    const url = document.createElement("div");
+    url.className = "search-result-url";
+    url.textContent = String(item.bvid || "");
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "primary-button";
+    button.dataset.url = String(item.url || "");
+    button.textContent = "点歌";
+
+    meta.append(title, url);
+    row.append(meta, button);
+    elements.followSongResults.appendChild(row);
+  });
+}
+
+function renderFollowBrowse() {
+  if (!elements.followBrowseView || !elements.followUpGrid || !elements.followSongResults) {
+    return;
+  }
+
+  elements.searchForm?.classList.toggle("hidden", state.followBrowseVisible);
+  elements.searchResults?.classList.toggle("hidden", state.followBrowseVisible || !elements.searchResults.children.length);
+  elements.followBrowseView.classList.toggle("hidden", !state.followBrowseVisible);
+  if (elements.followBrowseToggle) {
+    elements.followBrowseToggle.textContent = state.followBrowseVisible ? "返回搜索" : "关注浏览";
+    elements.followBrowseToggle.setAttribute("aria-pressed", String(state.followBrowseVisible));
+  }
+  if (!state.followBrowseVisible) {
+    return;
+  }
+
+  const owners = Array.isArray(state.followBrowseData?.owners) ? state.followBrowseData.owners : [];
+  const items = Array.isArray(state.followBrowseData?.items) ? state.followBrowseData.items : [];
+  const signature = JSON.stringify({
+    loading: state.followBrowseLoading,
+    selected: state.followBrowseSelectedUid,
+    owners,
+    items,
+  });
+  if (signature === state.followBrowseRenderSignature) {
+    return;
+  }
+  state.followBrowseRenderSignature = signature;
+
+  const hasSelectedUid = Boolean(state.followBrowseSelectedUid);
+  elements.followUpListView?.classList.toggle("hidden", hasSelectedUid);
+  elements.followUpItemsView?.classList.toggle("hidden", !hasSelectedUid);
+
+  if (!hasSelectedUid) {
+    elements.followUpGrid.innerHTML = "";
+    if (!owners.length) {
+      const empty = document.createElement("div");
+      empty.className = "search-empty";
+      empty.textContent = state.followBrowseLoading ? "正在读取关注列表..." : "还没有可浏览的关注 UID。";
+      elements.followUpGrid.appendChild(empty);
+    } else {
+      owners.forEach((owner) => {
+        const displayName = followOwnerDisplayName(owner);
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "follow-up-button";
+        button.dataset.uid = String(owner.uid || "");
+        button.title = displayName;
+
+        const name = document.createElement("span");
+        name.className = "follow-up-name";
+        name.textContent = displayName;
+
+        const count = document.createElement("span");
+        count.className = "follow-up-count";
+        count.textContent = `${Number(owner.count || 0)} 首`;
+
+        button.append(name, count);
+        elements.followUpGrid.appendChild(button);
+      });
+    }
+    setFollowBrowseMessage(state.followBrowseLoading ? "正在读取关注列表..." : "");
+    return;
+  }
+
+  const owner = selectedFollowOwner();
+  if (elements.followBrowseTitle) {
+    elements.followBrowseTitle.textContent = followOwnerDisplayName(owner) || `UID ${state.followBrowseSelectedUid}`;
+  }
+  if (elements.followBrowseCount) {
+    const totalCount = Number(owner?.count || items.length || 0);
+    elements.followBrowseCount.textContent = `${items.length}/${totalCount} 首`;
+  }
+  renderFollowSongResults(
+    items,
+    state.followBrowseLoading ? "正在读取稿件..." : "这个 UP 的缓存稿件里没有匹配结果。",
+  );
+  setFollowBrowseMessage(state.followBrowseLoading ? "正在读取稿件..." : "");
+}
+
+async function loadFollowBrowse({ uid = state.followBrowseSelectedUid, query = "", keepQuery = false } = {}) {
+  state.followBrowseLoading = true;
+  state.followBrowseSelectedUid = String(uid || "").trim();
+  renderFollowBrowse();
+  try {
+    const nextData = await fetchGatchaBrowse(state.followBrowseSelectedUid, query);
+    state.followBrowseData = nextData;
+    state.followBrowseSelectedUid = String(nextData.selected_uid || state.followBrowseSelectedUid || "");
+    if (!keepQuery && elements.followSearchQuery) {
+      elements.followSearchQuery.value = String(nextData.query || "");
+    }
+  } catch (error) {
+    setFollowBrowseMessage(error.message, true);
+  } finally {
+    state.followBrowseLoading = false;
+    renderFollowBrowse();
+  }
 }
 
 async function handleGatchaDraw() {
@@ -707,6 +931,7 @@ function render() {
   renderRemoteAvSyncControls(data.playback_mode, data.player_settings);
   renderRemoteVolumeControls(data.playback_mode, data.player_settings);
   renderRemoteAccess(data.remote_access);
+  renderFollowBrowse();
   renderListHeader(data.playlist || [], data.history || []);
   renderQueue(Array.isArray(data.playlist) ? data.playlist : []);
   renderHistory(Array.isArray(data.history) ? data.history : []);
@@ -1727,6 +1952,69 @@ elements.searchResults.addEventListener("click", async (event) => {
     return;
   }
   await addByUrl(String(button.dataset.url || ""), "tail");
+});
+
+elements.followBrowseToggle?.addEventListener("click", () => {
+  state.followBrowseVisible = !state.followBrowseVisible;
+  renderFollowBrowse();
+  if (state.followBrowseVisible && !state.followBrowseLoading) {
+    state.followBrowseSelectedUid = "";
+    if (elements.followSearchQuery) {
+      elements.followSearchQuery.value = "";
+    }
+    loadFollowBrowse({ uid: "", query: "" });
+  }
+});
+
+elements.followUpGrid?.addEventListener("click", async (event) => {
+  const button = event.target.closest("button[data-uid]");
+  if (!button) {
+    return;
+  }
+  const uid = String(button.dataset.uid || "").trim();
+  if (!uid) {
+    return;
+  }
+  state.followBrowseSelectedUid = uid;
+  if (elements.followSearchQuery) {
+    elements.followSearchQuery.value = "";
+  }
+  await loadFollowBrowse({ uid, query: "" });
+});
+
+elements.followBrowseBack?.addEventListener("click", () => {
+  state.followBrowseSelectedUid = "";
+  if (elements.followSearchQuery) {
+    elements.followSearchQuery.value = "";
+  }
+  renderFollowBrowse();
+});
+
+elements.followSearchForm?.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const query = String(elements.followSearchQuery?.value || "").trim();
+  await loadFollowBrowse({
+    uid: state.followBrowseSelectedUid,
+    query,
+    keepQuery: true,
+  });
+});
+
+elements.followSongResults?.addEventListener("click", async (event) => {
+  const button = event.target.closest("button[data-url]");
+  if (!button) {
+    return;
+  }
+  const url = String(button.dataset.url || "").trim();
+  if (!url) {
+    return;
+  }
+  button.disabled = true;
+  try {
+    await addByUrl(url, "tail");
+  } finally {
+    button.disabled = false;
+  }
 });
 
 elements.addNextButton.addEventListener("click", async () => {

--- a/static/styles.css
+++ b/static/styles.css
@@ -2619,7 +2619,8 @@ select:disabled {
   min-height: 29px;
 }
 
-.gatcha-cookie-toggle {
+.gatcha-uid-toggle,
+.search-cookie-toggle {
   flex: 0 0 auto;
   white-space: nowrap;
 }
@@ -2642,6 +2643,10 @@ select:disabled {
 }
 
 .gatcha-stage.is-cookie-view .gatcha-stage-inner {
+  transform: rotateY(180deg);
+}
+
+.gatcha-stage.is-uid-view .gatcha-stage-inner {
   transform: rotateY(180deg);
 }
 
@@ -2670,24 +2675,36 @@ select:disabled {
   pointer-events: auto;
 }
 
-.gatcha-cookie-view {
+.gatcha-stage.is-uid-view .gatcha-face-front {
+  pointer-events: none;
+}
+
+.gatcha-stage.is-uid-view .gatcha-face-back {
+  pointer-events: auto;
+}
+
+.gatcha-cookie-view,
+.gatcha-uid-view {
   display: grid;
   align-content: start;
   padding-top: 2px;
 }
 
-.gatcha-cookie-view .cookie-config-bar {
+.gatcha-cookie-view .cookie-config-bar,
+.gatcha-uid-view .gatcha-uid-bar {
   align-content: start;
   height: auto;
 }
 
-.gatcha-cookie-view .cookie-inputs {
+.gatcha-cookie-view .cookie-inputs,
+.gatcha-uid-view .gatcha-uid-form {
   display: grid;
   gap: 12px;
   align-items: stretch;
 }
 
-.gatcha-panel.is-cookie-view .request-head h2 {
+.gatcha-panel.is-cookie-view .request-head h2,
+.gatcha-panel.is-uid-view .request-head h2 {
   color: var(--ink);
 }
 
@@ -2721,7 +2738,9 @@ select:disabled {
   color: var(--muted);
 }
 
-.gatcha-cookie-view .gatcha-message:empty {
+.gatcha-cookie-view .gatcha-message:empty,
+.gatcha-uid-view .gatcha-message:empty,
+.search-cookie-view .gatcha-message:empty {
   display: none;
 }
 
@@ -2796,13 +2815,25 @@ select:disabled {
   padding: 0 18px;
 }
 
-.gatcha-cookie-view .next-button {
+.gatcha-cookie-view .next-button,
+.gatcha-uid-view .next-button,
+.search-cookie-view .next-button {
   width: 100%;
 }
 
 .cookie-config-bar {
   display: grid;
   gap: 14px;
+}
+
+.gatcha-uid-bar {
+  display: grid;
+  gap: 12px;
+}
+
+.gatcha-refresh-button {
+  width: 100%;
+  min-height: 40px;
 }
 
 .sub-card {
@@ -2813,6 +2844,46 @@ select:disabled {
   display: grid;
   gap: 14px;
   align-content: start;
+}
+
+.search-stage {
+  perspective: 1800px;
+}
+
+.search-stage-inner {
+  display: grid;
+  transform-style: preserve-3d;
+  transition: transform 420ms ease;
+}
+
+.search-stage.is-cookie-view .search-stage-inner {
+  transform: rotateY(180deg);
+}
+
+.search-face {
+  grid-area: 1 / 1;
+  display: grid;
+  gap: 14px;
+  align-content: start;
+  min-height: 148px;
+  backface-visibility: hidden;
+  pointer-events: none;
+}
+
+.search-face-front {
+  pointer-events: auto;
+}
+
+.search-face-back {
+  transform: rotateY(180deg);
+}
+
+.search-stage.is-cookie-view .search-face-front {
+  pointer-events: none;
+}
+
+.search-stage.is-cookie-view .search-face-back {
+  pointer-events: auto;
 }
 
 .search-sub-card,
@@ -2848,7 +2919,9 @@ select:disabled {
   font-size: inherit;
 }
 
-.bottom-grid .gatcha-cookie-view .cookie-inputs {
+.bottom-grid .gatcha-cookie-view .cookie-inputs,
+.bottom-grid .search-cookie-view .cookie-inputs,
+.bottom-grid .gatcha-uid-view .gatcha-uid-form {
   display: grid;
   align-items: stretch;
 }
@@ -2941,7 +3014,8 @@ select:disabled {
 
 @media (max-width: 760px) {
   .search-inputs,
-  .cookie-inputs {
+  .cookie-inputs,
+  .gatcha-uid-form {
     flex-direction: column;
     align-items: stretch;
   }
@@ -2955,7 +3029,8 @@ select:disabled {
   }
 
   .search-result-item .next-button,
-  .cookie-sub-card .next-button {
+  .cookie-sub-card .next-button,
+  .gatcha-uid-view .next-button {
     width: 100%;
   }
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -148,7 +148,9 @@ p {
   position: relative;
   width: min(760px, calc(100vw - 32px));
   max-height: calc(100vh - 48px);
-  overflow: auto;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  overflow: hidden;
   padding: 22px;
   border-radius: 24px;
   border: 1px solid rgba(208, 90, 63, 0.18);
@@ -174,10 +176,15 @@ p {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
+  min-height: 0;
   margin-top: 18px;
+  overflow: hidden;
 }
 
 .selection-modal-column {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  min-height: 0;
   padding: 16px;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.74);
@@ -191,7 +198,12 @@ p {
 .selection-option-list {
   margin-top: 12px;
   display: grid;
+  align-content: start;
   gap: 10px;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
 }
 
 .selection-option {
@@ -218,6 +230,10 @@ p {
 .selection-modal-actions {
   margin-top: 18px;
   justify-content: flex-end;
+  padding-top: 14px;
+  padding-bottom: 2px;
+  border-top: 1px solid rgba(87, 63, 43, 0.08);
+  background: #fffaf4;
 }
 
 .confirm-text {
@@ -2780,6 +2796,15 @@ select:disabled {
   .bottom-grid {
     grid-template-columns: 1fr;
   }
+
+  .follow-up-grid {
+    grid-template-columns: repeat(auto-fill, minmax(104px, 1fr));
+    max-height: 340px;
+  }
+
+  .follow-search-form {
+    grid-template-columns: 1fr;
+  }
 }
 
 .bottom-grid .remote-card {
@@ -2824,6 +2849,124 @@ select:disabled {
 .cookie-config-bar {
   display: grid;
   gap: 14px;
+}
+
+.follow-browser {
+  display: grid;
+  gap: 12px;
+  min-height: 0;
+}
+
+.follow-up-list-view,
+.follow-up-items-view {
+  display: grid;
+  gap: 12px;
+  min-height: 0;
+}
+
+.follow-up-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(112px, 1fr));
+  gap: 10px;
+  max-height: 280px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
+}
+
+.follow-up-button {
+  min-width: 0;
+  min-height: 76px;
+  display: grid;
+  align-content: space-between;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid rgba(67, 53, 41, 0.08);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    transform 0.16s ease,
+    border-color 0.16s ease,
+    box-shadow 0.16s ease;
+}
+
+.follow-up-button:hover {
+  transform: translateY(-1px);
+  border-color: rgba(202, 91, 60, 0.24);
+  box-shadow: 0 10px 24px rgba(79, 56, 39, 0.1);
+}
+
+.follow-up-name {
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 800;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.follow-up-count,
+.follow-browser-count {
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.3;
+}
+
+.follow-browser-head {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+}
+
+.follow-browser-head .toolbar-button {
+  min-height: 40px;
+  padding: 0 12px;
+}
+
+.follow-browser-title-block {
+  min-width: 0;
+}
+
+.follow-browser-title-block h3 {
+  min-width: 0;
+  font-size: 16px;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.follow-search-form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+}
+
+.follow-search-form input {
+  height: 44px;
+  border-radius: 14px;
+  padding: 0 14px;
+  font-size: inherit;
+}
+
+.follow-search-form .next-button {
+  height: 44px;
+  min-width: 72px;
+  border-radius: 14px;
+  padding: 0 16px;
+}
+
+#follow-song-results {
+  max-height: 300px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
 }
 
 .gatcha-uid-bar {

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -180,6 +180,23 @@ class CacheManagerPolicyTest(unittest.TestCase):
         self.assertFalse(item_dir.exists())
         self.assertFalse(log_path.exists())
 
+    def test_remove_cache_dir_ignores_windows_missing_path_race(self):
+        log_dir = Path(self.temp_dir.name) / "logs"
+        missing_error = OSError(3, "系统找不到指定的路径。")
+        missing_error.winerror = 3
+
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir), patch("bilikara.cache.LOG_DIR", log_dir), patch(
+            "bilikara.cache.shutil.rmtree",
+            side_effect=missing_error,
+        ) as rmtree_mock:
+            manager = CacheManager(self.store, max_cache_items=3)
+            try:
+                manager._remove_cache_dir("song-a")
+            finally:
+                manager.shutdown()
+
+        rmtree_mock.assert_called_once_with(self.cache_dir / "song-a", ignore_errors=True)
+
     def test_enrich_snapshot_includes_cache_activity_timestamp(self):
         with patch("bilikara.cache.CACHE_DIR", self.cache_dir):
             manager = CacheManager(self.store, max_cache_items=3)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -197,6 +197,13 @@ class CacheManagerPolicyTest(unittest.TestCase):
 
         rmtree_mock.assert_called_once_with(self.cache_dir / "song-a", ignore_errors=True)
 
+    def test_path_size_ignores_directory_removed_during_scan(self):
+        item_dir = self.cache_dir / "song-a"
+        item_dir.mkdir(parents=True, exist_ok=True)
+
+        with patch.object(Path, "rglob", side_effect=OSError(3, "missing path")):
+            self.assertEqual(CacheManager._path_size(item_dir), 0)
+
     def test_enrich_snapshot_includes_cache_activity_timestamp(self):
         with patch("bilikara.cache.CACHE_DIR", self.cache_dir):
             manager = CacheManager(self.store, max_cache_items=3)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -66,6 +66,37 @@ class AppContextStateRevisionTest(unittest.TestCase):
         self.assertEqual(results, [True])
 
 
+class AppContextPlayerStatusTest(unittest.TestCase):
+    def make_context(self) -> AppContext:
+        context = AppContext.__new__(AppContext)
+        context._player_status_lock = threading.RLock()
+        context._player_status = None
+        context._state_change_condition = threading.Condition()
+        context._state_revision = 0
+        context.store = SimpleNamespace(mark_item_playback_started=lambda item_id: None)
+        return context
+
+    def test_player_status_preserves_reported_duration(self):
+        context = self.make_context()
+
+        context.update_player_status(
+            item_id="song-1",
+            is_paused=False,
+            current_time=12.0,
+            duration=123.4,
+        )
+        context.update_player_status(
+            item_id="song-1",
+            is_paused=True,
+            current_time=13.0,
+        )
+
+        snapshot = context.player_status_snapshot({"id": "song-1"})
+        self.assertIsNotNone(snapshot)
+        self.assertEqual(snapshot["duration"], 123.4)
+        self.assertEqual(snapshot["current_time"], 13.0)
+
+
 class AppContextClientTrackingTest(unittest.TestCase):
     def make_context(self) -> AppContext:
         context = AppContext.__new__(AppContext)
@@ -164,6 +195,35 @@ class PlayerResetRouteTest(unittest.TestCase):
 
         self.assertEqual(writes[0], {"reset_player": True})
         self.assertEqual(writes[1], {"ok": True, "data": {"playback_mode": "local"}})
+
+
+class PlayerControlRouteTest(unittest.TestCase):
+    def test_absolute_seek_route_forwards_target_seconds(self):
+        handler = BilikaraHandler.__new__(BilikaraHandler)
+        writes: list[dict] = []
+        issued: list[dict] = []
+        context = SimpleNamespace(
+            touch_client=lambda client_id, is_host=True: None,
+            issue_player_control=lambda **kwargs: issued.append(kwargs),
+            snapshot=lambda: {"player_control_command": issued[-1]},
+        )
+
+        handler.path = "/api/player/control"
+        handler.headers = {}
+        handler._read_json_body = lambda: {
+            "action": "seek-absolute",
+            "item_id": "song-1",
+            "target_seconds": 262.5,
+        }
+        handler._write_json = lambda payload, status=None: writes.append(payload)
+
+        with patch("bilikara.server.CONTEXT", context):
+            handler.do_POST()
+
+        self.assertEqual(issued[0]["action"], "seek-absolute")
+        self.assertEqual(issued[0]["item_id"], "song-1")
+        self.assertEqual(issued[0]["target_seconds"], 262.5)
+        self.assertEqual(writes[0]["data"]["player_control_command"]["target_seconds"], 262.5)
 
 
 class PlaylistResortRouteTest(unittest.TestCase):

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -1,4 +1,5 @@
 import json
+import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -504,6 +505,8 @@ class PlaylistStoreTest(unittest.TestCase):
         self.assertTrue(self.backup_file.exists())
         gatcha_file = self.state_file.parent / "gatcha_cache.json"
         gatcha_file.write_text("{}", encoding="utf-8")
+        gatcha_uid_file = self.state_file.parent / "gatcha_uids.json"
+        gatcha_uid_file.write_text("{}", encoding="utf-8")
         played_file = self.session_archive_dir / "played-keep.json"
         played_file.parent.mkdir(parents=True, exist_ok=True)
         played_file.write_text("{}", encoding="utf-8")
@@ -511,6 +514,7 @@ class PlaylistStoreTest(unittest.TestCase):
         self.store.reset_runtime_data()
 
         self.assertTrue(gatcha_file.exists())
+        self.assertTrue(gatcha_uid_file.exists())
         self.assertTrue(played_file.exists())
         self.assertFalse(self.backup_file.exists())
         self.assertEqual(self.store.playback_mode, "local")
@@ -717,6 +721,201 @@ class BilibiliParserTest(unittest.TestCase):
                 bilibili_module.MISSING_BILIBILI_COOKIE_MESSAGE,
             ):
                 bilibili_module.fetch_gatcha_candidate()
+
+    def test_gatcha_uid_snapshot_creates_default_uid_file(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module.cfg, "GATCHA_UIDS", ["1", "2", "1"]),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+            ):
+                snapshot = bilibili_module.gatcha_uid_snapshot()
+
+            self.assertEqual(snapshot["uids"], ["1", "2"])
+            self.assertEqual(json.loads(uid_file.read_text(encoding="utf-8"))["uids"], ["1", "2"])
+
+    def test_gatcha_uid_rejects_video_ids_instead_of_guessing_digits(self):
+        with self.assertRaisesRegex(bilibili_module.BilibiliError, "不要输入 BV/av 视频号"):
+            bilibili_module._normalize_gatcha_uid("BV1xx411c7mD")
+
+        with self.assertRaisesRegex(bilibili_module.BilibiliError, "不要输入 BV/av 视频号"):
+            bilibili_module._normalize_gatcha_uid("https://www.bilibili.com/video/BV1xx411c7mD")
+
+    def test_preview_gatcha_uid_fetches_owner_and_cache_mode(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+            cache_file = data_dir / "gatcha_cache.json"
+            uid_file.write_text(json.dumps({"uids": ["42"]}), encoding="utf-8")
+            cache_file.write_text(
+                json.dumps(
+                    {
+                        "uids": {
+                            "42": [
+                                {
+                                    "mid": "42",
+                                    "bvid": "BVOLD",
+                                    "title": "old karaoke",
+                                    "url": "https://www.bilibili.com/video/BVOLD",
+                                }
+                            ]
+                        },
+                        "updated_at": 1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+                patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
+                patch.object(bilibili_module, "effective_bilibili_cookie", return_value="cookie"),
+                patch.object(
+                    bilibili_module,
+                    "_request_gatcha_uid_profile",
+                    return_value={
+                        "uid": "42",
+                        "name": "example-up",
+                        "space_url": "https://space.bilibili.com/42",
+                    },
+                ),
+            ):
+                preview = bilibili_module.preview_gatcha_uid("https://space.bilibili.com/42")
+
+            self.assertEqual(preview["uid"], "42")
+            self.assertEqual(preview["name"], "example-up")
+            self.assertTrue(preview["already_followed"])
+            self.assertEqual(preview["cache_mode"], "incremental")
+            self.assertEqual(preview["cache_mode_label"], "最新")
+
+    def test_refresh_gatcha_cache_incremental_for_existing_and_full_for_missing_uid(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+            cache_file = data_dir / "gatcha_cache.json"
+            uid_file.write_text(json.dumps({"uids": ["1", "2"]}), encoding="utf-8")
+            cache_file.write_text(
+                json.dumps(
+                    {
+                        "uids": {
+                            "1": [
+                                {
+                                    "mid": "1",
+                                    "bvid": "BVOLD",
+                                    "title": "old karaoke",
+                                    "url": "https://www.bilibili.com/video/BVOLD",
+                                }
+                            ]
+                        },
+                        "updated_at": 1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            calls: list[tuple[str, object, bool]] = []
+
+            def fake_fetch(mid, *, on_progress=None, max_pages=None):
+                calls.append((mid, max_pages, on_progress is not None))
+                if mid == "1":
+                    return [
+                        {
+                            "mid": "1",
+                            "bvid": "BVNEW",
+                            "title": "new karaoke",
+                            "url": "https://www.bilibili.com/video/BVNEW",
+                        },
+                        {
+                            "mid": "1",
+                            "bvid": "BVOLD",
+                            "title": "old karaoke",
+                            "url": "https://www.bilibili.com/video/BVOLD",
+                        },
+                    ]
+                entries = [
+                    {
+                        "mid": "2",
+                        "bvid": "BV2A",
+                        "title": "first karaoke",
+                        "url": "https://www.bilibili.com/video/BV2A",
+                    },
+                    {
+                        "mid": "2",
+                        "bvid": "BV2B",
+                        "title": "second karaoke",
+                        "url": "https://www.bilibili.com/video/BV2B",
+                    },
+                ]
+                if on_progress is not None:
+                    on_progress(entries[:1])
+                return entries
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+                patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
+                patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", threading.Lock()),
+                patch.object(bilibili_module, "effective_bilibili_cookie", return_value="cookie"),
+                patch.object(bilibili_module, "_fetch_gatcha_videos_for_uid", side_effect=fake_fetch),
+            ):
+                bilibili_module.refresh_gatcha_cache()
+
+            self.assertEqual(calls, [("1", 1, False), ("2", None, True)])
+            cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
+            self.assertEqual([entry["bvid"] for entry in cache_payload["uids"]["1"]], ["BVNEW", "BVOLD"])
+            self.assertEqual([entry["bvid"] for entry in cache_payload["uids"]["2"]], ["BV2A", "BV2B"])
+
+    def test_add_gatcha_uid_persists_uid_and_refreshes_added_uid(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+            cache_file = data_dir / "gatcha_cache.json"
+            uid_file.write_text(json.dumps({"uids": ["1"]}), encoding="utf-8")
+            calls: list[str] = []
+
+            def fake_fetch(mid, *, on_progress=None, max_pages=None):
+                calls.append(mid)
+                entries = [
+                    {
+                        "mid": mid,
+                        "bvid": "BVADDED42",
+                        "title": "added test karaoke",
+                        "url": "https://www.bilibili.com/video/BVADDED42",
+                    }
+                ]
+                if on_progress is not None:
+                    on_progress(entries)
+                return entries
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+                patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
+                patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", threading.Lock()),
+                patch.object(bilibili_module, "effective_bilibili_cookie", return_value="cookie"),
+                patch.object(
+                    bilibili_module,
+                    "_request_gatcha_uid_profile",
+                    return_value={
+                        "uid": "42",
+                        "name": "example-up",
+                        "space_url": "https://space.bilibili.com/42",
+                    },
+                ),
+                patch.object(bilibili_module, "_fetch_gatcha_videos_for_uid", side_effect=fake_fetch),
+            ):
+                result = bilibili_module.add_gatcha_uid("https://space.bilibili.com/42")
+
+            self.assertTrue(result["added"])
+            self.assertEqual(result["uid"], "42")
+            self.assertIn("42", calls)
+            self.assertEqual(calls.count("42"), 1)
+            self.assertEqual(json.loads(uid_file.read_text(encoding="utf-8"))["uids"], ["1", "42"])
+            cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
+            self.assertEqual(cache_payload["uids"]["42"][0]["bvid"], "BVADDED42")
 
     @patch("bilikara.bilibili.request_json")
     def test_fetch_video_item(self, mock_request_json):

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -853,18 +853,31 @@ class BilibiliParserTest(unittest.TestCase):
                     on_progress(entries[:1])
                 return entries
 
+            def fake_profile(mid):
+                return {
+                    "uid": mid,
+                    "name": f"up-{mid}",
+                    "space_url": f"https://space.bilibili.com/{mid}",
+                }
+
             with (
                 patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
                 patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
                 patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
                 patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", threading.Lock()),
                 patch.object(bilibili_module, "effective_bilibili_cookie", return_value="cookie"),
+                patch.object(bilibili_module, "_request_gatcha_uid_profile", side_effect=fake_profile),
                 patch.object(bilibili_module, "_fetch_gatcha_videos_for_uid", side_effect=fake_fetch),
             ):
                 bilibili_module.refresh_gatcha_cache()
 
             self.assertEqual(calls, [("1", 1, False), ("2", None, True)])
+            uid_payload = json.loads(uid_file.read_text(encoding="utf-8"))
+            self.assertEqual(uid_payload["profiles"]["1"]["name"], "up-1")
+            self.assertEqual(uid_payload["profiles"]["2"]["name"], "up-2")
             cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
+            self.assertEqual(cache_payload["profiles"]["1"]["name"], "up-1")
+            self.assertEqual(cache_payload["profiles"]["2"]["name"], "up-2")
             self.assertEqual([entry["bvid"] for entry in cache_payload["uids"]["1"]], ["BVNEW", "BVOLD"])
             self.assertEqual([entry["bvid"] for entry in cache_payload["uids"]["2"]], ["BV2A", "BV2B"])
 

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -801,6 +801,7 @@ class BilibiliParserTest(unittest.TestCase):
             cache_file.write_text(
                 json.dumps(
                     {
+                        "schema_version": 2,
                         "uids": {
                             "1": [
                                 {
@@ -810,6 +811,13 @@ class BilibiliParserTest(unittest.TestCase):
                                     "url": "https://www.bilibili.com/video/BVOLD",
                                 }
                             ]
+                        },
+                        "profiles": {
+                            "1": {
+                                "uid": "1",
+                                "name": "up-1",
+                                "space_url": "https://space.bilibili.com/1",
+                            }
                         },
                         "updated_at": 1,
                     }
@@ -880,6 +888,71 @@ class BilibiliParserTest(unittest.TestCase):
             self.assertEqual(cache_payload["profiles"]["2"]["name"], "up-2")
             self.assertEqual([entry["bvid"] for entry in cache_payload["uids"]["1"]], ["BVNEW", "BVOLD"])
             self.assertEqual([entry["bvid"] for entry in cache_payload["uids"]["2"]], ["BV2A", "BV2B"])
+
+    def test_refresh_gatcha_cache_clears_legacy_cache_without_profiles(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+            cache_file = data_dir / "gatcha_cache.json"
+            uid_file.write_text(json.dumps({"uids": ["1"]}), encoding="utf-8")
+            cache_file.write_text(
+                json.dumps(
+                    {
+                        "uids": {
+                            "1": [
+                                {
+                                    "mid": "1",
+                                    "bvid": "BVOLD",
+                                    "title": "old karaoke",
+                                    "url": "https://www.bilibili.com/video/BVOLD",
+                                }
+                            ]
+                        },
+                        "updated_at": 1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+            calls: list[tuple[str, object, bool]] = []
+
+            def fake_fetch(mid, *, on_progress=None, max_pages=None):
+                calls.append((mid, max_pages, on_progress is not None))
+                entries = [
+                    {
+                        "mid": mid,
+                        "bvid": "BVFULL",
+                        "title": "full karaoke",
+                        "url": "https://www.bilibili.com/video/BVFULL",
+                    }
+                ]
+                if on_progress is not None:
+                    on_progress(entries)
+                return entries
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+                patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
+                patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", threading.Lock()),
+                patch.object(bilibili_module, "effective_bilibili_cookie", return_value="cookie"),
+                patch.object(
+                    bilibili_module,
+                    "_request_gatcha_uid_profile",
+                    return_value={
+                        "uid": "1",
+                        "name": "up-1",
+                        "space_url": "https://space.bilibili.com/1",
+                    },
+                ),
+                patch.object(bilibili_module, "_fetch_gatcha_videos_for_uid", side_effect=fake_fetch),
+            ):
+                bilibili_module.refresh_gatcha_cache()
+
+            self.assertEqual(calls, [("1", None, True)])
+            cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
+            self.assertEqual(cache_payload["schema_version"], 2)
+            self.assertEqual(cache_payload["profiles"]["1"]["name"], "up-1")
+            self.assertEqual([entry["bvid"] for entry in cache_payload["uids"]["1"]], ["BVFULL"])
 
     def test_add_gatcha_uid_persists_uid_and_refreshes_added_uid(self):
         with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## 概要
本次改动主要完成关注列表浏览功能、Host/Remote 多 P 绑定 UI 调整，并增强 smoke test 与缓存下载稳定性。

## 主要改动
- 移除前端 Cookie Config 输入 UI，保留后端接口。
- 新增关注列表浏览功能：
  - 第一层以网格按钮展示固定 UID 和用户加入 gatcha 的 UID。
  - 按钮显示 UP 主名称，名称过长自动省略。
  - 点击 UP 后进入第二层，展示该 UP 在 gatcha cache 中的所有稿件。
  - 第二层支持返回和搜索，点歌逻辑复用现有搜索结果的点歌流程。
  - Host 和 Remote 均支持该功能。
- gatcha cache 增加/使用 UID 对应 UP 主名称与稿件数量，让关注列表初始即可显示名称。
- 进入关注列表时重新拉取 UP 主名称和歌曲数量，避免未进入详情时数据不更新。
- 修复关注列表稿件点歌没有接通的问题。
- 调整 Host/Remote 多 P 绑定 UI：
  - “取消 / 加入点歌列表”操作区固定在绑定面板底部。
  - 去掉底部透明悬浮感，优化滚动区域和底部操作区布局。
- 修复 cache retry/metrics 扫描时目录被删除导致的 WinError 3 问题。
- smoke test 增强：
  - 加入关注列表/近期 UI surface 检查。
  - 下载前自动把视频清晰度切到 480P，减轻 smoke test 重复下载压力，并覆盖清晰度设置功能。
  - 下载流程结束后恢复原 cache policy。
  - 播放器状态上报增加 duration。
  - transition UI 测试从相对 seek 改为绝对 seek，避免因旧 current_time 导致直接跳到结尾。
  - near-end 校验改成目标窗口校验，落到视频结尾不会再误判 OK。

## 验证
- 运行 Python 语法检查通过。
- `py -B -m unittest tests.test_server` 通过。
- python scripts\dev_smoke_test.py 通过。

English PR Description:
## Summary
This change adds the follow-browse experience, refines Host/Remote multi-part binding UI, and hardens smoke-test/cache behavior.

## Changes
- Removed the frontend Cookie Config UI while keeping the backend API intact.
- Added follow-browse support:
  - First level shows fixed UIDs and user-added gatcha UIDs as grid buttons.
  - Buttons display UP owner names with ellipsis for long names.
  - Clicking an owner opens a second level with all cached gatcha videos for that owner.
  - Second level supports back navigation and search.
  - Song request behavior reuses the existing search-result add flow.
  - Implemented on both Host and Remote.
- Added/used cached UP owner profile data so owner names and song counts are available before opening an owner detail view.
- Refresh owner names and song counts when entering the follow-browse view.
- Fixed follow-browse song request wiring.
- Updated Host/Remote multi-part binding UI:
  - Pin “Cancel / Add to playlist” actions to the bottom of the binding panel.
  - Removed the floating translucent bottom feel and improved scroll/action layout.
- Fixed cache retry/metrics path scanning race where deleted cache directories could raise WinError 3.
- Improved smoke test coverage and stability:
  - Added follow-browse/recent UI surface checks.
  - Set video quality to 480P before song downloads to reduce repeated smoke-test download cost and cover cache-quality settings.
  - Restore the original cache policy after the download flow.
  - Include media duration in player status reports.
  - Use absolute seek for transition UI testing instead of accumulated relative seeks.
  - Validate near-end playback with a bounded target window so landing at media end is no longer reported as OK.

## Verification
- Python syntax checks passed.
- `py -B -m unittest tests.test_server` passed.
- python scripts\dev_smoke_test.py passed.