### PR TITLE
fix: 完善更新检测，改进 played_session 记录策略，下线在线外挂，ui: 开关尺寸等微调

### DIFF
--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -520,7 +520,13 @@ class BilikaraHandler(BaseHTTPRequestHandler):
             return
         if route == "/api/app/update":
             try:
-                self._write_json({"ok": True, "data": check_for_update()})
+                include_preview = str(query.get("include_preview", [""])[0]).lower() in {
+                    "1",
+                    "true",
+                    "yes",
+                    "on",
+                }
+                self._write_json({"ok": True, "data": check_for_update(include_preview=include_preview)})
             except Exception as e:
                 self._write_json({"ok": False, "error": str(e)}, status=HTTPStatus.BAD_GATEWAY)
             return

--- a/bilikara/store.py
+++ b/bilikara/store.py
@@ -52,9 +52,8 @@ class PlaylistStore:
         self.session_history: list[HistoryEntry] = []
         self.session_users: list[str] = []
         self.session_started_at = time.time()
-        self.session_played_file = (
-            self.session_archive_dir
-            / f"played-{self._session_file_label(self.session_started_at)}.json"
+        self.session_played_file = self._session_played_file_for_timestamp(
+            self.session_started_at
         )
         self.session_played: list[SessionPlayedEntry] = []
         self.updated_at = time.time()
@@ -378,6 +377,7 @@ class PlaylistStore:
                 for item in playlist_payload
             ]
             self.current_item_started = False
+            self._restore_session_played_from_backup_unlocked(payload)
             self._rebuild_cycle_items_unlocked()
             self._touch(persist_backup=False)
             return True
@@ -387,6 +387,8 @@ class PlaylistStore:
             existed = self.backup_file.exists() or self.current_item is not None or bool(self.playlist)
             self.current_item = None
             self.playlist = []
+            if existed:
+                self._start_new_session_played_unlocked()
             self.backup_file.unlink(missing_ok=True)
             self._touch(persist_backup=False)
             return existed
@@ -686,9 +688,74 @@ class PlaylistStore:
                 self._backup_item_payload(self.current_item) if self.current_item else None
             ),
             "playlist": [self._backup_item_payload(item) for item in self.playlist],
+            "played_session": {
+                "file": self.session_played_file.name,
+                "session_started_at": self.session_started_at,
+            },
             "updated_at": self.updated_at,
         }
         self._write_json_payload_unlocked(self.backup_file, payload)
+
+    def _restore_session_played_from_backup_unlocked(self, payload: dict[str, Any]) -> bool:
+        session_payload = payload.get("played_session")
+        if not isinstance(session_payload, dict):
+            self._start_new_session_played_unlocked()
+            return False
+
+        filename = Path(str(session_payload.get("file") or "").strip()).name
+        if not filename:
+            self._start_new_session_played_unlocked()
+            return False
+
+        candidate = self.session_archive_dir / filename
+        played_payload = self._read_json_payload_unlocked(candidate)
+        if not played_payload:
+            self._start_new_session_played_unlocked()
+            return False
+
+        entries: list[SessionPlayedEntry] = []
+        for entry_payload in played_payload.get("items") or []:
+            if not isinstance(entry_payload, dict):
+                continue
+            try:
+                entries.append(SessionPlayedEntry.from_dict(dict(entry_payload)))
+            except TypeError:
+                continue
+
+        self.session_played_file = candidate
+        self.session_started_at = self._session_started_at_from_payload(
+            played_payload,
+            session_payload,
+        )
+        self.session_played = entries
+        return True
+
+    def _start_new_session_played_unlocked(self) -> None:
+        self.session_started_at = time.time()
+        self.session_played_file = self._session_played_file_for_timestamp(
+            self.session_started_at
+        )
+        self.session_played = []
+
+    def _session_played_file_for_timestamp(self, timestamp: float) -> Path:
+        return (
+            self.session_archive_dir
+            / f"played-{self._session_file_label(timestamp)}.json"
+        )
+
+    @staticmethod
+    def _session_started_at_from_payload(
+        played_payload: dict[str, Any],
+        backup_payload: dict[str, Any],
+    ) -> float:
+        for payload in (played_payload, backup_payload):
+            try:
+                timestamp = float(payload.get("session_started_at") or 0.0)
+            except (TypeError, ValueError):
+                timestamp = 0.0
+            if timestamp > 0:
+                return timestamp
+        return time.time()
 
     def _touch(self, *, persist_backup: bool) -> None:
         self.updated_at = time.time()

--- a/bilikara/store.py
+++ b/bilikara/store.py
@@ -836,7 +836,7 @@ class PlaylistStore:
 
             player_payload = self._read_json_payload_unlocked(self.player_state_file)
             if player_payload:
-                self.playback_mode = str(player_payload.get("playback_mode") or "local")
+                self.playback_mode = self._load_playback_mode(player_payload)
                 self.av_offset_ms = self._load_av_offset_ms(player_payload)
                 self.volume_percent = self._load_volume_percent(player_payload)
                 self.is_muted = self._load_is_muted(player_payload)
@@ -866,6 +866,12 @@ class PlaylistStore:
         if state_file.name == "state.json":
             return state_file.with_name(default_name)
         return state_file.with_name(f"{state_file.stem}-{suffix}.json")
+
+    @staticmethod
+    def _load_playback_mode(_payload: dict[str, Any]) -> str:
+        # Online embed playback is deprecated in the frontend. Keep the
+        # server-side mode field for compatibility, but never restore it.
+        return "local"
 
     @staticmethod
     def _load_av_offset_ms(payload: dict[str, Any]) -> int:

--- a/bilikara/updater.py
+++ b/bilikara/updater.py
@@ -7,7 +7,8 @@ from typing import Any, Callable
 
 from .config import APP_RELEASE_API, APP_RELEASES_URL, APP_VERSION
 
-VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)$", re.IGNORECASE)
+VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-preview\.(\d+))?$", re.IGNORECASE)
+APP_RELEASES_API = APP_RELEASE_API.rsplit("/", 1)[0] if APP_RELEASE_API.endswith("/latest") else APP_RELEASE_API
 
 
 def normalize_version_tag(version: object) -> str:
@@ -18,24 +19,44 @@ def version_tuple(version: object) -> tuple[int, int, int] | None:
     match = VERSION_RE.match(normalize_version_tag(version))
     if not match:
         return None
-    return tuple(int(part) for part in match.groups())
+    return tuple(int(part) for part in match.groups()[:3])
+
+
+def version_sort_key(version: object) -> tuple[int, int, int, int, int] | None:
+    match = VERSION_RE.match(normalize_version_tag(version))
+    if not match:
+        return None
+    major, minor, patch = (int(part) for part in match.groups()[:3])
+    preview_number = match.group(4)
+    if preview_number is None:
+        return (major, minor, patch, 1, 0)
+    return (major, minor, patch, 0, int(preview_number))
 
 
 def is_release_version(version: object) -> bool:
-    return version_tuple(version) is not None
+    return version_sort_key(version) is not None
+
+
+def is_preview_version(version: object) -> bool:
+    match = VERSION_RE.match(normalize_version_tag(version))
+    return bool(match and match.group(4) is not None)
+
+
+def is_stable_version(version: object) -> bool:
+    return is_release_version(version) and not is_preview_version(version)
 
 
 def is_newer_version(latest_version: object, current_version: object) -> bool:
-    latest_tuple = version_tuple(latest_version)
-    current_tuple = version_tuple(current_version)
-    if latest_tuple is None or current_tuple is None:
+    latest_key = version_sort_key(latest_version)
+    current_key = version_sort_key(current_version)
+    if latest_key is None or current_key is None:
         return False
-    return latest_tuple > current_tuple
+    return latest_key > current_key
 
 
-def fetch_latest_release() -> dict[str, Any]:
+def fetch_releases() -> list[dict[str, Any]]:
     request = urllib.request.Request(
-        APP_RELEASE_API,
+        APP_RELEASES_API,
         headers={
             "Accept": "application/vnd.github+json",
             "User-Agent": "bilikara-update-check",
@@ -43,17 +64,61 @@ def fetch_latest_release() -> dict[str, Any]:
     )
     with urllib.request.urlopen(request, timeout=8) as response:
         payload = json.loads(response.read().decode("utf-8"))
-    if not isinstance(payload, dict):
+    if not isinstance(payload, list):
         raise RuntimeError("GitHub Release 响应格式不正确")
     return payload
+
+
+def fetch_latest_release() -> dict[str, Any]:
+    releases = fetch_releases()
+    if not releases:
+        raise RuntimeError("没有找到 GitHub Release")
+    return releases[0]
+
+
+def _coerce_releases(payload: object) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list):
+        return [release for release in payload if isinstance(release, dict)]
+    return []
+
+
+def _latest_release_for_current(current_version: str, releases: list[dict[str, Any]]) -> dict[str, Any]:
+    valid_releases = [
+        release
+        for release in releases
+        if not release.get("draft") and version_sort_key(release.get("tag_name")) is not None
+    ]
+    if not valid_releases:
+        return {}
+
+    latest_any = max(valid_releases, key=lambda release: version_sort_key(release.get("tag_name")) or (0, 0, 0, 0, 0))
+    stable_releases = [
+        release
+        for release in valid_releases
+        if is_stable_version(release.get("tag_name"))
+    ]
+    latest_stable = (
+        max(stable_releases, key=lambda release: version_sort_key(release.get("tag_name")) or (0, 0, 0, 0, 0))
+        if stable_releases
+        else {}
+    )
+
+    if is_stable_version(current_version):
+        return latest_stable
+    if is_preview_version(current_version):
+        return latest_any
+    return latest_stable or latest_any
 
 
 def check_for_update(
     *,
     current_version: str = APP_VERSION,
-    release_fetcher: Callable[[], dict[str, Any]] = fetch_latest_release,
+    release_fetcher: Callable[[], object] = fetch_releases,
 ) -> dict[str, Any]:
-    release = release_fetcher()
+    releases = _coerce_releases(release_fetcher())
+    release = _latest_release_for_current(normalize_version_tag(current_version) or "dev", releases)
     latest_version = normalize_version_tag(release.get("tag_name"))
     release_url = str(release.get("html_url") or APP_RELEASES_URL)
     current_version = normalize_version_tag(current_version) or "dev"
@@ -61,11 +126,12 @@ def check_for_update(
     latest_is_release = is_release_version(latest_version)
     update_available = is_newer_version(latest_version, current_version)
     switch_to_release_available = bool(latest_version and latest_is_release and not current_is_release)
+    latest_channel = "预览版" if is_preview_version(latest_version) else "正式版"
 
     if switch_to_release_available:
-        message = f"当前是开发版或非正式版（{current_version}），最新正式版是 {latest_version}。"
+        message = f"当前是开发版或非正式版（{current_version}），最新{latest_channel}是 {latest_version}。"
     elif update_available:
-        message = f"发现新版本 {latest_version}，当前版本 {current_version}。"
+        message = f"发现新{latest_channel} {latest_version}，当前版本 {current_version}。"
     else:
         message = f"当前已是最新版本（{current_version}）。"
 

--- a/bilikara/updater.py
+++ b/bilikara/updater.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 import re
+import socket
+import urllib.error
 import urllib.request
 from typing import Any, Callable
 
@@ -9,6 +11,9 @@ from .config import APP_RELEASE_API, APP_RELEASES_URL, APP_VERSION
 
 VERSION_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-preview\.(\d+))?$", re.IGNORECASE)
 APP_RELEASES_API = APP_RELEASE_API.rsplit("/", 1)[0] if APP_RELEASE_API.endswith("/latest") else APP_RELEASE_API
+APP_UPDATE_TIMEOUT_SECONDS = 5
+APP_UPDATE_NETWORK_ERROR = "无法连接 GitHub Releases，请检查网络后重试"
+APP_UPDATE_TIMEOUT_ERROR = "连接 GitHub Releases 超时，请稍后重试"
 
 
 def normalize_version_tag(version: object) -> str:
@@ -54,26 +59,38 @@ def is_newer_version(latest_version: object, current_version: object) -> bool:
     return latest_key > current_key
 
 
-def fetch_releases() -> list[dict[str, Any]]:
+def _fetch_release_json(url: str) -> object:
     request = urllib.request.Request(
-        APP_RELEASES_API,
+        url,
         headers={
             "Accept": "application/vnd.github+json",
             "User-Agent": "bilikara-update-check",
         },
     )
-    with urllib.request.urlopen(request, timeout=8) as response:
-        payload = json.loads(response.read().decode("utf-8"))
+    try:
+        with urllib.request.urlopen(request, timeout=APP_UPDATE_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (TimeoutError, socket.timeout) as exc:
+        raise RuntimeError(APP_UPDATE_TIMEOUT_ERROR) from exc
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", None)
+        if isinstance(reason, (TimeoutError, socket.timeout)):
+            raise RuntimeError(APP_UPDATE_TIMEOUT_ERROR) from exc
+        raise RuntimeError(APP_UPDATE_NETWORK_ERROR) from exc
+
+
+def fetch_releases() -> list[dict[str, Any]]:
+    payload = _fetch_release_json(APP_RELEASES_API)
     if not isinstance(payload, list):
         raise RuntimeError("GitHub Release 响应格式不正确")
     return payload
 
 
 def fetch_latest_release() -> dict[str, Any]:
-    releases = fetch_releases()
-    if not releases:
-        raise RuntimeError("没有找到 GitHub Release")
-    return releases[0]
+    payload = _fetch_release_json(APP_RELEASE_API)
+    if not isinstance(payload, dict):
+        raise RuntimeError("GitHub Release 响应格式不正确")
+    return payload
 
 
 def _coerce_releases(payload: object) -> list[dict[str, Any]]:
@@ -84,7 +101,12 @@ def _coerce_releases(payload: object) -> list[dict[str, Any]]:
     return []
 
 
-def _latest_release_for_current(current_version: str, releases: list[dict[str, Any]]) -> dict[str, Any]:
+def _latest_release_for_current(
+    current_version: str,
+    releases: list[dict[str, Any]],
+    *,
+    include_preview: bool = False,
+) -> dict[str, Any]:
     valid_releases = [
         release
         for release in releases
@@ -105,20 +127,25 @@ def _latest_release_for_current(current_version: str, releases: list[dict[str, A
         else {}
     )
 
-    if is_stable_version(current_version):
-        return latest_stable
-    if is_preview_version(current_version):
+    if include_preview:
         return latest_any
-    return latest_stable or latest_any
+    return latest_stable
 
 
 def check_for_update(
     *,
     current_version: str = APP_VERSION,
-    release_fetcher: Callable[[], object] = fetch_releases,
+    include_preview: bool = False,
+    release_fetcher: Callable[[], object] | None = None,
 ) -> dict[str, Any]:
+    if release_fetcher is None:
+        release_fetcher = fetch_releases if include_preview else fetch_latest_release
     releases = _coerce_releases(release_fetcher())
-    release = _latest_release_for_current(normalize_version_tag(current_version) or "dev", releases)
+    release = _latest_release_for_current(
+        normalize_version_tag(current_version) or "dev",
+        releases,
+        include_preview=include_preview,
+    )
     latest_version = normalize_version_tag(release.get("tag_name"))
     release_url = str(release.get("html_url") or APP_RELEASES_URL)
     current_version = normalize_version_tag(current_version) or "dev"
@@ -145,5 +172,6 @@ def check_for_update(
         "published_at": str(release.get("published_at") or ""),
         "update_available": update_available,
         "switch_to_release_available": switch_to_release_available,
+        "include_preview": include_preview,
         "message": message,
     }

--- a/static/app.js
+++ b/static/app.js
@@ -13,11 +13,13 @@ const playerClickDelayMs = 220;
 const playerControlsAutoHideMs = 5000;
 const defaultSongAdvanceDelaySeconds = 3;
 const maxSongAdvanceDelaySeconds = 30;
+const appUpdateCheckTimeoutMs = 10000;
 const storageKeys = {
   playerVolume: "bilikara.player.volume",
   playerMuted: "bilikara.player.muted",
   avOffsetMs: "bilikara.player.av_offset_ms",
   layoutMode: "bilikara.layout.mode",
+  updatePreview: "bilikara.update.preview",
 };
 
 const state = {
@@ -113,6 +115,7 @@ const state = {
   gatchaRefreshSaving: false,
   bbdownLoginRequesting: false,
   updateChecking: false,
+  updatePreviewEnabled: false,
   appToastTimer: null,
   layoutMode: "full",
 };
@@ -145,6 +148,7 @@ const elements = {
   dataResetButton: document.getElementById("data-reset-button"),
   currentCacheRetryButton: document.getElementById("current-cache-retry-button"),
   playerResetButton: document.getElementById("player-reset-button"),
+  updatePreviewCheckbox: document.getElementById("update-preview-checkbox"),
   updateCheckButton: document.getElementById("update-check-button"),
   currentTitle: document.getElementById("current-title"),
   playerPanel: document.querySelector(".player-panel"),
@@ -600,6 +604,7 @@ function hydrateLocalPreferences() {
   );
   state.localPlayerMuted = readLocalBoolean(storageKeys.playerMuted, state.localPlayerMuted);
   state.layoutMode = normalizeLayoutMode(readLocalString(storageKeys.layoutMode, state.layoutMode));
+  state.updatePreviewEnabled = readLocalBoolean(storageKeys.updatePreview, state.updatePreviewEnabled);
 }
 
 function normalizeLayoutMode(value) {
@@ -688,10 +693,11 @@ async function apiPost(url, payload = {}) {
   return data.data;
 }
 
-async function apiGet(url) {
+async function apiGet(url, options = {}) {
   const response = await fetch(url, {
     cache: "no-store",
     headers: clientHeaders(),
+    signal: options.signal,
   });
   const data = await response.json();
   if (!response.ok || !data.ok) {
@@ -1548,7 +1554,16 @@ function renderCacheSettings(bbdown, ffmpeg, cachePolicy) {
   setTextContent(elements.cacheUsageDetail, cacheUsageDetail);
   renderCacheSlider(cachePolicy);
   renderCachePolicyControls(cachePolicy);
+  renderUpdatePreviewControl();
   syncCachePanelVisibility();
+}
+
+function renderUpdatePreviewControl() {
+  if (!elements.updatePreviewCheckbox) {
+    return;
+  }
+  elements.updatePreviewCheckbox.checked = state.updatePreviewEnabled;
+  elements.updatePreviewCheckbox.disabled = state.updateChecking;
 }
 
 function renderPlaybackRepairControls(currentItem) {
@@ -3971,12 +3986,18 @@ async function checkAppUpdate(event) {
   const button = elements.updateCheckButton;
   const point = anchorPointForEvent(event, button || elements.cacheSettings);
   state.updateChecking = true;
+  renderUpdatePreviewControl();
   if (button) {
     button.disabled = true;
     button.textContent = "检查中";
   }
+  const controller = typeof AbortController === "function" ? new AbortController() : null;
+  const timeoutId = controller
+    ? window.setTimeout(() => controller.abort(), appUpdateCheckTimeoutMs)
+    : null;
   try {
-    const result = await apiGet("/api/app/update");
+    const query = state.updatePreviewEnabled ? "?include_preview=1" : "";
+    const result = await apiGet(`/api/app/update${query}`, { signal: controller?.signal });
     if (result?.update_available || result?.switch_to_release_available) {
       const fallbackMessage = result?.switch_to_release_available
         ? "当前为开发版或非正式版。是否打开 GitHub Releases 下载最新正式版？"
@@ -3994,9 +4015,16 @@ async function checkAppUpdate(event) {
     }
     setAppMessage(result?.message || "当前已是最新版本。");
   } catch (error) {
-    setAppMessage(error.message, true);
+    const message = error?.name === "AbortError"
+      ? "连接 GitHub Releases 超时，请稍后重试。"
+      : error?.message || "检查更新失败，请稍后重试。";
+    setAppMessage(message, true);
   } finally {
+    if (timeoutId !== null) {
+      window.clearTimeout(timeoutId);
+    }
     state.updateChecking = false;
+    renderUpdatePreviewControl();
     if (button) {
       button.disabled = false;
       button.textContent = "检查更新";
@@ -4448,6 +4476,12 @@ elements.cacheHiresCheckbox?.addEventListener("change", async (event) => {
     { audio_hires: audioHires },
     audioHires ? "已启用 Hi-Res 音频优先。" : "已关闭 Hi-Res 音频优先。",
   );
+});
+
+elements.updatePreviewCheckbox?.addEventListener("change", (event) => {
+  state.updatePreviewEnabled = Boolean(event.target.checked);
+  writeLocalPreference(storageKeys.updatePreview, state.updatePreviewEnabled);
+  renderUpdatePreviewControl();
 });
 
 elements.avSyncPanel?.addEventListener("click", async (event) => {

--- a/static/app.js
+++ b/static/app.js
@@ -518,7 +518,7 @@ function showMountedPlayerControls() {
 }
 
 function toggleMountedLocalPlayback() {
-  if (state.data?.playback_mode !== "local" || !state.data?.current_item) {
+  if (frontendPlaybackMode(state.data?.playback_mode) !== "local" || !state.data?.current_item) {
     return false;
   }
   const video = activePrimaryVideoElement();
@@ -1200,13 +1200,14 @@ function render() {
   renderRemoteAccess(data.remote_access);
   renderLayoutMode();
 
-  renderAudioVariantBar(currentItem, data.playback_mode);
-  renderAvSyncControls(data.playback_mode, data.player_settings);
-  renderVolumeControls(data.playback_mode);
+  const playbackMode = frontendPlaybackMode(data.playback_mode);
+  renderAudioVariantBar(currentItem, playbackMode);
+  renderAvSyncControls(playbackMode, data.player_settings);
+  renderVolumeControls(playbackMode);
   applyStoredVolumeToMountedPlayer();
-  renderPlayer(currentItem, data.playback_mode);
+  renderPlayer(currentItem, playbackMode);
   renderPlayerFullscreenButton();
-  applyRemotePlayerControl(data.player_control_command, currentItem, data.playback_mode);
+  applyRemotePlayerControl(data.player_control_command, currentItem, playbackMode);
   renderQueueCurrent(currentItem);
   if (!state.dragItemId) {
     renderPlaylist(data.playlist, data.current_item, data.cache_policy);
@@ -1686,8 +1687,12 @@ function aggregateToolStatusState(bbdown, ffmpeg) {
   return "loading";
 }
 
-function formatPlaybackMode(mode) {
-  return mode === "online" ? "在线外挂" : "本地缓存";
+function frontendPlaybackMode(_mode) {
+  return "local";
+}
+
+function formatPlaybackMode(_mode) {
+  return "本地缓存";
 }
 
 function renderCacheSlider(cachePolicy) {
@@ -2221,7 +2226,7 @@ function syncSplitPlayerVolumeFromVideo(video, audio) {
     state.localPlayerVolume = nextVolume;
     state.localPlayerMuted = nextMuted;
     persistLocalVolumePreferences();
-    renderVolumeControls(state.data?.playback_mode || "local");
+    renderVolumeControls(frontendPlaybackMode(state.data?.playback_mode));
   }
 
   if (Math.abs(audio.volume - state.localPlayerVolume) > 0.001) {
@@ -2469,7 +2474,7 @@ async function setLocalPlayerVolume(nextVolume, { unmute = true } = {}) {
   }
   persistLocalVolumePreferences();
   applyStoredVolumeToMountedPlayer();
-  renderVolumeControls(state.data?.playback_mode || "local");
+  renderVolumeControls(frontendPlaybackMode(state.data?.playback_mode));
   try {
     const nextData = await apiPost("/api/player/volume", {
       volume_percent: Math.round(normalizedVolume * 100),
@@ -2489,7 +2494,7 @@ async function setLocalPlayerVolume(nextVolume, { unmute = true } = {}) {
     state.localPlayerMuted = previousMuted;
     persistLocalVolumePreferences();
     applyStoredVolumeToMountedPlayer();
-    renderVolumeControls(state.data?.playback_mode || "local");
+    renderVolumeControls(frontendPlaybackMode(state.data?.playback_mode));
     setAppMessage(error.message, true);
   }
 }
@@ -2500,7 +2505,7 @@ async function toggleLocalPlayerMute() {
   state.localPlayerMuted = !state.localPlayerMuted;
   persistLocalVolumePreferences();
   applyStoredVolumeToMountedPlayer();
-  renderVolumeControls(state.data?.playback_mode || "local");
+  renderVolumeControls(frontendPlaybackMode(state.data?.playback_mode));
   try {
     const nextData = await apiPost("/api/player/volume", {
       volume_percent: Math.round(state.localPlayerVolume * 100),
@@ -2519,7 +2524,7 @@ async function toggleLocalPlayerMute() {
     state.localPlayerMuted = previousMuted;
     persistLocalVolumePreferences();
     applyStoredVolumeToMountedPlayer();
-    renderVolumeControls(state.data?.playback_mode || "local");
+    renderVolumeControls(frontendPlaybackMode(state.data?.playback_mode));
     setAppMessage(error.message, true);
   }
 }
@@ -2538,7 +2543,7 @@ function scheduleAudioVariantSwitchUnlock() {
     state.audioVariantSwitchUnlockAt = 0;
     state.audioVariantSwitchTimer = null;
     if (state.data) {
-      renderAudioVariantBar(state.data.current_item, state.data.playback_mode);
+      renderAudioVariantBar(state.data.current_item, frontendPlaybackMode(state.data.playback_mode));
     }
   }, remainingMs);
 }
@@ -2729,6 +2734,8 @@ function renderPlayer(currentItem, playbackMode) {
     return;
   }
 
+  // LEGACY: online embed playback is kept for reference, but normal frontend
+  // rendering now passes only the local mode.
   if (playbackMode === "online") {
     elements.playerFrame.innerHTML = `
       <iframe
@@ -4224,7 +4231,7 @@ async function setAvOffset(offsetMs) {
   }
   syncMountedLocalPlayer(true);
   state.avOffsetSaving = true;
-  renderAvSyncControls(state.data?.playback_mode, state.data?.player_settings);
+  renderAvSyncControls(frontendPlaybackMode(state.data?.playback_mode), state.data?.player_settings);
   try {
     const nextData = await apiPost("/api/player/av-offset", { offset_ms: boundedOffsetMs });
     if (requestSeq !== state.avOffsetSaveSeq) {
@@ -4245,7 +4252,7 @@ async function setAvOffset(offsetMs) {
   } finally {
     if (requestSeq === state.avOffsetSaveSeq) {
       state.avOffsetSaving = false;
-      renderAvSyncControls(state.data?.playback_mode, state.data?.player_settings);
+      renderAvSyncControls(frontendPlaybackMode(state.data?.playback_mode), state.data?.player_settings);
     }
   }
 }
@@ -4588,14 +4595,15 @@ elements.queueCurrentRetry.addEventListener("click", async () => {
   }
 });
 
+// LEGACY: the online embed mode endpoint still exists server-side, but the
+// frontend no longer exposes a switch into it.
 elements.modeSwitch?.addEventListener("click", async (event) => {
   const button = event.target.closest("button");
   if (!button) {
     return;
   }
-  const nextMode = state.data?.playback_mode === "online" ? "local" : "online";
   try {
-    state.data = await apiPost("/api/mode", { mode: nextMode });
+    state.data = await apiPost("/api/mode", { mode: "local" });
     render();
   } catch (error) {
     setAppMessage(error.message, true);
@@ -4661,7 +4669,7 @@ elements.audioVariantBar.addEventListener("click", async (event) => {
   if (toggleButton) {
     state.audioVariantBarExpanded = !state.audioVariantBarExpanded;
     if (state.data?.current_item) {
-      renderAudioVariantBar(state.data.current_item, state.data.playback_mode);
+      renderAudioVariantBar(state.data.current_item, frontendPlaybackMode(state.data.playback_mode));
     }
     return;
   }
@@ -4732,7 +4740,7 @@ elements.audioVariantBar.addEventListener("click", async (event) => {
   const video = elements.playerFrame.querySelector("video");
   state.audioVariantSwitchInFlight = true;
   state.audioVariantSwitchUnlockAt = Date.now() + audioVariantSwitchDebounceMs;
-  renderAudioVariantBar(currentItem, state.data?.playback_mode);
+  renderAudioVariantBar(currentItem, frontendPlaybackMode(state.data?.playback_mode));
   state.pendingPlaybackRestore = {
     itemId: currentItem.id,
     variantId: nextVariantId,

--- a/static/index.html
+++ b/static/index.html
@@ -643,7 +643,7 @@
             <p class="section-tag">Part Binding</p>
             <h2>选择分P绑定</h2>
           </div>
-          <button type="button" id="binding-modal-close" class="banner-close" aria-label="关闭">x</button>
+          <button type="button" id="binding-modal-close" class="banner-close" aria-label="关闭">×</button>
         </div>
         <p class="selection-modal-text" id="binding-modal-text">请选择要下载的视频分P和音频分P。</p>
         <div class="selection-modal-grid">

--- a/static/index.html
+++ b/static/index.html
@@ -174,10 +174,11 @@
                   重新生成二维码
                 </button>
               </div>
-              <div class="cache-panel-row cache-panel-mode-row">
+              <!-- LEGACY: 在线外挂模式暂时下线，保留元素 id 仅避免旧脚本引用失效。 -->
+              <div class="cache-panel-row cache-panel-mode-row hidden" aria-hidden="true">
                 <div>
                   <p class="cache-panel-label">播放模式</p>
-                  <p class="cache-panel-hint">⚠️在线外挂仅作为备用</p>
+                  <p class="cache-panel-hint">本地缓存</p>
                 </div>
                 <div class="cache-mode-control">
                   <span id="playback-mode-current">本地缓存</span>

--- a/static/index.html
+++ b/static/index.html
@@ -228,16 +228,25 @@
               <div class="cache-panel-row cache-panel-update-row">
                 <div>
                   <p class="cache-panel-label">应用更新</p>
-                  <p class="cache-panel-hint">从 GitHub Releases 获取新版本</p>
+                  <p class="cache-panel-hint">默认检查正式版</p>
                 </div>
-                <button
-                  type="button"
-                  class="toolbar-button cache-update-button"
-                  id="update-check-button"
-                  title="检查 bilikara 新版本"
-                >
-                  检查更新
-                </button>
+                <div class="cache-update-control">
+                  <label class="cache-preview-field" for="update-preview-checkbox" title="同时检查预览版 Release">
+                    <span>预览版</span>
+                    <input id="update-preview-checkbox" type="checkbox" />
+                    <span class="cache-preview-switch" aria-hidden="true">
+                      <span class="cache-preview-switch-thumb"></span>
+                    </span>
+                  </label>
+                  <button
+                    type="button"
+                    class="toolbar-button cache-update-button"
+                    id="update-check-button"
+                    title="检查 bilikara 新版本"
+                  >
+                    检查更新
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/static/remote.js
+++ b/static/remote.js
@@ -923,13 +923,14 @@ function render() {
   if (!data) {
     return;
   }
+  const playbackMode = frontendPlaybackMode(data.playback_mode);
 
   renderRequesterSelect(data.session_users || []);
-  renderCurrentItem(data.current_item, data.playback_mode);
-  renderAudioVariantBar(data.current_item, data.playback_mode);
-  renderPlayerControls(data.current_item, data.playback_mode);
-  renderRemoteAvSyncControls(data.playback_mode, data.player_settings);
-  renderRemoteVolumeControls(data.playback_mode, data.player_settings);
+  renderCurrentItem(data.current_item, playbackMode);
+  renderAudioVariantBar(data.current_item, playbackMode);
+  renderPlayerControls(data.current_item, playbackMode);
+  renderRemoteAvSyncControls(playbackMode, data.player_settings);
+  renderRemoteVolumeControls(playbackMode, data.player_settings);
   renderRemoteAccess(data.remote_access);
   renderFollowBrowse();
   renderListHeader(data.playlist || [], data.history || []);
@@ -938,6 +939,10 @@ function render() {
   syncListView();
   renderLayoutMode();
   renderGatchaUidView();
+}
+
+function frontendPlaybackMode(_mode) {
+  return "local";
 }
 
 function renderRequesterSelect(sessionUsers) {
@@ -973,7 +978,7 @@ function renderCurrentItem(current, playbackMode) {
     const requesterText = requesterBadgeText(current.requester_name);
     elements.currentRequester.textContent = requesterText;
     elements.currentRequester.classList.toggle("hidden", !requesterText);
-    const modeLabel = playbackMode === "online" ? "在线外挂" : "本地缓存";
+    const modeLabel = "本地缓存";
     const cacheText = current.cache_message || "等待缓存";
     elements.currentMeta.textContent = `${modeLabel} · ${cacheText}`;
     return;
@@ -1086,7 +1091,7 @@ function scheduleAudioVariantSwitchUnlock() {
     state.audioVariantSwitchUnlockAt = 0;
     state.audioVariantSwitchTimer = null;
     if (state.data) {
-      renderAudioVariantBar(state.data.current_item, state.data.playback_mode);
+      renderAudioVariantBar(state.data.current_item, frontendPlaybackMode(state.data.playback_mode));
     }
   }, remainingMs);
 }
@@ -1442,7 +1447,7 @@ async function setRemoteAvOffset(offsetMs) {
   if (elements.remoteAvOffsetInput) {
     elements.remoteAvOffsetInput.value = String(boundedOffsetMs);
   }
-  renderRemoteAvSyncControls(state.data?.playback_mode, state.data?.player_settings);
+  renderRemoteAvSyncControls(frontendPlaybackMode(state.data?.playback_mode), state.data?.player_settings);
   try {
     const nextData = await apiPost("/api/player/av-offset", { offset_ms: boundedOffsetMs });
     if (requestSeq !== state.remoteAvOffsetSaveSeq) {
@@ -1456,7 +1461,7 @@ async function setRemoteAvOffset(offsetMs) {
     state.remoteLocalAvOffsetMs = null;
     state.remoteAvOffsetEchoSuppressUntil = 0;
     setFormMessage(error.message, true);
-    renderRemoteAvSyncControls(state.data?.playback_mode, state.data?.player_settings);
+    renderRemoteAvSyncControls(frontendPlaybackMode(state.data?.playback_mode), state.data?.player_settings);
   }
 }
 
@@ -1483,7 +1488,7 @@ async function commitRemoteVolumeSettings(payload, requestSeq) {
     state.remoteLocalMuted = null;
     state.remoteSettingsEchoSuppressUntil = 0;
     setFormMessage(error.message, true);
-    renderRemoteVolumeControls(state.data?.playback_mode, state.data?.player_settings);
+    renderRemoteVolumeControls(frontendPlaybackMode(state.data?.playback_mode), state.data?.player_settings);
   }
 }
 
@@ -1504,7 +1509,7 @@ async function setRemoteVolumeSettings({ volumePercent, isMuted } = {}, options 
   }
 
   const requestSeq = markRemoteVolumeWrite(payload);
-  renderRemoteVolumeControls(state.data?.playback_mode, state.data?.player_settings);
+  renderRemoteVolumeControls(frontendPlaybackMode(state.data?.playback_mode), state.data?.player_settings);
   if (options.debounce) {
     clearRemoteVolumeCommitTimer();
     state.remoteVolumeCommitTimer = window.setTimeout(() => {
@@ -1574,7 +1579,7 @@ function renderPlayerControls(currentItem, playbackMode) {
   }
 
   if (playbackMode !== "local") {
-    elements.playerControlHint.textContent = "当前是在线外挂，暂不支持远程控制播放。";
+    elements.playerControlHint.textContent = "当前模式暂不支持远程控制播放。";
     return;
   }
   if (!hasLocalSplitMedia(currentItem)) {
@@ -1840,7 +1845,7 @@ async function addByUrl(url, position = "tail") {
 
 async function sendPlayerControl(action, deltaSeconds = 0) {
   const currentItem = state.data?.current_item;
-  const playbackMode = state.data?.playback_mode;
+  const playbackMode = frontendPlaybackMode(state.data?.playback_mode);
   if (!currentItem || !canRemoteControlPlayer(currentItem, playbackMode)) {
     return;
   }
@@ -1875,7 +1880,7 @@ async function sendPlayerControl(action, deltaSeconds = 0) {
     await fetchState().catch(() => {});
   }
   state.playerControlPendingAction = "";
-  renderPlayerControls(state.data?.current_item, state.data?.playback_mode);
+  renderPlayerControls(state.data?.current_item, frontendPlaybackMode(state.data?.playback_mode));
 }
 
 async function sendPlayerNext() {
@@ -1884,7 +1889,7 @@ async function sendPlayerNext() {
   }
   try {
     state.playerControlPendingAction = "next-track";
-    renderPlayerControls(state.data?.current_item, state.data?.playback_mode);
+    renderPlayerControls(state.data?.current_item, frontendPlaybackMode(state.data?.playback_mode));
     applyStateSnapshot(await apiPost("/api/player/next"));
     setFormMessage("已切到下一首。");
   } catch (error) {
@@ -1892,7 +1897,7 @@ async function sendPlayerNext() {
     await fetchState().catch(() => {});
   }
   state.playerControlPendingAction = "";
-  renderPlayerControls(state.data?.current_item, state.data?.playback_mode);
+  renderPlayerControls(state.data?.current_item, frontendPlaybackMode(state.data?.playback_mode));
 }
 
 function queueNoteText() {
@@ -2160,7 +2165,7 @@ elements.audioVariantBar.addEventListener("click", async (event) => {
   if (toggleButton) {
     state.audioVariantBarExpanded = !state.audioVariantBarExpanded;
     if (state.data?.current_item) {
-      renderAudioVariantBar(state.data.current_item, state.data.playback_mode);
+      renderAudioVariantBar(state.data.current_item, frontendPlaybackMode(state.data.playback_mode));
     }
     return;
   }
@@ -2222,7 +2227,7 @@ elements.audioVariantBar.addEventListener("click", async (event) => {
   try {
     state.audioVariantSwitchInFlight = true;
     state.audioVariantSwitchUnlockAt = Date.now() + audioVariantSwitchDebounceMs;
-    renderAudioVariantBar(currentItem, state.data?.playback_mode);
+    renderAudioVariantBar(currentItem, frontendPlaybackMode(state.data?.playback_mode));
     applyStateSnapshot(await apiPost("/api/player/audio-variant", {
       item_id: currentItem.id,
       variant_id: nextVariantId,

--- a/static/styles.css
+++ b/static/styles.css
@@ -845,13 +845,16 @@ h2 {
 .cache-retry-current-button,
 .cache-update-button,
 .cache-data-reset-button {
+  --cache-control-height: 30px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   min-width: 0;
-  padding: 7px 12px;
+  min-height: var(--cache-control-height);
+  padding: 0 12px;
   font-size: 12px;
   font-weight: 700;
+  line-height: 1;
   border-radius: 999px;
 }
 
@@ -863,6 +866,83 @@ h2 {
   flex: 0 0 auto;
 }
 
+.cache-update-control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex: 0 0 auto;
+}
+
+.cache-preview-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.cache-preview-field input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.cache-preview-switch,
+.cache-hires-switch {
+  --cache-switch-width: 48px;
+  --cache-switch-height: 30px;
+  --cache-switch-thumb: 24px;
+  --cache-switch-travel: 18px;
+  width: var(--cache-switch-width);
+  height: var(--cache-switch-height);
+  padding: 3px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  background: rgba(109, 98, 88, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(87, 63, 43, 0.08);
+  transition:
+    background 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.cache-preview-switch-thumb,
+.cache-hires-switch-thumb {
+  width: var(--cache-switch-thumb);
+  height: var(--cache-switch-thumb);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 6px 14px rgba(88, 56, 30, 0.14);
+  transform: translateX(0);
+  transition: transform 180ms ease;
+}
+
+.cache-preview-field input:checked + .cache-preview-switch,
+.cache-hires-field input:checked + .cache-hires-switch {
+  background: rgba(208, 90, 63, 0.78);
+  box-shadow:
+    inset 0 0 0 1px rgba(208, 90, 63, 0.2),
+    0 8px 18px rgba(208, 90, 63, 0.12);
+}
+
+.cache-preview-field input:checked + .cache-preview-switch .cache-preview-switch-thumb,
+.cache-hires-field input:checked + .cache-hires-switch .cache-hires-switch-thumb {
+  transform: translateX(var(--cache-switch-travel));
+}
+
+.cache-preview-field input:focus-visible + .cache-preview-switch,
+.cache-hires-field input:focus-visible + .cache-hires-switch {
+  box-shadow:
+    inset 0 0 0 1px rgba(208, 90, 63, 0.28),
+    0 0 0 4px rgba(208, 90, 63, 0.1);
+}
+
 .cache-mode-toggle {
   background: var(--accent);
   color: white;
@@ -871,6 +951,7 @@ h2 {
 .cache-update-button {
   background: var(--accent);
   color: white;
+  min-width: 72px;
 }
 
 .cache-retry-current-button {
@@ -1053,48 +1134,6 @@ h2 {
   position: absolute;
   opacity: 0;
   pointer-events: none;
-}
-
-.cache-hires-switch {
-  width: 68px;
-  height: 34px;
-  padding: 3px;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  background: rgba(109, 98, 88, 0.12);
-  box-shadow: inset 0 0 0 1px rgba(87, 63, 43, 0.08);
-  transition:
-    background 180ms ease,
-    box-shadow 180ms ease;
-}
-
-.cache-hires-switch-thumb {
-  width: 28px;
-  height: 28px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.96);
-  box-shadow: 0 6px 14px rgba(88, 56, 30, 0.14);
-  transform: translateX(0);
-  transition: transform 180ms ease;
-}
-
-.cache-hires-field input:checked + .cache-hires-switch {
-  background: rgba(208, 90, 63, 0.78);
-  box-shadow:
-    inset 0 0 0 1px rgba(208, 90, 63, 0.2),
-    0 8px 18px rgba(208, 90, 63, 0.12);
-}
-
-.cache-hires-field input:checked + .cache-hires-switch .cache-hires-switch-thumb {
-  transform: translateX(34px);
-}
-
-.cache-hires-field input:focus-visible + .cache-hires-switch {
-  box-shadow:
-    inset 0 0 0 1px rgba(208, 90, 63, 0.28),
-    0 0 0 4px rgba(208, 90, 63, 0.1);
 }
 
 .cache-hires-field input:disabled + .cache-hires-switch {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -228,11 +228,37 @@ class UpdateRouteTest(unittest.TestCase):
                 "release_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.4.1",
                 "update_available": True,
             },
-        ):
+        ) as update_check:
             handler.do_GET()
 
         self.assertEqual(writes[0]["ok"], True)
         self.assertTrue(writes[0]["data"]["update_available"])
+        update_check.assert_called_once_with(include_preview=False)
+
+    def test_update_check_route_can_include_preview_releases(self):
+        handler = BilikaraHandler.__new__(BilikaraHandler)
+        writes: list[dict] = []
+        context = SimpleNamespace(touch_client=lambda client_id, is_host=True: None)
+
+        handler.path = "/api/app/update?include_preview=1"
+        handler.headers = {}
+        handler._write_json = lambda payload, status=None: writes.append(payload)
+
+        with patch("bilikara.server.CONTEXT", context), patch(
+            "bilikara.server.check_for_update",
+            return_value={
+                "current_version": "v0.4.0",
+                "latest_version": "v0.5.0-preview.1",
+                "release_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.5.0-preview.1",
+                "update_available": True,
+                "include_preview": True,
+            },
+        ) as update_check:
+            handler.do_GET()
+
+        self.assertEqual(writes[0]["ok"], True)
+        self.assertTrue(writes[0]["data"]["include_preview"])
+        update_check.assert_called_once_with(include_preview=True)
 
 
 class PlayerResetRouteTest(unittest.TestCase):

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -366,6 +366,53 @@ class PlaylistStoreTest(unittest.TestCase):
 
         self.assertEqual(restored_store.session_played, [])
 
+    def test_restore_backup_continues_existing_played_session_archive(self):
+        self.add_item("a", requester_name="A", song_key="song-a")
+        self.add_item("b", requester_name="B", song_key="song-b")
+        original_played_file = self.store.session_played_file
+        backup_payload = json.loads(self.backup_file.read_text(encoding="utf-8"))
+        self.assertEqual(backup_payload["played_session"]["file"], original_played_file.name)
+
+        restored_store = PlaylistStore(
+            state_file=self.state_file,
+            backup_file=self.backup_file,
+            session_archive_dir=self.session_archive_dir,
+        )
+
+        self.assertTrue(restored_store.restore_backup())
+        self.assertEqual(restored_store.session_played_file, original_played_file)
+        self.assertEqual([entry.item_id for entry in restored_store.session_played], ["a"])
+
+        restored_store.mark_item_playback_started("a")
+        restored_store.advance_to_next()
+
+        payload = json.loads(original_played_file.read_text(encoding="utf-8"))
+        self.assertEqual([entry["item_id"] for entry in payload["items"]], ["a", "b"])
+
+    def test_discard_restored_backup_starts_new_played_session_archive(self):
+        self.add_item("a", requester_name="A", song_key="song-a")
+        original_played_file = self.store.session_played_file
+
+        restored_store = PlaylistStore(
+            state_file=self.state_file,
+            backup_file=self.backup_file,
+            session_archive_dir=self.session_archive_dir,
+        )
+        self.assertTrue(restored_store.restore_backup())
+        self.assertEqual(restored_store.session_played_file, original_played_file)
+
+        with patch("bilikara.store.time.time", return_value=self.store.session_started_at + 60):
+            self.assertTrue(restored_store.discard_backup())
+        self.assertEqual(restored_store.session_played, [])
+        self.assertNotEqual(restored_store.session_played_file, original_played_file)
+
+        restored_store.add_item(self.make_item("c", song_key="song-c"), requester_name="C")
+
+        new_payload = json.loads(restored_store.session_played_file.read_text(encoding="utf-8"))
+        old_payload = json.loads(original_played_file.read_text(encoding="utf-8"))
+        self.assertEqual([entry["item_id"] for entry in new_payload["items"]], ["c"])
+        self.assertEqual([entry["item_id"] for entry in old_payload["items"]], ["a"])
+
     def test_active_duplicate_for_item_matches_current_or_playlist(self):
         first = self.make_item("a", song_key="song-a")
         second = self.make_item("b", song_key="song-b")

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -39,6 +39,21 @@ class PlaylistStoreTest(unittest.TestCase):
     def test_default_mode_is_local(self):
         self.assertEqual(self.store.playback_mode, "local")
 
+    def test_online_mode_from_player_state_restores_as_local(self):
+        player_state_file = self.state_file.parent / "player_state.json"
+        player_state_file.write_text(
+            json.dumps({"playback_mode": "online"}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        restored_store = PlaylistStore(
+            state_file=self.state_file,
+            backup_file=self.backup_file,
+            session_archive_dir=self.session_archive_dir,
+        )
+
+        self.assertEqual(restored_store.playback_mode, "local")
+
     def test_av_offset_persists_in_player_state_file(self):
         self.store.set_av_offset_ms(230)
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -7,11 +7,16 @@ class UpdateCheckTest(unittest.TestCase):
     def test_version_tuple_accepts_release_tags(self):
         self.assertEqual(version_tuple("v0.4.1"), (0, 4, 1))
         self.assertEqual(version_tuple("0.4.1"), (0, 4, 1))
+        self.assertEqual(version_tuple("v0.5.0-preview.1"), (0, 5, 0))
         self.assertIsNone(version_tuple("v0.4.1-2-gabc123"))
 
     def test_is_newer_version_compares_semver_tags(self):
         self.assertTrue(is_newer_version("v0.4.1", "v0.4.0"))
+        self.assertTrue(is_newer_version("v0.5.0-preview.2", "v0.5.0-preview.1"))
+        self.assertTrue(is_newer_version("v0.5.0", "v0.5.0-preview.2"))
+        self.assertTrue(is_newer_version("v0.5.1", "v0.5.0-preview.2"))
         self.assertFalse(is_newer_version("v0.4.0", "v0.4.0"))
+        self.assertFalse(is_newer_version("v0.5.0-preview.2", "v0.5.0"))
         self.assertFalse(is_newer_version("v0.4.0", "dev"))
 
     def test_check_for_update_reports_release_link(self):
@@ -43,6 +48,84 @@ class UpdateCheckTest(unittest.TestCase):
         self.assertFalse(result["update_available"])
         self.assertTrue(result["switch_to_release_available"])
         self.assertIn("非正式版", result["message"])
+
+    def test_stable_current_ignores_newer_preview_release(self):
+        result = check_for_update(
+            current_version="v0.4.0",
+            release_fetcher=lambda: [
+                {
+                    "tag_name": "v0.5.0-preview.1",
+                    "html_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.5.0-preview.1",
+                    "prerelease": True,
+                },
+                {
+                    "tag_name": "v0.4.0",
+                    "html_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.4.0",
+                },
+            ],
+        )
+
+        self.assertEqual(result["latest_version"], "v0.4.0")
+        self.assertFalse(result["update_available"])
+
+    def test_preview_current_updates_to_newer_preview(self):
+        result = check_for_update(
+            current_version="v0.5.0-preview.1",
+            release_fetcher=lambda: [
+                {
+                    "tag_name": "v0.5.0-preview.2",
+                    "html_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.5.0-preview.2",
+                    "prerelease": True,
+                },
+                {
+                    "tag_name": "v0.4.0",
+                    "html_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.4.0",
+                },
+            ],
+        )
+
+        self.assertEqual(result["latest_version"], "v0.5.0-preview.2")
+        self.assertTrue(result["update_available"])
+        self.assertIn("预览版", result["message"])
+
+    def test_preview_current_updates_to_stable_release(self):
+        result = check_for_update(
+            current_version="v0.5.0-preview.2",
+            release_fetcher=lambda: [
+                {
+                    "tag_name": "v0.5.0",
+                    "html_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.5.0",
+                },
+                {
+                    "tag_name": "v0.5.0-preview.2",
+                    "html_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.5.0-preview.2",
+                    "prerelease": True,
+                },
+            ],
+        )
+
+        self.assertEqual(result["latest_version"], "v0.5.0")
+        self.assertTrue(result["update_available"])
+        self.assertIn("正式版", result["message"])
+
+    def test_preview_current_updates_to_newer_stable_minor(self):
+        result = check_for_update(
+            current_version="v0.5.0-preview.2",
+            release_fetcher=lambda: [
+                {
+                    "tag_name": "v0.5.1",
+                    "html_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.5.1",
+                },
+                {
+                    "tag_name": "v0.5.0-preview.2",
+                    "html_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.5.0-preview.2",
+                    "prerelease": True,
+                },
+            ],
+        )
+
+        self.assertEqual(result["latest_version"], "v0.5.1")
+        self.assertTrue(result["update_available"])
 
 
 if __name__ == "__main__":

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,6 +1,8 @@
 import unittest
+import urllib.error
+from unittest.mock import patch
 
-from bilikara.updater import check_for_update, is_newer_version, version_tuple
+from bilikara.updater import check_for_update, fetch_latest_release, is_newer_version, version_tuple
 
 
 class UpdateCheckTest(unittest.TestCase):
@@ -35,6 +37,16 @@ class UpdateCheckTest(unittest.TestCase):
         self.assertEqual(result["latest_version"], "v0.4.1")
         self.assertEqual(result["release_url"], "https://github.com/VZRXS/bilikara/releases/tag/v0.4.1")
 
+    def test_fetch_latest_release_reports_timeout_error(self):
+        with patch("bilikara.updater.urllib.request.urlopen", side_effect=TimeoutError):
+            with self.assertRaisesRegex(RuntimeError, "连接 GitHub Releases 超时"):
+                fetch_latest_release()
+
+    def test_fetch_latest_release_reports_network_error(self):
+        with patch("bilikara.updater.urllib.request.urlopen", side_effect=urllib.error.URLError("offline")):
+            with self.assertRaisesRegex(RuntimeError, "无法连接 GitHub Releases"):
+                fetch_latest_release()
+
     def test_check_for_update_offers_switch_for_non_release_build(self):
         result = check_for_update(
             current_version="v0.4.0-8-gabcdef-dirty",
@@ -68,9 +80,31 @@ class UpdateCheckTest(unittest.TestCase):
         self.assertEqual(result["latest_version"], "v0.4.0")
         self.assertFalse(result["update_available"])
 
+    def test_stable_current_can_opt_into_preview_release_check(self):
+        result = check_for_update(
+            current_version="v0.4.0",
+            include_preview=True,
+            release_fetcher=lambda: [
+                {
+                    "tag_name": "v0.5.0-preview.1",
+                    "html_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.5.0-preview.1",
+                    "prerelease": True,
+                },
+                {
+                    "tag_name": "v0.4.0",
+                    "html_url": "https://github.com/VZRXS/bilikara/releases/tag/v0.4.0",
+                },
+            ],
+        )
+
+        self.assertEqual(result["latest_version"], "v0.5.0-preview.1")
+        self.assertTrue(result["update_available"])
+        self.assertTrue(result["include_preview"])
+
     def test_preview_current_updates_to_newer_preview(self):
         result = check_for_update(
             current_version="v0.5.0-preview.1",
+            include_preview=True,
             release_fetcher=lambda: [
                 {
                     "tag_name": "v0.5.0-preview.2",
@@ -91,6 +125,7 @@ class UpdateCheckTest(unittest.TestCase):
     def test_preview_current_updates_to_stable_release(self):
         result = check_for_update(
             current_version="v0.5.0-preview.2",
+            include_preview=True,
             release_fetcher=lambda: [
                 {
                     "tag_name": "v0.5.0",
@@ -111,6 +146,7 @@ class UpdateCheckTest(unittest.TestCase):
     def test_preview_current_updates_to_newer_stable_minor(self):
         result = check_for_update(
             current_version="v0.5.0-preview.2",
+            include_preview=True,
             release_fetcher=lambda: [
                 {
                     "tag_name": "v0.5.1",


### PR DESCRIPTION
- 增加应用更新检测能力，支持正式版 / preview 版判断，并在服务设置中加入“预览版”开关。
- 为 GitHub Releases 检查增加前后端超时保护，避免网络异常时按钮长期卡在“检查中”。
- 改进版本号解析，支持 `v0.5.0-preview.1` 这类 preview 版本比较。
- 改进 `played_sessions` 策略：自动恢复备份时继续原本场次记录，清空恢复备份后开启新场次记录。
- 修复关闭按钮 `x`/`×` 表示不统一的问题。
- 下线前端在线外挂入口，前端统一使用本地缓存模式；后端 `/api/mode` 和 legacy 分支保留。
- 调整服务设置 UI：更新检测开关、Hi-Res 开关尺寸统一，检查更新按钮宽度稳定。

## 兼容性说明

- 后端在线外挂相关接口暂时保留，避免旧状态或旧调用直接失效。
- 如果旧 `player_state.json` 中保存了 `online`，新版启动后会恢复为 `local`。
- 默认只检查正式版 latest；开启“预览版”开关后才检查 pre-release。