### PR TITLE
fix: 优化歌单导出与 remote 控制界面

### DIFF
--- a/bilikara/history_export.py
+++ b/bilikara/history_export.py
@@ -16,7 +16,7 @@ _BV_RE = re.compile(r"(BV[0-9A-Za-z]+)", re.IGNORECASE)
 _AV_RE = re.compile(r"(av\d+)", re.IGNORECASE)
 
 
-def history_csv_bytes(history: list[dict[str, Any]]) -> bytes:
+def history_csv_bytes(history: list[dict[str, Any]], *, time_header: str = "点歌时间") -> bytes:
     ordered_history = _history_in_export_order(history)
     buffer = io.StringIO()
     writer = csv.DictWriter(
@@ -29,7 +29,7 @@ def history_csv_bytes(history: list[dict[str, Any]]) -> bytes:
             "UP主",
             "UP主UID",
             "点歌次数",
-            "点歌时间",
+            time_header,
             "视频链接",
             "原始链接",
             "分P/版本",
@@ -47,7 +47,7 @@ def history_csv_bytes(history: list[dict[str, Any]]) -> bytes:
                 "UP主": _text(entry.get("owner_name")),
                 "UP主UID": _text(entry.get("owner_mid")),
                 "点歌次数": _request_count(entry),
-                "点歌时间": _format_time(entry.get("requested_at")),
+                time_header: _format_time(entry.get("requested_at")),
                 "视频链接": _text(entry.get("resolved_url")),
                 "原始链接": _text(entry.get("original_url")),
                 "分P/版本": _text(entry.get("part_title")),
@@ -60,6 +60,7 @@ def history_image_export(
     history: list[dict[str, Any]],
     *,
     logo_path: Path | None = None,
+    title: str = "Bilikara 点歌历史",
 ) -> tuple[bytes, str, str]:
     try:
         from PIL import Image, ImageDraw, ImageFont
@@ -78,6 +79,7 @@ def history_image_export(
             page_count=len(pages),
             total_count=len(ordered_history),
             logo_path=logo_path,
+            title=title,
             image_module=Image,
             draw_module=ImageDraw,
             font_module=ImageFont,
@@ -106,6 +108,7 @@ def _render_history_page(
     page_count: int,
     total_count: int,
     logo_path: Path | None,
+    title: str,
     image_module: Any,
     draw_module: Any,
     font_module: Any,
@@ -125,8 +128,8 @@ def _render_history_page(
     small_font = _load_font(font_module, 21)
     footer_font = _load_font(font_module, 23, bold=True)
 
-    draw.text((90, 78), "Bilikara 点歌历史", fill="#2A213B", font=title_font)
-    draw.text((84, 72), "Bilikara 点歌历史", fill="#FFF7E6", font=title_font)
+    draw.text((90, 78), title, fill="#2A213B", font=title_font)
+    draw.text((84, 72), title, fill="#FFF7E6", font=title_font)
     subtitle = f"共 {total_count} 首 · 第 {page_number}/{page_count} 页 · {datetime.now().strftime('%Y-%m-%d %H:%M')}"
     draw.text((88, 154), subtitle, fill="#F7B98A", font=subtitle_font)
 
@@ -245,9 +248,23 @@ def _draw_qr(draw: Any, matrix: list[list[bool]], *, x: int, y: int, size: int) 
 def _load_font(font_module: Any, size: int, *, bold: bool = False) -> Any:
     candidates = [
         "C:/Windows/Fonts/msyhbd.ttc" if bold else "C:/Windows/Fonts/msyh.ttc",
+        "C:/Windows/Fonts/Dengb.ttf" if bold else "C:/Windows/Fonts/Deng.ttf",
         "C:/Windows/Fonts/simhei.ttf",
+        "C:/Windows/Fonts/simsun.ttc",
         "/System/Library/Fonts/PingFang.ttc",
+        "/System/Library/Fonts/STHeiti Medium.ttc",
+        "/System/Library/Fonts/Supplemental/Songti.ttc",
+        "/System/Library/Fonts/Supplemental/Arial Unicode.ttf",
+        "/Library/Fonts/Arial Unicode.ttf",
+        "/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc" if bold else "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
         "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc" if bold else "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",
+        "/usr/share/fonts/opentype/source-han-sans/SourceHanSansSC-Bold.otf" if bold else "/usr/share/fonts/opentype/source-han-sans/SourceHanSansSC-Regular.otf",
+        "/usr/share/fonts/truetype/wqy/wqy-microhei.ttc",
+        "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc",
+        "/usr/share/fonts/truetype/arphic/uming.ttc",
+        "/usr/share/fonts/truetype/arphic/ukai.ttc",
         "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf" if bold else "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
     ]
     for candidate in candidates:

--- a/bilikara/history_export.py
+++ b/bilikara/history_export.py
@@ -114,32 +114,27 @@ def _render_history_page(
     font_module: Any,
 ) -> Any:
     width, height = 1600, 2200
-    image = image_module.new("RGB", (width, height), "#101018")
+    image = image_module.new("RGB", (width, height), "#F6EFE3")
     draw = draw_module.Draw(image)
 
     _draw_gradient(draw, width, height)
-    _draw_glow(draw, width, height)
-    _draw_neon_details(draw, width, height)
 
-    title_font = _load_font(font_module, 66, bold=True)
-    subtitle_font = _load_font(font_module, 28)
+    title_font = _load_font(font_module, 72, bold=True)
+    subtitle_font = _load_font(font_module, 27)
     header_font = _load_font(font_module, 25, bold=True)
     row_font = _load_font(font_module, 24)
-    small_font = _load_font(font_module, 21)
-    footer_font = _load_font(font_module, 23, bold=True)
+    footer_font = _load_font(font_module, 22)
 
-    draw.text((90, 78), title, fill="#2A213B", font=title_font)
-    draw.text((84, 72), title, fill="#FFF7E6", font=title_font)
+    draw.text((86, 72), "BILIKARA", fill="#8B7B6D", font=subtitle_font)
+    draw.text((84, 112), title, fill="#1F1A16", font=title_font)
     subtitle = f"共 {total_count} 首 · 第 {page_number}/{page_count} 页 · {datetime.now().strftime('%Y-%m-%d %H:%M')}"
-    draw.text((88, 154), subtitle, fill="#F7B98A", font=subtitle_font)
-
-    _draw_logo(image, logo_path, image_module, size=168, position=(1348, 52))
+    draw.text((88, 206), subtitle, fill="#77695E", font=subtitle_font)
 
     table_x = 70
-    table_y = 245
+    table_y = 292
     table_w = width - table_x * 2
     row_h = 66
-    header_h = 58
+    header_h = 62
     columns = [
         ("#", 64),
         ("标题", 564),
@@ -149,18 +144,20 @@ def _render_history_page(
         ("时间", 280),
     ]
 
-    _rounded_rectangle(draw, (table_x, table_y, table_x + table_w, table_y + header_h), 24, "#252036")
-    draw.line((table_x + 28, table_y + header_h - 2, table_x + table_w - 28, table_y + header_h - 2), fill="#5FD6D1", width=2)
+    card_box = (table_x, table_y, table_x + table_w, table_y + header_h + HISTORY_IMAGE_PAGE_SIZE * row_h + 24)
+    _rounded_rectangle(draw, card_box, 34, "#FFFCF7")
+    draw.rounded_rectangle(card_box, radius=34, outline="#EADDD0", width=2)
+    _rounded_rectangle(draw, (table_x + 18, table_y + 18, table_x + table_w - 18, table_y + header_h + 10), 24, "#F5E7DA")
     cursor_x = table_x + 24
     for label, col_w in columns:
-        draw.text((cursor_x, table_y + 11), label, fill="#FFD9A8", font=header_font)
+        draw.text((cursor_x, table_y + 30), label, fill="#8F3E2B", font=header_font)
         cursor_x += col_w
 
     start_index = (page_number - 1) * HISTORY_IMAGE_PAGE_SIZE
     for row_index, entry in enumerate(entries):
         top = table_y + header_h + row_index * row_h
-        bg = "#1B1927" if row_index % 2 == 0 else "#171520"
-        _rounded_rectangle(draw, (table_x, top + 5, table_x + table_w, top + row_h - 5), 18, bg)
+        bg = "#FFFFFF" if row_index % 2 == 0 else "#FBF6EF"
+        _rounded_rectangle(draw, (table_x + 18, top + 9, table_x + table_w - 18, top + row_h - 7), 18, bg)
 
         values = [
             str(start_index + row_index + 1),
@@ -172,27 +169,25 @@ def _render_history_page(
         ]
         cursor_x = table_x + 24
         for col_index, ((_, col_w), value) in enumerate(zip(columns, values)):
-            fill = "#F8F0DF" if col_index in {0, 1} else "#BFC2D6"
+            fill = "#1F1A16" if col_index == 1 else "#6F6258"
+            if col_index == 0:
+                fill = "#8F3E2B"
             clipped = _fit_text(draw, value, row_font, col_w - 18)
-            draw.text((cursor_x, top + 17), clipped, fill=fill, font=row_font)
+            draw.text((cursor_x, top + 20), clipped, fill=fill, font=row_font)
             cursor_x += col_w
 
     footer_y = height - 155
-    draw.line((80, footer_y - 26, width - 80, footer_y - 26), fill="#343044", width=2)
-    draw.text((92, footer_y), PROJECT_URL, fill="#FFE0AC", font=footer_font)
-
-    qr_matrix = _qr_matrix(RELEASES_URL)
-    _draw_qr(draw, qr_matrix, x=width - 230, y=height - 255, size=154)
-    draw.text((width - 198, height - 81), "Releases", fill="#FFF7E6", font=small_font)
+    draw.line((86, footer_y - 28, width - 86, footer_y - 28), fill="#E2D5C8", width=2)
+    draw.text((92, footer_y), PROJECT_URL, fill="#8B7B6D", font=footer_font)
     return image
 
 
 def _draw_gradient(draw: Any, width: int, height: int) -> None:
     for y in range(height):
         t = y / max(1, height - 1)
-        r = int(16 + 23 * t)
-        g = int(16 + 9 * t)
-        b = int(30 + 10 * t)
+        r = int(250 - 7 * t)
+        g = int(244 - 14 * t)
+        b = int(235 - 25 * t)
         draw.line((0, y, width, y), fill=(r, g, b))
 
 

--- a/bilikara/history_export.py
+++ b/bilikara/history_export.py
@@ -8,9 +8,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-HISTORY_IMAGE_PAGE_SIZE = 25
+from .title_cleanup import clean_display_title
+
+HISTORY_IMAGE_PAGE_SIZE = 80
 PROJECT_URL = "https://github.com/VZRXS/bilikara"
-RELEASES_URL = "https://github.com/VZRXS/bilikara/releases"
 
 _BV_RE = re.compile(r"(BV[0-9A-Za-z]+)", re.IGNORECASE)
 _AV_RE = re.compile(r"(av\d+)", re.IGNORECASE)
@@ -113,7 +114,15 @@ def _render_history_page(
     draw_module: Any,
     font_module: Any,
 ) -> Any:
-    width, height = 1600, 2200
+    width = 1600
+    table_y = 292
+    row_h = 104
+    header_h = 62
+    row_count = len(entries)
+    table_h = header_h + row_count * row_h + 24
+    footer_gap = 44
+    footer_h = footer_gap + 154 + 58
+    height = max(760, table_y + table_h + footer_h)
     image = image_module.new("RGB", (width, height), "#F6EFE3")
     draw = draw_module.Draw(image)
 
@@ -125,16 +134,12 @@ def _render_history_page(
     row_font = _load_font(font_module, 24)
     footer_font = _load_font(font_module, 22)
 
-    draw.text((86, 72), "BILIKARA", fill="#8B7B6D", font=subtitle_font)
-    draw.text((84, 112), title, fill="#1F1A16", font=title_font)
+    draw.text((84, 94), title, fill="#1F1A16", font=title_font)
     subtitle = f"共 {total_count} 首 · 第 {page_number}/{page_count} 页 · {datetime.now().strftime('%Y-%m-%d %H:%M')}"
-    draw.text((88, 206), subtitle, fill="#77695E", font=subtitle_font)
+    draw.text((88, 188), subtitle, fill="#77695E", font=subtitle_font)
 
     table_x = 70
-    table_y = 292
     table_w = width - table_x * 2
-    row_h = 66
-    header_h = 62
     columns = [
         ("#", 64),
         ("标题", 564),
@@ -144,7 +149,7 @@ def _render_history_page(
         ("时间", 280),
     ]
 
-    card_box = (table_x, table_y, table_x + table_w, table_y + header_h + HISTORY_IMAGE_PAGE_SIZE * row_h + 24)
+    card_box = (table_x, table_y, table_x + table_w, table_y + table_h)
     _rounded_rectangle(draw, card_box, 34, "#FFFCF7")
     draw.rounded_rectangle(card_box, radius=34, outline="#EADDD0", width=2)
     _rounded_rectangle(draw, (table_x + 18, table_y + 18, table_x + table_w - 18, table_y + header_h + 10), 24, "#F5E7DA")
@@ -161,7 +166,7 @@ def _render_history_page(
 
         values = [
             str(start_index + row_index + 1),
-            _text(entry.get("display_title") or entry.get("title")) or "未命名歌曲",
+            _export_title(entry) or "未命名歌曲",
             _video_id(entry),
             _text(entry.get("requester_name")) or "-",
             _text(entry.get("owner_name")) or "-",
@@ -172,13 +177,23 @@ def _render_history_page(
             fill = "#1F1A16" if col_index == 1 else "#6F6258"
             if col_index == 0:
                 fill = "#8F3E2B"
-            clipped = _fit_text(draw, value, row_font, col_w - 18)
-            draw.text((cursor_x, top + 20), clipped, fill=fill, font=row_font)
+            lines = _wrap_text(draw, value, row_font, col_w - 18, max_lines=3)
+            line_y = top + 17
+            for line in lines:
+                draw.text((cursor_x, line_y), line, fill=fill, font=row_font)
+                line_y += 29
             cursor_x += col_w
 
-    footer_y = height - 155
-    draw.line((86, footer_y - 28, width - 86, footer_y - 28), fill="#E2D5C8", width=2)
-    draw.text((92, footer_y), PROJECT_URL, fill="#8B7B6D", font=footer_font)
+    qr_matrix = _qr_matrix(PROJECT_URL)
+    qr_x = 92
+    qr_y = table_y + table_h + footer_gap
+    qr_size = 154
+    qr_quiet_px = _qr_quiet_zone_pixels(qr_matrix, qr_size)
+    _draw_qr(draw, qr_matrix, x=qr_x, y=qr_y, size=qr_size)
+
+    link_x = qr_x + 190
+    draw.text((link_x, qr_y + 76 - qr_quiet_px // 2), "项目地址", fill="#8F3E2B", font=header_font)
+    draw.text((link_x, qr_y + 118 - qr_quiet_px // 2), PROJECT_URL, fill="#8B7B6D", font=footer_font)
     return image
 
 
@@ -229,7 +244,7 @@ def _draw_qr(draw: Any, matrix: list[list[bool]], *, x: int, y: int, size: int) 
     quiet = 4
     cell = max(1, size // (count + quiet * 2))
     actual = cell * (count + quiet * 2)
-    draw.rounded_rectangle((x, y, x + actual, y + actual), radius=18, fill="#FFF8EC")
+    draw.rectangle((x, y, x + actual, y + actual), fill="#FFFCF7")
     offset = quiet * cell
     for row_index, row in enumerate(matrix):
         for col_index, dark in enumerate(row):
@@ -237,7 +252,14 @@ def _draw_qr(draw: Any, matrix: list[list[bool]], *, x: int, y: int, size: int) 
                 continue
             left = x + offset + col_index * cell
             top = y + offset + row_index * cell
-            draw.rectangle((left, top, left + cell - 1, top + cell - 1), fill="#11131C")
+            draw.rectangle((left, top, left + cell - 1, top + cell - 1), fill="#1F1A16")
+
+
+def _qr_quiet_zone_pixels(matrix: list[list[bool]], size: int) -> int:
+    quiet = 4
+    count = len(matrix)
+    cell = max(1, size // (count + quiet * 2))
+    return quiet * cell
 
 
 def _load_font(font_module: Any, size: int, *, bold: bool = False) -> Any:
@@ -283,6 +305,40 @@ def _fit_text(draw: Any, text: str, font: Any, max_width: int) -> str:
     return value + ellipsis if value else ellipsis
 
 
+def _wrap_text(draw: Any, text: str, font: Any, max_width: int, *, max_lines: int) -> list[str]:
+    value = _text(text)
+    if not value:
+        return [""]
+
+    lines: list[str] = []
+    current = ""
+    for char in value:
+        candidate = current + char
+        if current and draw.textlength(candidate, font=font) > max_width:
+            lines.append(current)
+            current = char
+            if len(lines) >= max_lines:
+                break
+        else:
+            current = candidate
+
+    if len(lines) < max_lines and current:
+        lines.append(current)
+
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+
+    consumed = "".join(lines)
+    if len(consumed) < len(value) and lines:
+        ellipsis = "..."
+        last_line = lines[-1].rstrip()
+        while last_line and draw.textlength(last_line + ellipsis, font=font) > max_width:
+            last_line = last_line[:-1]
+        lines[-1] = f"{last_line}{ellipsis}" if last_line else ellipsis
+
+    return lines or [""]
+
+
 def _rounded_rectangle(draw: Any, box: tuple[int, int, int, int], radius: int, fill: str) -> None:
     draw.rounded_rectangle(box, radius=radius, fill=fill)
 
@@ -308,6 +364,14 @@ def _video_id(entry: dict[str, Any]) -> str:
         if match:
             return match.group(1)
     return ""
+
+
+def _export_title(entry: dict[str, Any]) -> str:
+    return clean_display_title(
+        title=_text(entry.get("title")),
+        display_title=_text(entry.get("display_title")),
+        part_title=_text(entry.get("part_title")),
+    )
 
 
 def _text(value: object) -> str:

--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -152,6 +152,9 @@ class AppContext:
         history = self.store.snapshot().get("history") or []
         return list(history) if isinstance(history, list) else []
 
+    def session_played_snapshot(self) -> list[dict]:
+        return self.store.session_played_snapshot()
+
     def move_item(self, item_id: str, direction: str) -> None:
         self.store.move_item(item_id, direction)
         self.cache_manager.sync_with_playlist()
@@ -572,23 +575,43 @@ class BilikaraHandler(BaseHTTPRequestHandler):
         if route == "/api/history/export":
             query = parse_qs(urlparse(self.path).query)
             export_format = str(query.get("format", ["csv"])[0] or "csv").strip().lower()
+            export_source = str(query.get("source", ["history"])[0] or "history").strip().lower()
+            source_settings = {
+                "history": {
+                    "items": lambda: CONTEXT.history_snapshot(),
+                    "filename": "history",
+                    "title": "Bilikara 点歌历史",
+                    "time_header": "点歌时间",
+                },
+                "played": {
+                    "items": lambda: CONTEXT.session_played_snapshot(),
+                    "filename": "played",
+                    "title": "Bilikara 本场已唱",
+                    "time_header": "播放时间",
+                },
+            }
+            if export_source not in source_settings:
+                self._write_json({"ok": False, "error": "source must be history or played"}, status=HTTPStatus.BAD_REQUEST)
+                return
+            settings = source_settings[export_source]
             timestamp = time.strftime("%Y%m%d-%H%M%S")
             try:
-                history = CONTEXT.history_snapshot()
+                history = settings["items"]()
                 if export_format == "csv":
                     self._write_download(
-                        history_csv_bytes(history),
+                        history_csv_bytes(history, time_header=str(settings["time_header"])),
                         content_type="text/csv; charset=utf-8",
-                        filename=f"bilikara-history-{timestamp}.csv",
+                        filename=f"bilikara-{settings['filename']}-{timestamp}.csv",
                     )
                     return
                 if export_format == "image":
                     payload, content_type, default_filename = history_image_export(
                         history,
                         logo_path=_history_export_logo_path(),
+                        title=str(settings["title"]),
                     )
                     suffix = Path(default_filename).suffix or ".png"
-                    filename = f"bilikara-history-{timestamp}{suffix}"
+                    filename = f"bilikara-{settings['filename']}-{timestamp}{suffix}"
                     self._write_download(payload, content_type=content_type, filename=filename)
                     return
                 raise ValueError("format must be csv or image")

--- a/bilikara/store.py
+++ b/bilikara/store.py
@@ -442,6 +442,13 @@ class PlaylistStore:
                     return PlaylistItem.from_dict(existing.serialize())
             return None
 
+    def session_played_snapshot(self) -> list[dict[str, Any]]:
+        with self.lock:
+            return [
+                self._session_played_export_payload_unlocked(entry)
+                for entry in self.session_played
+            ]
+
     def missing_owner_urls(self) -> list[str]:
         with self.lock:
             urls: list[str] = []
@@ -1010,6 +1017,13 @@ class PlaylistStore:
                 requester_name=item.requester_name,
             )
         )
+
+    @staticmethod
+    def _session_played_export_payload_unlocked(entry: SessionPlayedEntry) -> dict[str, Any]:
+        payload = entry.to_dict()
+        payload["requested_at"] = entry.played_at
+        payload["request_count"] = 1
+        return payload
 
     @staticmethod
     def _session_file_label(timestamp: float) -> str:

--- a/static/app.js
+++ b/static/app.js
@@ -198,6 +198,7 @@ const elements = {
   historyTemplate: document.getElementById("history-item-template"),
   confirmPopover: document.getElementById("confirm-popover"),
   confirmText: document.getElementById("confirm-text"),
+  confirmSource: document.getElementById("confirm-source"),
   confirmCancel: document.getElementById("confirm-cancel"),
   confirmSecondary: document.getElementById("confirm-secondary"),
   confirmOk: document.getElementById("confirm-ok"),
@@ -1515,7 +1516,7 @@ function renderListHeader(playlist, history) {
   setTextContent(elements.queueCount, queueCount);
   setTextContent(elements.historyToggleButton, historyButtonText);
   setClassToggle(elements.clearPlaylistButton, "hidden", isHistoryView);
-  setClassToggle(elements.historyExportButton, "hidden", !isHistoryView || !history.length);
+  setClassToggle(elements.historyExportButton, "hidden", !isHistoryView);
   setClassToggle(elements.clearHistoryButton, "hidden", !isHistoryView || !history.length);
   setClassToggle(elements.nextButton, "hidden", isHistoryView);
 }
@@ -3570,9 +3571,13 @@ function renderConfirmPopover() {
     return;
   }
 
-  const width = 260;
   const hasSecondaryAction = Boolean(intent.secondaryLabel);
-  const popoverHeight = hasSecondaryAction ? 126 : 112;
+  const hasSourceSelect = Boolean(intent.sourceSelect);
+  const hideMessage = Boolean(intent.hideMessage);
+  const width = hasSourceSelect ? 340 : 260;
+  const popoverHeight = (hasSecondaryAction ? 126 : 112)
+    + (hasSourceSelect ? 48 : 0)
+    - (hideMessage ? 34 : 0);
   const margin = 12;
   const left = Math.min(
     Math.max(intent.x, margin),
@@ -3583,7 +3588,14 @@ function renderConfirmPopover() {
     window.innerHeight - popoverHeight - margin,
   );
 
-  elements.confirmText.textContent = intent.message;
+  elements.confirmText.textContent = intent.message || "";
+  elements.confirmText.classList.toggle("hidden", hideMessage);
+  if (elements.confirmSource) {
+    elements.confirmSource.classList.toggle("hidden", !hasSourceSelect);
+    if (hasSourceSelect) {
+      elements.confirmSource.value = normalizedHistoryExportSource(intent.source);
+    }
+  }
   elements.confirmOk.textContent = intent.primaryLabel || "确认";
   if (elements.confirmSecondary) {
     elements.confirmSecondary.textContent = intent.secondaryLabel || "";
@@ -3591,6 +3603,7 @@ function renderConfirmPopover() {
   }
   elements.confirmPopover.style.left = `${left}px`;
   elements.confirmPopover.style.top = `${top}px`;
+  elements.confirmPopover.classList.toggle("confirm-popover-wide", hasSourceSelect);
   elements.confirmPopover.classList.remove("hidden");
 }
 
@@ -3973,12 +3986,29 @@ function filenameFromContentDisposition(header, fallback) {
   return plainMatch ? plainMatch[1].trim() : fallback;
 }
 
-async function downloadHistoryExport(format) {
+function normalizedHistoryExportSource(source) {
+  return String(source || "").trim().toLowerCase() === "history" ? "history" : "played";
+}
+
+function historyExportSourceLabel(source) {
+  return normalizedHistoryExportSource(source) === "history" ? "全部历史" : "本场记录";
+}
+
+function selectedConfirmHistoryExportSource(intent) {
+  return normalizedHistoryExportSource(elements.confirmSource?.value || intent?.source);
+}
+
+async function downloadHistoryExport(format, source = "played") {
   const normalizedFormat = String(format || "").trim().toLowerCase();
+  const normalizedSource = normalizedHistoryExportSource(source);
   if (!["csv", "image"].includes(normalizedFormat)) {
     return;
   }
-  const response = await fetch(`/api/history/export?format=${encodeURIComponent(normalizedFormat)}`, {
+  const params = new URLSearchParams({
+    format: normalizedFormat,
+    source: normalizedSource,
+  });
+  const response = await fetch(`/api/history/export?${params.toString()}`, {
     cache: "no-store",
     headers: clientHeaders(),
   });
@@ -3993,7 +4023,9 @@ async function downloadHistoryExport(format) {
     throw new Error(message);
   }
   const blob = await response.blob();
-  const fallback = normalizedFormat === "csv" ? "bilikara-history.csv" : "bilikara-history.png";
+  const fallback = normalizedFormat === "csv"
+    ? `bilikara-${normalizedSource}.csv`
+    : `bilikara-${normalizedSource}.png`;
   const filename = filenameFromContentDisposition(response.headers.get("Content-Disposition"), fallback);
   const downloadUrl = URL.createObjectURL(blob);
   const link = document.createElement("a");
@@ -4006,11 +4038,13 @@ async function downloadHistoryExport(format) {
   window.setTimeout(() => URL.revokeObjectURL(downloadUrl), 1000);
 }
 
-async function exportHistory(format) {
+async function exportHistory(format, source = "played") {
+  const normalizedSource = normalizedHistoryExportSource(source);
+  const sourceLabel = historyExportSourceLabel(normalizedSource);
   try {
-    await downloadHistoryExport(format);
+    await downloadHistoryExport(format, normalizedSource);
     closeConfirm();
-    setAppMessage(format === "csv" ? "历史记录 CSV 已开始下载。" : "历史记录图片已开始下载。");
+    setAppMessage(format === "csv" ? `${sourceLabel} CSV 已开始下载。` : `${sourceLabel}图片已开始下载。`);
   } catch (error) {
     setAppMessage(error.message, true);
   }
@@ -4618,7 +4652,9 @@ elements.historyExportButton?.addEventListener("click", (event) => {
   const point = anchorPointForEvent(event, elements.historyExportButton);
   openConfirm({
     type: "export-history",
-    message: "选择历史记录导出格式。图片每 25 首自动分页，超过一页会打包为 zip。",
+    source: "played",
+    sourceSelect: true,
+    message: "选择导出范围和格式。本场记录是本次启动后已播放的歌曲，全部历史是累计点歌历史。",
     primaryLabel: "导出图片",
     secondaryLabel: "导出 CSV",
     x: point.x,
@@ -4888,7 +4924,8 @@ elements.confirmSecondary?.addEventListener("click", async () => {
     return;
   }
   if (intent.type === "export-history") {
-    await exportHistory("csv");
+    await exportHistory("csv", selectedConfirmHistoryExportSource(intent));
+    return;
   }
 });
 
@@ -4924,7 +4961,7 @@ elements.confirmOk.addEventListener("click", async () => {
       return;
     }
     if (intent.type === "export-history") {
-      await exportHistory("image");
+      await exportHistory("image", selectedConfirmHistoryExportSource(intent));
       return;
     }
     if (intent.type === "reset-data") {

--- a/static/app.js
+++ b/static/app.js
@@ -1501,7 +1501,7 @@ function renderListHeader(playlist, history) {
   const listTag = isHistoryView ? "History" : "Requests";
   const listTitle = isHistoryView ? "历史记录" : "点歌列表";
   const queueCount = isHistoryView ? `(${history.length}首)` : `(${playlist.length}首)`;
-  const historyButtonText = isHistoryView ? "返回点歌列表" : "历史记录";
+  const historyButtonText = isHistoryView ? "点歌列表" : "历史记录";
   const signature = JSON.stringify({
     isHistoryView,
     queueCount,

--- a/static/app.js
+++ b/static/app.js
@@ -157,6 +157,7 @@ const elements = {
   audioVariantBar: document.getElementById("audio-variant-bar"),
   avSyncPanel: document.getElementById("av-sync-panel"),
   avOffsetInput: document.getElementById("av-offset-input"),
+  avOffsetResetButton: document.getElementById("av-offset-reset-button"),
   volumePanel: document.getElementById("volume-panel"),
   volumeMuteButton: document.getElementById("volume-mute-button"),
   volumeSlider: document.getElementById("volume-slider"),
@@ -2419,6 +2420,10 @@ function volumePercentText() {
   return `${Math.round(state.localPlayerVolume * 100)}%`;
 }
 
+function muteIcon(isMuted) {
+  return isMuted ? "🔇" : "🔊";
+}
+
 function setRangeFillPercent(input, percent) {
   if (!input) {
     return;
@@ -2439,11 +2444,13 @@ function renderVolumeControls(playbackMode) {
   const volumePercent = Math.round(state.localPlayerVolume * 100);
   const label = volumePercentText();
   const muteLabel = state.localPlayerMuted ? "取消静音" : "静音";
+  const muteButtonText = muteIcon(state.localPlayerMuted);
   const signature = JSON.stringify({
     isLocalMode,
     volumePercent,
     label,
     muteLabel,
+    muteButtonText,
     muted: state.localPlayerMuted,
   });
 
@@ -2458,7 +2465,9 @@ function renderVolumeControls(playbackMode) {
   }
   setRangeFillPercent(elements.volumeSlider, volumePercent);
   setTextContent(elements.volumeValue, label);
-  setTextContent(elements.volumeMuteButton, muteLabel);
+  setTextContent(elements.volumeMuteButton, muteButtonText);
+  elements.volumeMuteButton.setAttribute("aria-label", muteLabel);
+  elements.volumeMuteButton.setAttribute("title", muteLabel);
   setClassToggle(elements.volumeMuteButton, "is-muted", state.localPlayerMuted);
 }
 
@@ -2669,6 +2678,9 @@ function renderAvSyncControls(playbackMode, playerSettings) {
   elements.avSyncPanel.classList.toggle("hidden", !isLocalMode);
   const offsetMs = currentAvOffsetMs();
   elements.avOffsetInput.disabled = state.avOffsetSaving;
+  if (elements.avOffsetResetButton) {
+    elements.avOffsetResetButton.disabled = state.avOffsetSaving || offsetMs === 0;
+  }
   if (document.activeElement !== elements.avOffsetInput || state.avOffsetSaving) {
     elements.avOffsetInput.value = String(offsetMs);
   }
@@ -4596,8 +4608,15 @@ elements.updatePreviewCheckbox?.addEventListener("change", (event) => {
 });
 
 elements.avSyncPanel?.addEventListener("click", async (event) => {
-  const button = event.target.closest("button[data-step]");
+  const button = event.target.closest("button[data-step], button[data-reset-av-offset]");
   if (!button) {
+    return;
+  }
+  if (button.disabled) {
+    return;
+  }
+  if (button.hasAttribute("data-reset-av-offset")) {
+    await setAvOffset(0);
     return;
   }
   const step = Number(button.dataset.step || 0);
@@ -5407,6 +5426,7 @@ window.addEventListener("pagehide", () => {
 window.addEventListener("beforeunload", disconnectClient);
 window.addEventListener("pageshow", () => {
   showMountedPlayerControls();
+  renderVolumeControls(frontendPlaybackMode(state.data?.playback_mode));
 });
 
 startPolling();

--- a/static/index.html
+++ b/static/index.html
@@ -643,6 +643,10 @@
 
     <div class="confirm-popover hidden" id="confirm-popover" role="dialog" aria-modal="false">
       <p class="confirm-text" id="confirm-text">确定执行这个操作吗？</p>
+      <select id="confirm-source" class="confirm-source hidden" aria-label="导出范围">
+        <option value="played">本场记录</option>
+        <option value="history">全部历史</option>
+      </select>
       <div class="confirm-actions">
         <button type="button" id="confirm-cancel" class="toolbar-button">取消</button>
         <button type="button" id="confirm-secondary" class="toolbar-button hidden">导出 CSV</button>

--- a/static/index.html
+++ b/static/index.html
@@ -282,17 +282,18 @@
             <section class="av-sync-panel" id="av-sync-panel">
               <div class="av-sync-copy">
                 <p class="section-tag">音画延迟</p>
-                <p class="av-sync-hint">正数表示音频延后，负数表示音频提前。</p>
+                <p class="av-sync-hint">正数表示画面提前，负数表示画面延后。</p>
               </div>
               <div class="av-sync-controls">
-                <button type="button" class="toolbar-button ghost av-sync-step-button" data-step="-200">-200ms</button>
-                <button type="button" class="toolbar-button ghost av-sync-step-button" data-step="-50">-50ms</button>
+                <button type="button" class="toolbar-button ghost av-sync-step-button" data-step="-200">« -200</button>
+                <button type="button" class="toolbar-button ghost av-sync-step-button" data-step="-50">‹ -50</button>
                 <label class="av-sync-input-wrap" for="av-offset-input">
                   <input id="av-offset-input" type="number" min="-5000" max="5000" step="10" value="0" />
                   <span>ms</span>
                 </label>
-                <button type="button" class="toolbar-button ghost av-sync-step-button" data-step="50">+50ms</button>
-                <button type="button" class="toolbar-button ghost av-sync-step-button" data-step="200">+200ms</button>
+                <button type="button" class="toolbar-button ghost av-sync-step-button" data-step="50">+50 ›</button>
+                <button type="button" class="toolbar-button ghost av-sync-step-button" data-step="200">+200 »</button>
+                <button type="button" class="toolbar-button ghost av-sync-reset-button" id="av-offset-reset-button" data-reset-av-offset disabled>复位</button>
               </div>
             </section>
             <section class="volume-panel" id="volume-panel">
@@ -301,7 +302,7 @@
                 <p class="volume-hint">直接控制服务端当前本地播放的音量。</p>
               </div>
               <div class="volume-controls">
-                <button type="button" class="toolbar-button ghost volume-mute-button" id="volume-mute-button">静音</button>
+                <button type="button" class="toolbar-button ghost volume-mute-button" id="volume-mute-button" aria-label="静音" title="静音">🔊</button>
                 <input
                   id="volume-slider"
                   class="volume-slider"

--- a/static/index.html
+++ b/static/index.html
@@ -21,7 +21,7 @@
 
       <header class="topbar">
         <div>
-          <p class="eyebrow">bilibili karaoke host</p>
+          <p class="eyebrow">bilikara host</p>
           <h1>bilikara</h1>
           <p class="designer">@VZRXS</p>
         </div>
@@ -189,7 +189,7 @@
               </div>
               <div class="cache-panel-row cache-panel-danger-row">
                 <div>
-                  <p class="cache-panel-label">数据维护</p>
+                  <p class="cache-panel-label">数据清理</p>
                   <p class="cache-panel-hint">保留已唱归档和抽卡缓存</p>
                 </div>
                 <button
@@ -516,7 +516,7 @@
             <div class="queue-toolbar">
               <button type="button" id="clear-playlist-button" class="toolbar-button ghost">清空点歌列表</button>
               <button type="button" id="history-export-button" class="toolbar-button ghost hidden" title="导出历史记录">
-                <span aria-hidden="true">⇩</span>
+                <!-- <span aria-hidden="true">⇩</span> -->
                 <span>导出</span>
               </button>
               <button type="button" id="clear-history-button" class="toolbar-button ghost hidden">清空历史</button>

--- a/static/remote.css
+++ b/static/remote.css
@@ -991,6 +991,17 @@ select:disabled {
   box-shadow: 0 8px 18px rgba(79, 56, 39, 0.08);
 }
 
+.history-export-row {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr 1fr;
+  gap: 8px;
+  margin: -4px 0 14px;
+}
+
+.history-export-source {
+  min-width: 0;
+}
+
 .list {
   display: grid;
   gap: 10px;
@@ -1273,6 +1284,7 @@ select:disabled {
 
   .action-row,
   .history-actions,
+  .history-export-row,
   .view-toggle,
   .player-control-row {
     grid-template-columns: 1fr;

--- a/static/remote.css
+++ b/static/remote.css
@@ -326,6 +326,12 @@ h1 {
   line-height: 1.15;
 }
 
+.panel-title {
+  margin-top: 6px;
+  font-size: 22px;
+  line-height: 1.15;
+}
+
 .muted,
 .message,
 .queue-note,
@@ -408,9 +414,7 @@ h1 {
 }
 
 .remote-shell.layout-mode-basic .search-panel,
-.remote-shell.layout-mode-basic .gatcha-panel,
-.remote-shell.layout-mode-basic #remote-av-sync-panel,
-.remote-shell.layout-mode-basic #remote-volume-panel {
+.remote-shell.layout-mode-basic .gatcha-panel {
   display: none !important;
 }
 
@@ -455,24 +459,42 @@ h1 {
   text-align: right;
   color: var(--ink);
   outline: none;
+  box-shadow: none;
+}
+
+.remote-input-wrap:focus-within {
+  border-color: rgba(202, 91, 60, 0.42);
+  box-shadow: 0 0 0 4px rgba(202, 91, 60, 0.1);
+}
+
+.remote-input-wrap input:focus {
+  outline: none;
+  border: none;
+  box-shadow: none;
 }
 
 .remote-step-button,
+.remote-reset-button,
 .remote-mute-button {
   min-height: 42px;
   border-radius: 14px;
   font-weight: 700;
-  box-shadow: 0 10px 20px rgba(79, 56, 39, 0.08);
+  border: 1px solid rgba(67, 53, 41, 0.08);
+  box-shadow: none;
 }
 
 .remote-step-button:hover,
+.remote-reset-button:hover,
 .remote-mute-button:hover {
-  box-shadow: 0 12px 24px rgba(202, 91, 60, 0.12);
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(202, 91, 60, 0.22);
+  box-shadow: none;
 }
 
 .remote-mute-button.is-muted {
   background: var(--accent);
   color: white;
+  border-color: rgba(163, 54, 33, 0.38);
 }
 
 .remote-volume-slider {
@@ -561,18 +583,56 @@ h1 {
 }
 
 #remote-av-sync-panel .remote-setting-controls {
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  align-items: center;
+}
+
+#remote-av-sync-panel .remote-step-button,
+#remote-av-sync-panel .remote-reset-button {
+  width: 100%;
+  min-width: 0;
+  padding-inline: 8px;
+  border: 1px solid rgba(67, 53, 41, 0.08);
+}
+
+#remote-av-sync-panel .remote-step-button:hover,
+#remote-av-sync-panel .remote-reset-button:hover,
+#remote-volume-panel .remote-mute-button:hover {
+  border-color: rgba(202, 91, 60, 0.22);
+}
+
+#remote-av-sync-panel .remote-reset-button {
+  grid-column: 1;
+}
+
+#remote-av-sync-panel .remote-input-wrap {
+  grid-column: 2 / -1;
+  width: 100%;
+  justify-content: center;
 }
 
 #remote-volume-panel .remote-setting-controls {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: 42px minmax(0, 1fr) auto;
   gap: 12px;
   align-items: center;
 }
 
 #remote-volume-panel .remote-mute-button {
-  min-width: 88px;
+  width: 42px;
+  min-width: 42px;
+  padding-inline: 0;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(67, 53, 41, 0.08);
+  font-size: 18px;
+  line-height: 1;
+}
+
+#remote-volume-panel .remote-mute-button.is-muted {
+  border-color: rgba(163, 54, 33, 0.38);
 }
 
 #remote-volume-panel .remote-volume-slider {
@@ -587,35 +647,38 @@ h1 {
 }
 
 .player-control-row button {
+  border: 1px solid rgba(67, 53, 41, 0.08);
   min-height: 42px;
   padding-inline: 10px;
   transition:
-    transform 0.14s ease,
-    box-shadow 0.14s ease,
+    border-color 0.18s ease,
     background 0.18s ease,
     color 0.18s ease,
     opacity 0.18s ease;
 }
 
+.player-control-row button:hover {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(202, 91, 60, 0.22);
+}
+
 .player-control-row button:active {
-  transform: scale(0.96);
+  transform: none;
 }
 
 .player-control-row .ghost-button,
 .player-control-row .primary-button {
-  box-shadow: 0 10px 20px rgba(79, 56, 39, 0.08);
+  box-shadow: none;
 }
 
 .player-control-row .ghost-button:active,
 .player-control-row .primary-button:active {
-  box-shadow: 0 4px 10px rgba(79, 56, 39, 0.12);
+  box-shadow: none;
 }
 
 .player-control-row button.is-pending {
-  transform: scale(0.97);
-  box-shadow:
-    0 0 0 3px rgba(202, 91, 60, 0.14),
-    0 10px 22px rgba(79, 56, 39, 0.12);
+  transform: none;
+  box-shadow: 0 0 0 3px rgba(202, 91, 60, 0.14);
 }
 
 .player-control-row button:disabled {
@@ -631,9 +694,7 @@ h1 {
 .player-control-row .primary-button.is-paused {
   background: rgba(255, 255, 255, 0.9);
   color: var(--accent-deep);
-  box-shadow:
-    inset 0 0 0 1px rgba(202, 91, 60, 0.24),
-    0 10px 20px rgba(79, 56, 39, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(202, 91, 60, 0.24);
 }
 
 .player-control-hint {
@@ -836,6 +897,10 @@ h1 {
   gap: 10px;
 }
 
+.request-panel .requester-row {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .requester-row-button {
   width: auto;
   min-height: 48px;
@@ -854,6 +919,12 @@ textarea {
   outline: none;
 }
 
+.request-panel textarea {
+  height: 72px;
+  min-height: 72px;
+  line-height: 1.45;
+}
+
 input {
   width: 100%;
   min-height: 48px;
@@ -864,7 +935,13 @@ input {
   outline: none;
 }
 
-input:focus {
+/* input:not([type="range"]):focus {
+  border-color: rgba(202, 91, 60, 0.42);
+  box-shadow: 0 0 0 4px rgba(202, 91, 60, 0.1);
+} */
+.form-input:focus,
+.form-textarea:focus {
+  outline: none;
   border-color: rgba(202, 91, 60, 0.42);
   box-shadow: 0 0 0 4px rgba(202, 91, 60, 0.1);
 }
@@ -905,6 +982,16 @@ select:disabled {
   grid-template-columns: 1fr;
 }
 
+.search-form {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.search-form .primary-button {
+  min-height: 48px;
+  white-space: nowrap;
+}
+
 .primary-button,
 .secondary-button,
 .ghost-button,
@@ -931,7 +1018,7 @@ select:disabled {
   border: 1.5px solid rgba(202, 91, 60, 0.58);
   background: rgba(202, 91, 60, 0.1);
   color: var(--accent-deep);
-  box-shadow: 0 8px 18px rgba(202, 91, 60, 0.08);
+  box-shadow: none;
 }
 
 .primary-button:disabled,
@@ -1042,6 +1129,29 @@ select:disabled {
   display: grid;
   gap: 10px;
   margin-top: 12px;
+  max-height: clamp(220px, 42vh, 460px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
+  scrollbar-gutter: stable;
+}
+
+.search-results::-webkit-scrollbar {
+  width: 8px;
+}
+
+.search-results::-webkit-scrollbar-track {
+  background: rgba(67, 53, 41, 0.05);
+  border-radius: 999px;
+}
+
+.search-results::-webkit-scrollbar-thumb {
+  background: rgba(143, 49, 29, 0.24);
+  border-radius: 999px;
+}
+
+.search-results::-webkit-scrollbar-thumb:hover {
+  background: rgba(143, 49, 29, 0.36);
 }
 
 .search-result-item {
@@ -1053,6 +1163,15 @@ select:disabled {
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.72);
   border: 1px solid rgba(67, 53, 41, 0.08);
+}
+
+.search-result-item > div {
+  min-width: 0;
+}
+
+.search-result-item .primary-button {
+  justify-self: end;
+  white-space: nowrap;
 }
 
 .search-result-title {
@@ -1079,6 +1198,10 @@ select:disabled {
   display: grid;
   gap: 12px;
   text-align: center;
+}
+
+.gatcha-actions {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .gatcha-uid-toggle {
@@ -1233,7 +1356,11 @@ select:disabled {
 }
 
 .history-item {
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) 76px;
+}
+
+.history-main {
+  min-width: 0;
 }
 
 .queue-title,
@@ -1255,6 +1382,22 @@ select:disabled {
   gap: 10px;
   font-size: 13px;
   line-height: 1.4;
+}
+
+.history-item .history-actions {
+  grid-template-columns: 1fr;
+  gap: 8px;
+  width: 76px;
+  justify-self: end;
+}
+
+.history-item .history-actions button {
+  width: 100%;
+  min-width: 0;
+  min-height: 36px;
+  padding: 8px 10px;
+  border-radius: 14px;
+  line-height: 1;
 }
 
 .queue-item.ready .queue-state {
@@ -1283,19 +1426,46 @@ select:disabled {
   }
 
   .action-row,
-  .history-actions,
-  .history-export-row,
-  .view-toggle,
-  .player-control-row {
+  .history-actions {
     grid-template-columns: 1fr;
+  }
+
+  .view-toggle {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .history-export-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .history-export-source {
+    grid-column: 1 / -1;
+  }
+
+  .player-control-row {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .player-control-row button[data-control-action="next-track"] {
+    grid-column: 1 / -1;
   }
 
   .queue-item {
     grid-template-columns: 1fr;
   }
 
+  .search-form,
   .search-result-item {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .search-results {
+    max-height: clamp(200px, 46vh, 420px);
+  }
+
+  .gatcha-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .queue-state {
@@ -1319,26 +1489,22 @@ select:disabled {
   }
 
   #remote-av-sync-panel .remote-setting-controls {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    grid-template-areas:
-      "neg200 neg50"
-      "input input"
-      "pos50 pos200";
-    gap: 12px;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 10px;
     align-items: stretch;
   }
 
-  #remote-av-sync-panel .remote-step-button {
+  #remote-av-sync-panel .remote-step-button,
+  #remote-av-sync-panel .remote-reset-button {
     width: 100%;
-    min-height: 48px;
+    min-height: 42px;
     padding-inline: 12px;
   }
 
   #remote-av-sync-panel .remote-input-wrap {
-    grid-area: input;
+    grid-column: 2 / -1;
     width: 100%;
-    min-height: 48px;
+    min-height: 42px;
     justify-content: center;
     padding: 0 16px;
   }
@@ -1348,31 +1514,21 @@ select:disabled {
     font-size: 18px;
   }
 
-  #remote-av-sync-panel [data-av-step="-200"] {
-    grid-area: neg200;
-  }
-
-  #remote-av-sync-panel [data-av-step="-50"] {
-    grid-area: neg50;
-  }
-
-  #remote-av-sync-panel [data-av-step="50"] {
-    grid-area: pos50;
-  }
-
-  #remote-av-sync-panel [data-av-step="200"] {
-    grid-area: pos200;
-  }
-
   #remote-volume-panel .remote-setting-controls {
-    grid-template-columns: 1fr;
-    gap: 14px;
-    align-items: stretch;
+    grid-template-columns: 42px minmax(0, 1fr) auto;
+    gap: 10px;
+    align-items: center;
   }
 
   #remote-volume-panel .remote-mute-button {
-    width: 100%;
-    min-height: 48px;
+    width: 42px;
+    min-width: 42px;
+    min-height: 42px;
+    padding-inline: 0;
+    display: grid;
+    place-items: center;
+    font-size: 18px;
+    line-height: 1;
   }
 
   #remote-volume-panel .remote-volume-slider {
@@ -1380,8 +1536,8 @@ select:disabled {
   }
 
   #remote-volume-panel .remote-volume-value {
-    min-width: 0;
-    text-align: left;
+    min-width: 44px;
+    text-align: right;
     font-size: 16px;
   }
 }

--- a/static/remote.css
+++ b/static/remote.css
@@ -1041,6 +1041,30 @@ select:disabled {
   color: var(--accent-deep);
 }
 
+.app-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 22px;
+  z-index: 420;
+  max-width: min(520px, calc(100vw - 32px));
+  padding: 11px 16px;
+  border: 1px solid rgba(87, 63, 43, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 251, 245, 0.94);
+  box-shadow: 0 16px 42px rgba(88, 56, 30, 0.16);
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: center;
+  transform: translateX(-50%);
+  backdrop-filter: blur(14px);
+}
+
+.app-toast.is-error {
+  border-color: rgba(177, 69, 69, 0.22);
+  color: var(--accent-deep);
+}
+
 .count-chip,
 .queue-state {
   display: inline-flex;

--- a/static/remote.html
+++ b/static/remote.html
@@ -163,6 +163,14 @@
             历史记录
           </button>
         </div>
+        <div id="history-export-row" class="history-export-row hidden">
+          <select id="history-export-source" class="history-export-source" aria-label="导出范围">
+            <option value="played">导出本场</option>
+            <option value="history">全部历史</option>
+          </select>
+          <button type="button" id="history-export-csv-button" class="ghost-button">导出 CSV</button>
+          <button type="button" id="history-export-image-button" class="primary-button">导出图片</button>
+        </div>
 
         <div id="queue-list" class="list"></div>
         <div id="history-list" class="list hidden"></div>

--- a/static/remote.html
+++ b/static/remote.html
@@ -74,17 +74,18 @@
         <section id="remote-av-sync-panel" class="remote-setting-panel hidden">
           <div class="remote-setting-copy">
             <p class="panel-tag">音画延迟</p>
-            <p class="muted">正数表示音频延后，负数表示音频提前。</p>
+            <p class="muted">正数表示画面提前，负数表示画面延后。</p>
           </div>
           <div class="remote-setting-controls">
-            <button type="button" class="ghost-button remote-step-button" data-av-step="-200">-200ms</button>
-            <button type="button" class="ghost-button remote-step-button" data-av-step="-50">-50ms</button>
+            <button type="button" class="ghost-button remote-step-button" data-av-step="-200">« -200</button>
+            <button type="button" class="ghost-button remote-step-button" data-av-step="-50">‹ -50</button>
+            <button type="button" class="ghost-button remote-step-button" data-av-step="50">+50 ›</button>
+            <button type="button" class="ghost-button remote-step-button" data-av-step="200">+200 »</button>
+            <button type="button" id="remote-av-offset-reset-button" class="ghost-button remote-reset-button" data-reset-av-offset disabled>复位</button>
             <label class="remote-input-wrap" for="remote-av-offset-input">
               <input id="remote-av-offset-input" type="number" min="-5000" max="5000" step="10" value="0" />
               <span>ms</span>
             </label>
-            <button type="button" class="ghost-button remote-step-button" data-av-step="50">+50ms</button>
-            <button type="button" class="ghost-button remote-step-button" data-av-step="200">+200ms</button>
           </div>
         </section>
         <section id="remote-volume-panel" class="remote-setting-panel hidden">
@@ -93,7 +94,7 @@
             <p class="muted">直接遥控服务端当前本地播放的音量。</p>
           </div>
           <div class="remote-setting-controls">
-            <button type="button" id="remote-volume-mute-button" class="ghost-button remote-mute-button">静音</button>
+            <button type="button" id="remote-volume-mute-button" class="ghost-button remote-mute-button" aria-label="静音" title="静音">🔊</button>
             <input
               id="remote-volume-slider"
               class="remote-volume-slider"
@@ -110,17 +111,20 @@
 
       <section class="panel request-panel">
         <div class="panel-head">
-          <p class="panel-tag">Song Request</p>
+          <div>
+            <p class="panel-tag">Song Request</p>
+            <h2 class="panel-title">点歌</h2>
+          </div>
+          <button type="button" id="resort-playlist-button" class="secondary-button requester-row-button">重新排序</button>
         </div>
         <form id="request-form" class="request-form">
           <div class="requester-row">
             <select id="requester-select" name="requester_name"></select>
-            <button type="button" id="resort-playlist-button" class="secondary-button requester-row-button">重新排序</button>
           </div>
           <textarea
             id="url-input"
             name="url"
-            rows="3"
+            rows="2"
             placeholder="输入 Bilibili 视频链接、BV 号或 av 号"
             autocomplete="off"
           ></textarea>
@@ -168,8 +172,8 @@
             <option value="played">导出本场</option>
             <option value="history">全部历史</option>
           </select>
-          <button type="button" id="history-export-csv-button" class="ghost-button">导出 CSV</button>
           <button type="button" id="history-export-image-button" class="primary-button">导出图片</button>
+          <button type="button" id="history-export-csv-button" class="ghost-button">导出 CSV</button>
         </div>
 
         <div id="queue-list" class="list"></div>
@@ -178,22 +182,24 @@
 
       <section class="panel search-panel">
         <div class="panel-head">
-          <p class="panel-tag">Local Search</p>
+          <div>
+            <p class="panel-tag">Local Search</p>
+            <h2 class="panel-title">搜索</h2>
+          </div>
           <button type="button" id="follow-browse-toggle" class="secondary-button follow-browse-toggle" aria-pressed="false">
             关注浏览
           </button>
         </div>
-        <form id="search-form" class="request-form">
+        <form id="search-form" class="request-form search-form">
           <input
             id="search-query"
             type="text"
             placeholder="搜索本地歌曲目录"
             autocomplete="off"
           />
-          <div class="action-row action-row-single">
-            <button type="submit" id="search-button" class="primary-button">搜索</button>
-          </div>
+          <button type="submit" id="search-button" class="primary-button">搜索</button>
         </form>
+        <p id="search-message" class="message search-message" role="status"></p>
         <div id="search-results" class="search-results hidden"></div>
         <div id="follow-browse-view" class="follow-browser hidden">
           <div id="follow-up-list-view">
@@ -224,7 +230,10 @@
 
       <section class="panel gatcha-panel">
         <div class="panel-head">
-          <p class="panel-tag">Gatcha Draw</p>
+          <div>
+            <p class="panel-tag">Gatcha Draw</p>
+            <h2 class="panel-title">试试运气</h2>
+          </div>
           <button type="button" id="gatcha-uid-toggle" class="secondary-button gatcha-uid-toggle" aria-pressed="false">
             添加 UID
           </button>
@@ -238,8 +247,8 @@
         <div id="gatcha-result-view" class="gatcha-content hidden">
           <p class="gatcha-label">运气不错，抽到了：</p>
           <h3 id="gatcha-candidate-title">歌曲标题加载中...</h3>
-          <div class="action-row">
-            <button type="button" id="gatcha-confirm-button" class="primary-button">确定点歌</button>
+          <div class="action-row gatcha-actions">
+            <button type="button" id="gatcha-confirm-button" class="primary-button">确认点歌</button>
             <button type="button" id="gatcha-retry-button" class="secondary-button">重新再来</button>
           </div>
         </div>
@@ -358,7 +367,7 @@
           </div>
         </div>
         <div class="history-actions">
-          <button type="button" data-action="history-tail" class="primary-button">再点一次</button>
+          <button type="button" data-action="history-tail" class="primary-button">点歌</button>
           <button type="button" data-action="history-next" class="secondary-button">顶歌</button>
         </div>
       </article>

--- a/static/remote.html
+++ b/static/remote.html
@@ -373,6 +373,8 @@
       </article>
     </template>
 
+    <div class="app-toast hidden" id="app-toast" role="status" aria-live="polite"></div>
+
     <script src="/remote.js" defer></script>
     <script src="/remote-queue.js" defer></script>
   </body>

--- a/static/remote.js
+++ b/static/remote.js
@@ -131,6 +131,10 @@ const elements = {
   listCount: document.getElementById("list-count"),
   queueViewButton: document.getElementById("queue-view-button"),
   historyViewButton: document.getElementById("history-view-button"),
+  historyExportRow: document.getElementById("history-export-row"),
+  historyExportSource: document.getElementById("history-export-source"),
+  historyExportImageButton: document.getElementById("history-export-image-button"),
+  historyExportCsvButton: document.getElementById("history-export-csv-button"),
   queueList: document.getElementById("queue-list"),
   historyList: document.getElementById("history-list"),
   queueItemTemplate: document.getElementById("queue-item-template"),
@@ -392,6 +396,72 @@ async function apiPost(url, payload = {}) {
     throw error;
   }
   return data.data;
+}
+
+function filenameFromContentDisposition(headerValue, fallback) {
+  const value = String(headerValue || "");
+  const quotedMatch = value.match(/filename="([^"]+)"/i);
+  if (quotedMatch) {
+    return quotedMatch[1];
+  }
+  const plainMatch = value.match(/filename=([^;]+)/i);
+  return plainMatch ? plainMatch[1].trim() : fallback;
+}
+
+function selectedHistoryExportSource() {
+  const source = String(elements.historyExportSource?.value || "played").trim().toLowerCase();
+  return source === "history" ? "history" : "played";
+}
+
+async function downloadHistoryExport(format, source = selectedHistoryExportSource()) {
+  const normalizedFormat = String(format || "").trim().toLowerCase();
+  const normalizedSource = source === "history" ? "history" : "played";
+  if (!["csv", "image"].includes(normalizedFormat)) {
+    return;
+  }
+  const params = new URLSearchParams({
+    format: normalizedFormat,
+    source: normalizedSource,
+  });
+  const response = await fetch(`/api/history/export?${params.toString()}`, {
+    cache: "no-store",
+    headers: clientHeaders(),
+  });
+  if (!response.ok) {
+    let message = "导出失败";
+    try {
+      const payload = await response.json();
+      message = payload.error || message;
+    } catch {
+      // Keep the generic message when the response is not JSON.
+    }
+    throw new Error(message);
+  }
+  const blob = await response.blob();
+  const sourceName = normalizedSource === "played" ? "played" : "history";
+  const fallback = normalizedFormat === "csv" ? `bilikara-${sourceName}.csv` : `bilikara-${sourceName}.png`;
+  const filename = filenameFromContentDisposition(response.headers.get("Content-Disposition"), fallback);
+  const downloadUrl = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = downloadUrl;
+  link.download = filename;
+  link.rel = "noopener";
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(downloadUrl), 1000);
+}
+
+async function exportHistory(format) {
+  const source = selectedHistoryExportSource();
+  const sourceLabel = source === "played" ? "本场记录" : "全部历史";
+  setFormMessage(format === "csv" ? `正在导出${sourceLabel} CSV...` : `正在导出${sourceLabel}图片...`);
+  try {
+    await downloadHistoryExport(format, source);
+    setFormMessage(format === "csv" ? `${sourceLabel} CSV 已开始下载。` : `${sourceLabel}图片已开始下载。`);
+  } catch (error) {
+    setFormMessage(error.message, true);
+  }
 }
 
 async function submitAddRequest(url, position, options = {}) {
@@ -1601,6 +1671,7 @@ function renderListHeader(playlist, history) {
   elements.queueViewButton.setAttribute("aria-selected", String(!isHistoryView));
   elements.historyViewButton.classList.toggle("active", isHistoryView);
   elements.historyViewButton.setAttribute("aria-selected", String(isHistoryView));
+  elements.historyExportRow?.classList.toggle("hidden", !isHistoryView);
 }
 
 function syncListView() {
@@ -2265,6 +2336,14 @@ elements.queueViewButton.addEventListener("click", () => {
 elements.historyViewButton.addEventListener("click", () => {
   state.listView = "history";
   render();
+});
+
+elements.historyExportImageButton?.addEventListener("click", async () => {
+  await exportHistory("image");
+});
+
+elements.historyExportCsvButton?.addEventListener("click", async () => {
+  await exportHistory("csv");
 });
 
 elements.historyList.addEventListener("click", async (event) => {

--- a/static/remote.js
+++ b/static/remote.js
@@ -48,6 +48,7 @@ const state = {
   layoutMode: "full",
   remoteAccessRenderSignature: "",
   remoteQrPopoverOpen: false,
+  appToastTimer: null,
   viewportScaleResetTimers: [],
 };
 
@@ -137,6 +138,7 @@ const elements = {
   historyExportSource: document.getElementById("history-export-source"),
   historyExportImageButton: document.getElementById("history-export-image-button"),
   historyExportCsvButton: document.getElementById("history-export-csv-button"),
+  appToast: document.getElementById("app-toast"),
   queueList: document.getElementById("queue-list"),
   historyList: document.getElementById("history-list"),
   queueItemTemplate: document.getElementById("queue-item-template"),
@@ -371,6 +373,25 @@ function setFormMessage(message, isError = false) {
   elements.formMessage.classList.toggle("error", isError);
 }
 
+function setAppMessage(message, isError = false) {
+  if (!elements.appToast) {
+    return;
+  }
+  if (state.appToastTimer) {
+    window.clearTimeout(state.appToastTimer);
+    state.appToastTimer = null;
+  }
+  elements.appToast.textContent = message || "";
+  elements.appToast.classList.toggle("is-error", Boolean(isError));
+  elements.appToast.classList.toggle("hidden", !message);
+  if (message) {
+    state.appToastTimer = window.setTimeout(() => {
+      elements.appToast.classList.add("hidden");
+      state.appToastTimer = null;
+    }, 2800);
+  }
+}
+
 function setSearchMessage(message, isError = false) {
   if (!elements.searchMessage) {
     return;
@@ -481,12 +502,12 @@ async function downloadHistoryExport(format, source = selectedHistoryExportSourc
 async function exportHistory(format) {
   const source = selectedHistoryExportSource();
   const sourceLabel = source === "played" ? "本场记录" : "全部历史";
-  setFormMessage(format === "csv" ? `正在导出${sourceLabel} CSV...` : `正在导出${sourceLabel}图片...`);
+  setAppMessage(format === "csv" ? `正在导出${sourceLabel} CSV...` : `正在导出${sourceLabel}图片...`);
   try {
     await downloadHistoryExport(format, source);
-    setFormMessage(format === "csv" ? `${sourceLabel} CSV 已开始下载。` : `${sourceLabel}图片已开始下载。`);
+    setAppMessage(format === "csv" ? `${sourceLabel} CSV 已开始下载。` : `${sourceLabel}图片已开始下载。`);
   } catch (error) {
-    setFormMessage(error.message, true);
+    setAppMessage(error.message, true);
   }
 }
 

--- a/static/remote.js
+++ b/static/remote.js
@@ -73,6 +73,7 @@ const elements = {
   playerControlHint: document.getElementById("player-control-hint"),
   remoteAvSyncPanel: document.getElementById("remote-av-sync-panel"),
   remoteAvOffsetInput: document.getElementById("remote-av-offset-input"),
+  remoteAvOffsetResetButton: document.getElementById("remote-av-offset-reset-button"),
   remoteVolumePanel: document.getElementById("remote-volume-panel"),
   remoteVolumeMuteButton: document.getElementById("remote-volume-mute-button"),
   remoteVolumeSlider: document.getElementById("remote-volume-slider"),
@@ -96,6 +97,7 @@ const elements = {
   searchForm: document.getElementById("search-form"),
   searchQuery: document.getElementById("search-query"),
   searchButton: document.getElementById("search-button"),
+  searchMessage: document.getElementById("search-message"),
   searchResults: document.getElementById("search-results"),
   followBrowseToggle: document.getElementById("follow-browse-toggle"),
   followBrowseView: document.getElementById("follow-browse-view"),
@@ -367,6 +369,30 @@ function renderRemoteQr(url, targets = []) {
 function setFormMessage(message, isError = false) {
   elements.formMessage.textContent = message;
   elements.formMessage.classList.toggle("error", isError);
+}
+
+function setSearchMessage(message, isError = false) {
+  if (!elements.searchMessage) {
+    return;
+  }
+  elements.searchMessage.textContent = message || "";
+  elements.searchMessage.classList.toggle("error", Boolean(isError));
+}
+
+function setMessageForSource(source, message, isError = false) {
+  if (source === "search") {
+    setSearchMessage(message, isError);
+    return;
+  }
+  if (source === "follow") {
+    setFollowBrowseMessage(message, isError);
+    return;
+  }
+  if (source === "gatcha") {
+    setGatchaMessage(message, isError);
+    return;
+  }
+  setFormMessage(message, isError);
 }
 
 function duplicateConfirmMessage(duplicateItem, sessionEntry, activeItem) {
@@ -1314,14 +1340,22 @@ function setRangeFillPercent(input, percent) {
   input.style.setProperty("--range-fill-percent", `${normalizedPercent}%`);
 }
 
+function muteIcon(isMuted) {
+  return isMuted ? "🔇" : "🔊";
+}
+
 function renderRemoteAvSyncControls(playbackMode, playerSettings) {
   if (!elements.remoteAvSyncPanel || !elements.remoteAvOffsetInput) {
     return;
   }
-  const isLocalMode = playbackMode === "local" && normalizeLayoutMode(state.layoutMode) === "full";
+  const isLocalMode = playbackMode === "local";
   elements.remoteAvSyncPanel.classList.toggle("hidden", !isLocalMode);
+  const offsetMs = currentRemoteAvOffsetMs(playerSettings);
+  if (elements.remoteAvOffsetResetButton) {
+    elements.remoteAvOffsetResetButton.disabled = offsetMs === 0;
+  }
   if (document.activeElement !== elements.remoteAvOffsetInput) {
-    elements.remoteAvOffsetInput.value = String(currentRemoteAvOffsetMs(playerSettings));
+    elements.remoteAvOffsetInput.value = String(offsetMs);
   }
 }
 
@@ -1329,14 +1363,17 @@ function renderRemoteVolumeControls(playbackMode, playerSettings) {
   if (!elements.remoteVolumePanel || !elements.remoteVolumeSlider || !elements.remoteVolumeMuteButton || !elements.remoteVolumeValue) {
     return;
   }
-  const isLocalMode = playbackMode === "local" && normalizeLayoutMode(state.layoutMode) === "full";
+  const isLocalMode = playbackMode === "local";
   elements.remoteVolumePanel.classList.toggle("hidden", !isLocalMode);
   const volumePercent = currentRemoteVolumePercent(playerSettings);
   const isMuted = currentRemoteMuted(playerSettings);
   elements.remoteVolumeSlider.value = String(volumePercent);
   setRangeFillPercent(elements.remoteVolumeSlider, volumePercent);
   elements.remoteVolumeValue.textContent = `${Math.round(volumePercent)}%`;
-  elements.remoteVolumeMuteButton.textContent = isMuted ? "取消静音" : "静音";
+  const muteLabel = isMuted ? "取消静音" : "静音";
+  elements.remoteVolumeMuteButton.textContent = muteIcon(isMuted);
+  elements.remoteVolumeMuteButton.setAttribute("aria-label", muteLabel);
+  elements.remoteVolumeMuteButton.setAttribute("title", muteLabel);
   elements.remoteVolumeMuteButton.classList.toggle("is-muted", isMuted);
 }
 
@@ -1451,18 +1488,19 @@ async function confirmBindingSheet() {
   if (!intent?.url || state.submitting) {
     return;
   }
+  const source = intent.source || "request-form";
   const { selectedVideoPage, selectedAudioPages } = currentBindingSelection();
   if (!selectedVideoPage) {
-    setFormMessage("请先选择一个视频分P", true);
+    setMessageForSource(source, "请先选择一个视频分P", true);
     return;
   }
   if (!selectedAudioPages.length) {
-    setFormMessage("请至少选择一个音频分P", true);
+    setMessageForSource(source, "请至少选择一个音频分P", true);
     return;
   }
 
   state.submitting = true;
-  setFormMessage(intent.position === "next" ? "正在按绑定关系顶歌..." : "正在按绑定关系加入点歌列表...");
+  setMessageForSource(source, intent.position === "next" ? "正在按绑定关系顶歌..." : "正在按绑定关系加入点歌列表...");
   try {
     const result = await submitAddRequestWithDuplicateConfirm(
       intent.url,
@@ -1474,7 +1512,7 @@ async function confirmBindingSheet() {
       },
     );
     if (result.cancelled) {
-      setFormMessage("已取消重复添加");
+      setMessageForSource(source, "已取消重复添加");
       return;
     }
     applyStateSnapshot(result.data, { forceRender: true });
@@ -1486,17 +1524,20 @@ async function confirmBindingSheet() {
       hideSearchResults();
       elements.searchQuery.value = "";
     }
+    if (intent.source === "follow") {
+      setFollowBrowseMessage("");
+    }
     if (intent.source === "gatcha") {
       state.gatchaCandidate = null;
       renderGatchaUidView();
     }
-    setFormMessage(intent.position === "next" ? "已按绑定关系顶歌到下一首" : "已按绑定关系加入点歌列表");
+    setMessageForSource(source, intent.position === "next" ? "已按绑定关系顶歌到下一首" : "已按绑定关系加入点歌列表");
   } catch (error) {
     if (error.code === "manual_binding_required") {
       openBindingSheet(intent, error.payload?.binding);
       return;
     }
-    setFormMessage(error.message, true);
+    setMessageForSource(source, error.message, true);
   } finally {
     state.submitting = false;
   }
@@ -1870,30 +1911,34 @@ async function resortPlaylistByCycle() {
   setFormMessage("已按本场用户座次重新排序点歌列表。");
 }
 
-async function addByUrl(url, position = "tail") {
+async function addByUrl(url, position = "tail", source = "search") {
   const requesterName = selectedRequesterName();
   if (!url || state.submitting) {
     return;
   }
   if (!requesterName) {
-    setFormMessage("请先选择点歌人。", true);
+    setMessageForSource(source, "请先选择点歌人。", true);
     return;
   }
 
   state.submitting = true;
-  setFormMessage("正在添加已选歌曲...");
+  setMessageForSource(source, "正在添加已选歌曲...");
   try {
     const result = await submitAddRequestWithDuplicateConfirm(url, position, requesterName);
     if (result.cancelled) {
-      setFormMessage("已取消重复点歌。");
+      setMessageForSource(source, "已取消重复点歌。");
       return;
     }
     applyStateSnapshot(result.data, { forceRender: true });
-    hideSearchResults();
-    elements.searchQuery.value = "";
-    state.gatchaCandidate = null;
-    renderGatchaUidView();
-    setFormMessage("点歌成功。");
+    if (source === "search") {
+      hideSearchResults();
+      elements.searchQuery.value = "";
+    }
+    if (source === "gatcha") {
+      state.gatchaCandidate = null;
+      renderGatchaUidView();
+    }
+    setMessageForSource(source, "点歌成功。");
   } catch (error) {
     if (error.code === "manual_binding_required") {
       openBindingSheet(
@@ -1902,13 +1947,13 @@ async function addByUrl(url, position = "tail") {
           position,
           requesterName,
           clearInput: false,
-          source: state.gatchaCandidate?.url === url ? "gatcha" : "search",
+          source,
         },
         error.payload?.binding,
       );
       return;
     }
-    setFormMessage(error.message, true);
+    setMessageForSource(source, error.message, true);
   } finally {
     state.submitting = false;
   }
@@ -2004,19 +2049,19 @@ elements.searchForm.addEventListener("submit", async (event) => {
   const query = String(elements.searchQuery.value || "").trim();
   if (!query) {
     hideSearchResults();
-    setFormMessage("请输入搜索关键词。", true);
+    setSearchMessage("请输入搜索关键词。", true);
     return;
   }
 
   elements.searchButton.disabled = true;
-  setFormMessage("正在搜索本地目录...");
+  setSearchMessage("正在搜索本地目录...");
   try {
     const items = await searchGatchaCache(query);
     renderSearchResults(items);
-    setFormMessage(items.length ? `找到 ${items.length} 条缓存结果。` : "未找到缓存结果。");
+    setSearchMessage(items.length ? `找到 ${items.length} 条缓存结果。` : "未找到缓存结果。");
   } catch (error) {
     hideSearchResults();
-    setFormMessage(error.message, true);
+    setSearchMessage(error.message, true);
   } finally {
     elements.searchButton.disabled = false;
   }
@@ -2027,7 +2072,7 @@ elements.searchResults.addEventListener("click", async (event) => {
   if (!button) {
     return;
   }
-  await addByUrl(String(button.dataset.url || ""), "tail");
+  await addByUrl(String(button.dataset.url || ""), "tail", "search");
 });
 
 elements.followBrowseToggle?.addEventListener("click", () => {
@@ -2087,7 +2132,7 @@ elements.followSongResults?.addEventListener("click", async (event) => {
   }
   button.disabled = true;
   try {
-    await addByUrl(url, "tail");
+    await addByUrl(url, "tail", "follow");
   } finally {
     button.disabled = false;
   }
@@ -2150,8 +2195,15 @@ elements.refreshButton.addEventListener("click", async () => {
 });
 
 elements.remoteAvSyncPanel?.addEventListener("click", async (event) => {
-  const button = event.target.closest("button[data-av-step]");
+  const button = event.target.closest("button[data-av-step], button[data-reset-av-offset]");
   if (!button) {
+    return;
+  }
+  if (button.disabled) {
+    return;
+  }
+  if (button.hasAttribute("data-reset-av-offset")) {
+    await setRemoteAvOffset(0);
     return;
   }
   await setRemoteAvOffset(
@@ -2202,7 +2254,7 @@ elements.gatchaConfirmButton.addEventListener("click", async () => {
   if (!state.gatchaCandidate?.url) {
     return;
   }
-  await addByUrl(String(state.gatchaCandidate.url), "tail");
+  await addByUrl(String(state.gatchaCandidate.url), "tail", "gatcha");
 });
 
 elements.bindingSheetClose?.addEventListener("click", () => {

--- a/static/styles.css
+++ b/static/styles.css
@@ -120,6 +120,10 @@ p {
   z-index: 180;
 }
 
+.confirm-popover.confirm-popover-wide {
+  width: min(340px, calc(100vw - 24px));
+}
+
 .confirm-popover.hidden {
   display: none;
 }
@@ -242,12 +246,26 @@ p {
   color: var(--ink);
 }
 
+.confirm-source {
+  width: 100%;
+  min-height: 42px;
+  margin-top: 2px;
+}
+
 .confirm-actions {
   margin-top: 12px;
   display: flex;
   justify-content: flex-end;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.confirm-popover-wide .confirm-actions {
+  flex-wrap: nowrap;
+}
+
+.confirm-popover-wide .confirm-actions button {
+  white-space: nowrap;
 }
 
 .backup-title,

--- a/static/styles.css
+++ b/static/styles.css
@@ -1475,17 +1475,14 @@ h2 {
 
 .av-sync-panel {
   margin-top: 14px;
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(260px, 1fr) auto;
   gap: 14px;
   align-items: center;
-  flex-wrap: wrap;
   padding: 14px 16px;
-  border-radius: 20px;
-  background:
-    linear-gradient(180deg, rgba(255, 252, 247, 0.94), rgba(255, 246, 236, 0.82));
-  border: 1px solid rgba(208, 90, 63, 0.16);
-  box-shadow: 0 14px 30px rgba(88, 56, 30, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(67, 53, 41, 0.08);
 }
 
 .volume-panel {
@@ -1496,11 +1493,9 @@ h2 {
   align-items: center;
   flex-wrap: wrap;
   padding: 14px 16px;
-  border-radius: 20px;
-  background:
-    linear-gradient(180deg, rgba(255, 252, 247, 0.94), rgba(255, 246, 236, 0.82));
-  border: 1px solid rgba(208, 90, 63, 0.16);
-  box-shadow: 0 14px 30px rgba(88, 56, 30, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.68);
+  border: 1px solid rgba(67, 53, 41, 0.08);
   contain: paint;
   isolation: isolate;
 }
@@ -1533,39 +1528,37 @@ html:has(.player-panel:-webkit-full-screen) .queue-current-indicator {
 }
 
 .av-sync-hint {
-  font-size: 13px;
-  line-height: 1.45;
+  font-size: inherit;
+  line-height: 1.55;
   color: var(--muted);
 }
 
 .volume-hint {
-  font-size: 13px;
-  line-height: 1.45;
+  font-size: inherit;
+  line-height: 1.55;
   color: var(--muted);
 }
 
 .av-sync-controls {
   display: flex;
-  gap: 8px;
-  align-items: center;
+  /* grid-template-columns: repeat(4, minmax(0, 1fr)); */
   flex-wrap: wrap;
-  justify-content: flex-end;
-}
-
-.volume-controls {
-  display: flex;
-  gap: 12px;
+  gap: 6px;
   align-items: center;
-  flex-wrap: wrap;
   justify-content: flex-end;
+  width: min(520px, 100%);
+  justify-self: end;
 }
 
 .av-sync-input-wrap {
   display: inline-flex;
+  flex: 0 0 112px;
+  min-width: 112px;
   align-items: center;
-  gap: 10px;
+  justify-content: flex-end;
+  gap: 0px;
   min-height: 42px;
-  padding: 0 14px;
+  padding: 0 10px;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.96);
   border: 1px solid rgba(208, 90, 63, 0.16);
@@ -1574,7 +1567,8 @@ html:has(.player-panel:-webkit-full-screen) .queue-current-indicator {
 }
 
 .av-sync-input-wrap input[type="number"] {
-  width: 104px;
+  flex-shrink: 0;
+  width: min(58px, 100%);
   height: auto;
   padding: 0;
   border: none;
@@ -1585,54 +1579,85 @@ html:has(.player-panel:-webkit-full-screen) .queue-current-indicator {
 }
 
 .av-sync-input-wrap input[type="number"]:focus {
+  outline: none;
   border: none;
   box-shadow: none;
 }
 
-.av-sync-step-button {
-  min-width: 78px;
-  min-height: 42px;
-  padding: 0 14px;
-  border-radius: 14px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(250, 239, 230, 0.94));
-  border: 1px solid rgba(208, 90, 63, 0.2);
-  color: var(--accent-deep);
-  font-weight: 700;
+.av-sync-input-wrap:focus-within {
+  border-color: rgba(208, 90, 63, 0.55);
   box-shadow:
-    0 10px 20px rgba(88, 56, 30, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+    0 0 0 3px rgba(208, 90, 63, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
 }
 
-.av-sync-step-button:hover {
-  background:
-    linear-gradient(180deg, rgba(255, 247, 241, 1), rgba(248, 229, 215, 0.98));
-  border-color: rgba(208, 90, 63, 0.32);
-  box-shadow:
-    0 12px 24px rgba(208, 90, 63, 0.12),
-    inset 0 1px 0 rgba(255, 255, 255, 0.96);
+.av-sync-step-button,
+.av-sync-reset-button {
+  /* min-width: 78px; */
+  flex: 1 1 0;
+  min-width: 0;
+  white-space: nowrap;
+  min-height: 42px;
+  padding: 0 10px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(87, 63, 43, 0.08);
+  color: var(--ink);
+  font-weight: 700;
+  box-shadow: none;
+}
+
+/* .av-sync-step-button[data-step="-50"],
+.av-sync-step-button[data-step="50"] {
+  flex-basis: 70px;
+} */
+
+.av-sync-step-button:hover,
+.av-sync-reset-button:hover,
+.volume-mute-button:hover {
+  background: rgba(255, 255, 255, 0.95);
+  border-color: rgba(208, 90, 63, 0.22);
+}
+
+.volume-controls {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .volume-mute-button {
-  min-width: 96px;
+  width: 42px;
+  min-width: 42px;
   min-height: 42px;
-  padding: 0 16px;
+  padding: 0;
+  display: inline-grid;
+  place-items: center;
   border-radius: 14px;
-  background:
-    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(250, 239, 230, 0.94));
-  border: 1px solid rgba(208, 90, 63, 0.2);
-  color: var(--accent-deep);
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(87, 63, 43, 0.08);
+  color: var(--ink);
+  font-size: 18px;
   font-weight: 700;
-  box-shadow:
-    0 10px 20px rgba(88, 56, 30, 0.08),
-    inset 0 1px 0 rgba(255, 255, 255, 0.92);
+  line-height: 1;
+  box-shadow: none;
 }
 
 .volume-mute-button.is-muted {
-  background: linear-gradient(180deg, rgba(208, 90, 63, 0.94), rgba(183, 71, 45, 0.96));
+  background: var(--accent);
   color: white;
-  border-color: rgba(163, 54, 33, 0.4);
-  box-shadow: 0 12px 22px rgba(208, 90, 63, 0.18);
+  border-color: rgba(163, 54, 33, 0.38);
+}
+
+.av-sync-reset-button {
+  flex: 0 0 52px;
+  grid-column: 1;
+  padding-inline: 8px;
+}
+
+.av-sync-input-wrap {
+  grid-column: 2 / -1;
 }
 
 .volume-slider {
@@ -3181,6 +3206,29 @@ select:disabled {
 .search-results {
   display: grid;
   gap: 10px;
+  max-height: clamp(180px, 30vh, 360px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
+  scrollbar-gutter: stable;
+}
+
+.search-results::-webkit-scrollbar {
+  width: 8px;
+}
+
+.search-results::-webkit-scrollbar-track {
+  background: rgba(67, 53, 41, 0.05);
+  border-radius: 999px;
+}
+
+.search-results::-webkit-scrollbar-thumb {
+  background: rgba(143, 49, 29, 0.24);
+  border-radius: 999px;
+}
+
+.search-results::-webkit-scrollbar-thumb:hover {
+  background: rgba(143, 49, 29, 0.36);
 }
 
 .search-result-item {
@@ -3261,6 +3309,10 @@ select:disabled {
     grid-template-columns: 1fr;
   }
 
+  .search-results {
+    max-height: clamp(180px, 44vh, 420px);
+  }
+
   .search-result-item {
     grid-template-columns: 1fr;
   }
@@ -3333,9 +3385,43 @@ select:disabled {
     width: 100%;
   }
 
+  .av-sync-panel {
+    grid-template-columns: 1fr;
+  }
+
   .av-sync-controls,
   .volume-controls {
     justify-content: flex-start;
+  }
+
+  .av-sync-controls {
+    justify-content: flex-end;
+  }
+
+  .volume-controls {
+    display: grid;
+    grid-template-columns: 42px minmax(0, 1fr) auto;
+    gap: 10px;
+    align-items: center;
+    width: 100%;
+  }
+
+  .volume-mute-button {
+    width: 42px;
+    min-width: 42px;
+    padding: 0;
+    display: inline-grid;
+    place-items: center;
+    font-size: 18px;
+    line-height: 1;
+  }
+
+  .volume-slider {
+    width: 100%;
+  }
+
+  .volume-value {
+    min-width: 44px;
   }
 
   .remote-qr-wrap {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -293,6 +293,47 @@ class HistoryRouteTest(unittest.TestCase):
         self.assertEqual(writes[0]["content_type"], "application/zip")
         self.assertEqual(writes[0]["filename"], "bilikara-history-20260430-123456.zip")
 
+    def test_history_export_played_source_downloads_session_csv(self):
+        handler = BilikaraHandler.__new__(BilikaraHandler)
+        writes: list[dict] = []
+        played = [
+            {
+                "display_title": "中文歌曲",
+                "resolved_url": "https://www.bilibili.com/video/BV9xx411c7mD",
+                "requester_name": "小明",
+                "requested_at": 300,
+            }
+        ]
+        context = SimpleNamespace(
+            touch_client=lambda client_id, is_host=True: None,
+            history_snapshot=lambda: (_ for _ in ()).throw(AssertionError("should export played")),
+            session_played_snapshot=lambda: played,
+        )
+
+        handler.path = "/api/history/export?format=csv&source=played"
+        handler.headers = {}
+        handler._write_download = lambda payload, content_type, filename: writes.append(
+            {
+                "payload": payload,
+                "content_type": content_type,
+                "filename": filename,
+            }
+        )
+
+        with patch("bilikara.server.CONTEXT", context), patch(
+            "bilikara.server.time.strftime",
+            return_value="20260430-123456",
+        ):
+            handler.do_GET()
+
+        self.assertEqual(writes[0]["filename"], "bilikara-played-20260430-123456.csv")
+        self.assertTrue(writes[0]["payload"].startswith(b"\xef\xbb\xbf"))
+        decoded = writes[0]["payload"].decode("utf-8-sig")
+        rows = list(csv.DictReader(io.StringIO(decoded)))
+        self.assertIn("播放时间", rows[0])
+        self.assertEqual(rows[0]["标题"], "中文歌曲")
+        self.assertEqual(rows[0]["点歌人"], "小明")
+
     def test_history_clear_route_returns_fresh_snapshot(self):
         handler = BilikaraHandler.__new__(BilikaraHandler)
         writes: list[dict] = []


### PR DESCRIPTION
## 主要改动

- remote 端支持导出歌单，可选择「本场记录 / 全部历史」
- host 与 remote 的导出交互统一为「导出图片 / 导出 CSV」
- 导出相关提示改为底部 toast，避免错误显示在点歌卡片中
- remote 按钮排布优化
- remote 的搜索、抽卡、点歌区域补充标题并优化小屏布局
- 基础布局中也显示音画延迟与音量控制
- remote 历史记录项改为左侧歌曲信息、右侧「点歌 / 顶歌」按钮布局
- local search 结果区增加最大高度，超长后内部滚动
- 导出图片模板改为接近前端主题的暖色卡片风格
- 导出图片支持动态高度、长文本最多三行换行、项目链接二维码落款