### PR TITLE
fix: 版本检测和恢复状态 corner case

### DIFF
--- a/bilikara/config.py
+++ b/bilikara/config.py
@@ -264,12 +264,6 @@ def _detect_app_version() -> str:
     override = os.getenv("BILIKARA_VERSION", "").strip()
     if override:
         return override
-    try:
-        version = APP_VERSION_FILE.read_text(encoding="utf-8").strip()
-    except OSError:
-        version = ""
-    if version:
-        return version
     if not getattr(sys, "frozen", False):
         try:
             process = subprocess.run(
@@ -287,6 +281,12 @@ def _detect_app_version() -> str:
             detected = (process.stdout or "").strip()
             if detected:
                 return detected
+    try:
+        version = APP_VERSION_FILE.read_text(encoding="utf-8").strip()
+    except OSError:
+        version = ""
+    if version:
+        return version
     return "dev"
 
 

--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -327,6 +327,7 @@ class AppContext:
             self._player_control_command = None
         with self._player_status_lock:
             self._player_status = None
+        self._notify_state_changed()
 
     def bind_server(self, server: ThreadingHTTPServer, *, shutdown_on_last_client: bool) -> None:
         with self._client_lock:

--- a/bilikara/store.py
+++ b/bilikara/store.py
@@ -377,6 +377,7 @@ class PlaylistStore:
                 PlaylistItem.from_dict(self._sanitize_backup_payload(item))
                 for item in playlist_payload
             ]
+            self.current_item_started = False
             self._rebuild_cycle_items_unlocked()
             self._touch(persist_backup=False)
             return True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from bilikara import config
@@ -47,6 +48,29 @@ class ConfigPathTest(unittest.TestCase):
                 with patch.object(config.os, "name", "nt"):
                     with patch("bilikara.config._detect_windows_physical_host", return_value="192.168.31.8"):
                         self.assertEqual(config._default_host(), "0.0.0.0")
+
+    def test_source_version_prefers_git_describe_over_cached_file(self):
+        with TemporaryDirectory() as temp_dir:
+            version_file = Path(temp_dir) / "APP_VERSION"
+            version_file.write_text("v0.4.0", encoding="utf-8")
+            with patch.dict(os.environ, {}, clear=True):
+                with patch.object(config.sys, "frozen", False, create=True):
+                    with patch.object(config, "APP_VERSION_FILE", version_file):
+                        with patch(
+                            "bilikara.config.subprocess.run",
+                            return_value=SimpleNamespace(returncode=0, stdout="v0.5.0-2-gabcdef\n"),
+                        ):
+                            self.assertEqual(config._detect_app_version(), "v0.5.0-2-gabcdef")
+
+    def test_frozen_version_uses_cached_file_without_git(self):
+        with TemporaryDirectory() as temp_dir:
+            version_file = Path(temp_dir) / "APP_VERSION"
+            version_file.write_text("v0.4.0", encoding="utf-8")
+            with patch.dict(os.environ, {}, clear=True):
+                with patch.object(config.sys, "frozen", True, create=True):
+                    with patch.object(config, "APP_VERSION_FILE", version_file):
+                        with patch("bilikara.config.subprocess.run", side_effect=AssertionError("git should not run")):
+                            self.assertEqual(config._detect_app_version(), "v0.4.0")
 
     def test_pick_windows_physical_host_prefers_non_virtual_adapter_with_gateway(self):
         payload = [

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -66,6 +66,25 @@ class AppContextStateRevisionTest(unittest.TestCase):
         self.assertFalse(worker.is_alive())
         self.assertEqual(results, [True])
 
+    def test_reset_player_state_notifies_after_clearing_player_state(self):
+        context = AppContext.__new__(AppContext)
+        context._state_change_condition = threading.Condition()
+        context._state_revision = 0
+        context._player_control_lock = threading.RLock()
+        context._player_control_seq = 7
+        context._player_control_ack_seq = 0
+        context._player_control_command = {"type": "play"}
+        context._player_status_lock = threading.RLock()
+        context._player_status = {"item_id": "song-a", "current_time": 12.0}
+        context.store = SimpleNamespace(reset_player_state=lambda: None)
+
+        context.reset_player_state()
+
+        self.assertEqual(context._state_revision, 1)
+        self.assertEqual(context._player_control_ack_seq, 7)
+        self.assertIsNone(context._player_control_command)
+        self.assertIsNone(context._player_status)
+
 
 class AppContextPlayerStatusTest(unittest.TestCase):
     def make_context(self) -> AppContext:

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -475,7 +475,9 @@ class PlaylistStoreTest(unittest.TestCase):
         )
         self.assertEqual(restored_store.playlist, [])
         self.assertTrue(restored_store.backup_summary()["available"])
+        restored_store.current_item_started = True
         self.assertTrue(restored_store.restore_backup())
+        self.assertFalse(restored_store.current_item_started)
         self.assertEqual(restored_store.playback_mode, "local")
         self.assertEqual(restored_store.av_offset_ms, 180)
         self.assertEqual(restored_store.volume_percent, 42)


### PR DESCRIPTION
修复 Codex auto review 中指出的 corner case 问题：
* 开发版版本号误判
* 恢复备份误计入历史
* 重置播放器后前端状态不同步