### PR TITLE
Add gatcha favlist pool, refresh logic, UI polish, and smoke coverage

### DIFF
--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -53,6 +53,7 @@ _GATCHA_FAVLIST_TITLE_KEYWORDS = ("🎤", "卡拉", "k")
 GATCHA_RETRY_DELAY_SECONDS = 5
 GATCHA_FAVLIST_RETRY_DELAY_SECONDS = 3
 GATCHA_PROFILE_CACHE_TTL_SECONDS = 300
+GATCHA_TASK_BUSY_MESSAGE = "拉取任务执行中，请等待任务结束"
 MISSING_BILIBILI_COOKIE_MESSAGE = "请登录 Bilibili 账号或输入 Cookie"
 _COOKIE_REQUIRED_KEYS = {"sessdata", "bili_jct"}
 _COOKIE_PREFERRED_ORDER = (
@@ -199,6 +200,13 @@ def _save_gatcha_uid_payload(uid_payload: dict) -> None:
     with temp_path.open("w", encoding="utf-8") as handle:
         json.dump(uid_payload, handle, ensure_ascii=False, indent=2)
     temp_path.replace(_GATCHA_UIDS_FILE)
+
+
+def gatcha_task_snapshot() -> dict:
+    return {
+        "busy": _GATCHA_REFRESH_LOCK.locked(),
+        "message": GATCHA_TASK_BUSY_MESSAGE if _GATCHA_REFRESH_LOCK.locked() else "",
+    }
 
 
 def _normalize_gatcha_profile(raw_uid: object, raw_profile: object) -> dict | None:
@@ -663,6 +671,21 @@ def _matches_gatcha_favlist_title(title: str) -> bool:
     return any(keyword.lower() in normalized for keyword in _GATCHA_FAVLIST_TITLE_KEYWORDS)
 
 
+def _selected_gatcha_favlist_folder_ids(raw_folder_ids: object) -> set[str] | None:
+    if raw_folder_ids is None:
+        return None
+    if not isinstance(raw_folder_ids, list):
+        raise BilibiliError("收藏夹选择格式不正确")
+    folder_ids: set[str] = set()
+    for value in raw_folder_ids:
+        folder_id = str(value or "").strip()
+        if folder_id and folder_id.isdigit():
+            folder_ids.add(folder_id)
+    if not folder_ids:
+        raise BilibiliError("请选择至少一个收藏夹")
+    return folder_ids
+
+
 def _is_public_gatcha_favlist_folder(folder: dict) -> bool:
     try:
         attr = int(folder.get("attr") or 0)
@@ -678,6 +701,42 @@ def _request_gatcha_favlist_folders(mid: str) -> list[dict]:
     data = payload.get("data")
     folders = data.get("list") if isinstance(data, dict) else []
     return [dict(folder) for folder in folders if isinstance(folder, dict)]
+
+
+def _gatcha_favlist_folder_summary(folder: dict) -> dict:
+    folder_id = _gatcha_favlist_media_id(folder)
+    try:
+        media_count = int(folder.get("media_count") or 0)
+    except (TypeError, ValueError):
+        media_count = 0
+    title = str(folder.get("title") or "").strip()
+    return {
+        "id": folder_id,
+        "fid": str(folder.get("fid") or ""),
+        "title": title,
+        "media_count": media_count,
+        "selected": _matches_gatcha_favlist_title(title),
+    }
+
+
+def preview_gatcha_favlist(raw_mid: object) -> dict:
+    mid = _normalize_gatcha_uid(raw_mid)
+    folders = _request_gatcha_favlist_folders(mid)
+    public_folders: list[dict] = []
+    for folder in folders:
+        title = str(folder.get("title") or "").strip()
+        if not title or not _is_public_gatcha_favlist_folder(folder):
+            continue
+        summary = _gatcha_favlist_folder_summary(folder)
+        if summary["id"]:
+            public_folders.append(summary)
+    return {
+        "uid": mid,
+        "folder_count": len(folders),
+        "public_folder_count": len(public_folders),
+        "selected_folder_ids": [folder["id"] for folder in public_folders if folder.get("selected")],
+        "folders": public_folders,
+    }
 
 
 def _request_gatcha_favlist_page(media_id: str, page_number: int, page_size: int = 20) -> dict:
@@ -771,27 +830,25 @@ def _fetch_gatcha_favlist_entries_for_folder(uid: str, folder: dict, *, max_page
     return entries
 
 
-def refresh_gatcha_favlist(raw_mid: object) -> dict:
+def _refresh_gatcha_favlist_unlocked(raw_mid: object, raw_folder_ids: object = None) -> dict:
     mid = _normalize_gatcha_uid(raw_mid)
+    selected_folder_ids = _selected_gatcha_favlist_folder_ids(raw_folder_ids)
     folders = _request_gatcha_favlist_folders(mid)
     matched_folders: list[dict] = []
     entries: list[dict] = []
 
     for folder in folders:
         title = str(folder.get("title") or "").strip()
-        if not title or not _is_public_gatcha_favlist_folder(folder) or not _matches_gatcha_favlist_title(title):
+        if not title or not _is_public_gatcha_favlist_folder(folder):
             continue
         folder_id = _gatcha_favlist_media_id(folder)
-        try:
-            media_count = int(folder.get("media_count") or 0)
-        except (TypeError, ValueError):
-            media_count = 0
-        matched_folder = {
-            "id": folder_id,
-            "fid": str(folder.get("fid") or ""),
-            "title": title,
-            "media_count": media_count,
-        }
+        if selected_folder_ids is None:
+            if not _matches_gatcha_favlist_title(title):
+                continue
+        elif folder_id not in selected_folder_ids:
+            continue
+        matched_folder = _gatcha_favlist_folder_summary(folder)
+        matched_folder.pop("selected", None)
         matched_folders.append(matched_folder)
         entries.extend(_fetch_gatcha_favlist_entries_for_folder(mid, folder))
 
@@ -812,6 +869,25 @@ def refresh_gatcha_favlist(raw_mid: object) -> dict:
         "item_count": len(deduped_entries),
         "updated_at": payload["updated_at"],
     }
+
+
+def refresh_gatcha_favlist(
+    raw_mid: object,
+    raw_folder_ids: object = None,
+    *,
+    on_start: callable | None = None,
+    on_done: callable | None = None,
+) -> dict:
+    if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
+        raise BilibiliError(GATCHA_TASK_BUSY_MESSAGE)
+    try:
+        if on_start is not None:
+            on_start()
+        return _refresh_gatcha_favlist_unlocked(raw_mid, raw_folder_ids)
+    finally:
+        _GATCHA_REFRESH_LOCK.release()
+        if on_done is not None:
+            on_done()
 
 
 def _refresh_existing_gatcha_favlist_cache() -> dict | None:
@@ -984,9 +1060,17 @@ def refresh_gatcha_cache() -> dict:
     return cache_payload
 
 
-def refresh_gatcha_cache_in_background() -> bool:
-    if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
-        return False
+def refresh_gatcha_cache_in_background(
+    *,
+    on_start: callable | None = None,
+    on_done: callable | None = None,
+    use_global_lock: bool = True,
+) -> bool:
+    if use_global_lock:
+        if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
+            return False
+        if on_start is not None:
+            on_start()
 
     def _worker() -> None:
         try:
@@ -994,41 +1078,47 @@ def refresh_gatcha_cache_in_background() -> bool:
         except Exception:
             return
         finally:
-            _GATCHA_REFRESH_LOCK.release()
+            if use_global_lock:
+                _GATCHA_REFRESH_LOCK.release()
+                if on_done is not None:
+                    on_done()
 
     threading.Thread(target=_worker, daemon=True, name="gatcha-cache-refresh").start()
     return True
 
 
-def add_gatcha_uid(raw_mid: object) -> dict:
-    preview = preview_gatcha_uid(raw_mid)
-    mid = preview["uid"]
-    with _GATCHA_UIDS_LOCK:
-        uid_payload = _load_gatcha_uid_payload()
-        uids = uid_payload.get("uids") if isinstance(uid_payload, dict) else []
-        if not isinstance(uids, list):
-            uids = []
-        added = False
-        if mid in uids:
-            uids = list(uids)
-        else:
-            uids.append(mid)
-            uid_payload["uids"] = uids
-            added = True
-        profiles = uid_payload.get("profiles")
-        if not isinstance(profiles, dict):
-            profiles = {}
-        profiles[mid] = {
-            "uid": mid,
-            "name": preview["name"],
-            "space_url": preview["space_url"],
-        }
-        uid_payload["profiles"] = profiles
-        uid_payload["updated_at"] = time.time()
-        _save_gatcha_uid_payload(uid_payload)
-
-    _GATCHA_REFRESH_LOCK.acquire()
+def add_gatcha_uid(raw_mid: object, *, on_start: callable | None = None, on_done: callable | None = None) -> dict:
+    if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
+        raise BilibiliError(GATCHA_TASK_BUSY_MESSAGE)
     try:
+        if on_start is not None:
+            on_start()
+        preview = preview_gatcha_uid(raw_mid)
+        mid = preview["uid"]
+        with _GATCHA_UIDS_LOCK:
+            uid_payload = _load_gatcha_uid_payload()
+            uids = uid_payload.get("uids") if isinstance(uid_payload, dict) else []
+            if not isinstance(uids, list):
+                uids = []
+            added = False
+            if mid in uids:
+                uids = list(uids)
+            else:
+                uids.append(mid)
+                uid_payload["uids"] = uids
+                added = True
+            profiles = uid_payload.get("profiles")
+            if not isinstance(profiles, dict):
+                profiles = {}
+            profiles[mid] = {
+                "uid": mid,
+                "name": preview["name"],
+                "space_url": preview["space_url"],
+            }
+            uid_payload["profiles"] = profiles
+            uid_payload["updated_at"] = time.time()
+            _save_gatcha_uid_payload(uid_payload)
+
         with _GATCHA_CACHE_LOCK:
             cache_payload = _load_gatcha_cache()
         cache_profiles = cache_payload.get("profiles") if isinstance(cache_payload, dict) else {}
@@ -1043,6 +1133,8 @@ def add_gatcha_uid(raw_mid: object) -> dict:
         cache_result = _refresh_gatcha_uid_cache(cache_payload, mid)
     finally:
         _GATCHA_REFRESH_LOCK.release()
+        if on_done is not None:
+            on_done()
 
     return {
         "uid": mid,

--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -43,8 +43,15 @@ _GATCHA_REQUEST_LOCK = threading.Lock()
 _GATCHA_LAST_REQUEST_AT = 0.0
 _GATCHA_CACHE_FILE = cfg.DATA_DIR / "gatcha_cache.json"
 _GATCHA_UIDS_FILE = cfg.DATA_DIR / "gatcha_uids.json"
+_GATCHA_FAVLIST_FILE = cfg.DATA_DIR / "gatcha_favlist.json"
 _GATCHA_CACHE_SCHEMA_VERSION = 2
+_GATCHA_FAVLIST_SCHEMA_VERSION = 1
+_GATCHA_FAVLIST_LOCK = threading.Lock()
+_GATCHA_FAVLIST_REQUEST_LOCK = threading.Lock()
+_GATCHA_FAVLIST_LAST_REQUEST_AT = 0.0
+_GATCHA_FAVLIST_TITLE_KEYWORDS = ("🎤", "卡拉", "k")
 GATCHA_RETRY_DELAY_SECONDS = 5
+GATCHA_FAVLIST_RETRY_DELAY_SECONDS = 3
 GATCHA_PROFILE_CACHE_TTL_SECONDS = 300
 MISSING_BILIBILI_COOKIE_MESSAGE = "请登录 Bilibili 账号或输入 Cookie"
 _COOKIE_REQUIRED_KEYS = {"sessdata", "bili_jct"}
@@ -364,6 +371,42 @@ def _save_gatcha_cache(cache_payload: dict) -> None:
     temp_path.replace(_GATCHA_CACHE_FILE)
 
 
+def _empty_gatcha_favlist_payload() -> dict:
+    return {"schema_version": _GATCHA_FAVLIST_SCHEMA_VERSION, "uid": "", "folders": [], "items": [], "updated_at": 0}
+
+
+def _load_gatcha_favlist() -> dict:
+    if not _GATCHA_FAVLIST_FILE.exists():
+        return _empty_gatcha_favlist_payload()
+    try:
+        with _GATCHA_FAVLIST_FILE.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return _empty_gatcha_favlist_payload()
+    if not isinstance(payload, dict):
+        return _empty_gatcha_favlist_payload()
+    folders = payload.get("folders")
+    if not isinstance(folders, list):
+        folders = []
+    items = _dedupe_gatcha_entries(payload.get("items"))
+    return {
+        "schema_version": _GATCHA_FAVLIST_SCHEMA_VERSION,
+        "uid": str(payload.get("uid") or ""),
+        "folders": [dict(folder) for folder in folders if isinstance(folder, dict)],
+        "items": items,
+        "updated_at": float(payload.get("updated_at") or 0),
+    }
+
+
+def _save_gatcha_favlist(payload: dict) -> None:
+    cfg.DATA_DIR.mkdir(parents=True, exist_ok=True)
+    payload["schema_version"] = _GATCHA_FAVLIST_SCHEMA_VERSION
+    temp_path = _GATCHA_FAVLIST_FILE.with_suffix(".tmp")
+    with temp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+    temp_path.replace(_GATCHA_FAVLIST_FILE)
+
+
 def _wait_for_gatcha_request_slot() -> None:
     global _GATCHA_LAST_REQUEST_AT
 
@@ -373,6 +416,34 @@ def _wait_for_gatcha_request_slot() -> None:
         if elapsed < GATCHA_RETRY_DELAY_SECONDS:
             time.sleep(GATCHA_RETRY_DELAY_SECONDS - elapsed)
         _GATCHA_LAST_REQUEST_AT = time.monotonic()
+
+
+def _wait_for_gatcha_favlist_request_slot() -> None:
+    global _GATCHA_FAVLIST_LAST_REQUEST_AT
+
+    with _GATCHA_FAVLIST_REQUEST_LOCK:
+        now = time.monotonic()
+        elapsed = now - _GATCHA_FAVLIST_LAST_REQUEST_AT
+        if elapsed < GATCHA_FAVLIST_RETRY_DELAY_SECONDS:
+            time.sleep(GATCHA_FAVLIST_RETRY_DELAY_SECONDS - elapsed)
+        _GATCHA_FAVLIST_LAST_REQUEST_AT = time.monotonic()
+
+
+def _request_gatcha_favlist_json(url: str, error_label: str) -> dict:
+    while True:
+        _wait_for_gatcha_favlist_request_slot()
+        payload = request_json(url)
+        try:
+            code = int(payload.get("code") or 0)
+        except (TypeError, ValueError):
+            code = 0
+        if code == 0:
+            return payload
+        message = str(payload.get("message") or error_label)
+        if code in {412, -412} or "412" in message:
+            time.sleep(GATCHA_FAVLIST_RETRY_DELAY_SECONDS)
+            continue
+        raise BilibiliError(message)
 
 
 def _matches_gatcha_keywords(title: str) -> bool:
@@ -583,6 +654,205 @@ def _dedupe_gatcha_entries(raw_entries: object) -> list[dict]:
     return entries
 
 
+def _is_expired_gatcha_entry(entry: dict) -> bool:
+    return str(entry.get("title") or "").strip() == "已失效视频"
+
+
+def _matches_gatcha_favlist_title(title: str) -> bool:
+    normalized = str(title or "").strip().lower().replace("ｋ", "k").replace("Ｋ", "k")
+    return any(keyword.lower() in normalized for keyword in _GATCHA_FAVLIST_TITLE_KEYWORDS)
+
+
+def _is_public_gatcha_favlist_folder(folder: dict) -> bool:
+    try:
+        attr = int(folder.get("attr") or 0)
+    except (TypeError, ValueError):
+        attr = 0
+    return (attr & 1) == 0
+
+
+def _request_gatcha_favlist_folders(mid: str) -> list[dict]:
+    query = urllib.parse.urlencode({"up_mid": str(mid), "platform": "web"})
+    url = f"https://api.bilibili.com/x/v3/fav/folder/created/list-all?{query}"
+    payload = _request_gatcha_favlist_json(url, "收藏夹列表拉取失败")
+    data = payload.get("data")
+    folders = data.get("list") if isinstance(data, dict) else []
+    return [dict(folder) for folder in folders if isinstance(folder, dict)]
+
+
+def _request_gatcha_favlist_page(media_id: str, page_number: int, page_size: int = 20) -> dict:
+    params = {
+        "media_id": str(media_id),
+        "platform": "web",
+        "pn": max(1, int(page_number)),
+        "ps": max(1, min(20, int(page_size))),
+        "order": "mtime",
+        "type": 0,
+    }
+    url = f"https://api.bilibili.com/x/v3/fav/resource/list?{urllib.parse.urlencode(params)}"
+    return _request_gatcha_favlist_json(url, "收藏夹内容拉取失败")
+
+
+def _gatcha_favlist_media_id(folder: dict) -> str:
+    for key in ("id", "media_id", "fid"):
+        value = str(folder.get(key) or "").strip()
+        if value and value.isdigit():
+            return value
+    return ""
+
+
+def _extract_gatcha_favlist_entries(uid: str, folder: dict, medias: object) -> list[dict]:
+    if not isinstance(medias, list):
+        return []
+    folder_id = _gatcha_favlist_media_id(folder)
+    folder_title = str(folder.get("title") or "").strip()
+    entries: list[dict] = []
+    for media in medias:
+        if not isinstance(media, dict):
+            continue
+        bvid = str(media.get("bvid") or "").strip()
+        title = str(media.get("title") or "").strip()
+        if not bvid or not title:
+            continue
+        upper = media.get("upper") if isinstance(media.get("upper"), dict) else {}
+        owner_mid = str(upper.get("mid") or media.get("upper_mid") or "").strip()
+        owner_name = str(upper.get("name") or media.get("upper_name") or "").strip()
+        entry = {
+            "mid": owner_mid,
+            "bvid": bvid,
+            "title": title,
+            "url": f"https://www.bilibili.com/video/{bvid}",
+            "fav_uid": str(uid),
+            "fav_folder_id": folder_id,
+            "fav_folder_title": folder_title,
+            "source": "favlist",
+        }
+        if owner_name:
+            entry["owner_name"] = owner_name
+        if owner_mid:
+            entry["owner_url"] = f"https://space.bilibili.com/{owner_mid}"
+        entries.append(entry)
+    return entries
+
+
+def _fetch_gatcha_favlist_entries_for_folder(uid: str, folder: dict, *, max_pages: int | None = None) -> list[dict]:
+    media_id = _gatcha_favlist_media_id(folder)
+    if not media_id:
+        return []
+    page_size = 20
+    page_number = 1
+    entries: list[dict] = []
+    page_limit = max(1, int(max_pages)) if max_pages is not None else None
+    while True:
+        payload = _request_gatcha_favlist_page(media_id, page_number, page_size)
+        data = payload.get("data") if isinstance(payload, dict) else {}
+        medias = data.get("medias") if isinstance(data, dict) else []
+        page_entries = _extract_gatcha_favlist_entries(uid, folder, medias)
+        entries.extend(page_entries)
+        info = data.get("info") if isinstance(data, dict) and isinstance(data.get("info"), dict) else {}
+        try:
+            media_count = int(info.get("media_count") or 0)
+        except (TypeError, ValueError):
+            media_count = 0
+        has_more = data.get("has_more") if isinstance(data, dict) else None
+        if not isinstance(medias, list) or not medias:
+            break
+        if page_limit is not None and page_number >= page_limit:
+            break
+        if media_count:
+            if page_number * page_size >= media_count:
+                break
+        else:
+            if len(medias) < page_size:
+                break
+            if isinstance(has_more, bool) and not has_more:
+                break
+        page_number += 1
+    return entries
+
+
+def refresh_gatcha_favlist(raw_mid: object) -> dict:
+    mid = _normalize_gatcha_uid(raw_mid)
+    folders = _request_gatcha_favlist_folders(mid)
+    matched_folders: list[dict] = []
+    entries: list[dict] = []
+
+    for folder in folders:
+        title = str(folder.get("title") or "").strip()
+        if not title or not _is_public_gatcha_favlist_folder(folder) or not _matches_gatcha_favlist_title(title):
+            continue
+        folder_id = _gatcha_favlist_media_id(folder)
+        try:
+            media_count = int(folder.get("media_count") or 0)
+        except (TypeError, ValueError):
+            media_count = 0
+        matched_folder = {
+            "id": folder_id,
+            "fid": str(folder.get("fid") or ""),
+            "title": title,
+            "media_count": media_count,
+        }
+        matched_folders.append(matched_folder)
+        entries.extend(_fetch_gatcha_favlist_entries_for_folder(mid, folder))
+
+    deduped_entries = _dedupe_gatcha_entries(entries)
+    payload = {
+        "schema_version": _GATCHA_FAVLIST_SCHEMA_VERSION,
+        "uid": mid,
+        "folders": matched_folders,
+        "items": deduped_entries,
+        "updated_at": time.time(),
+    }
+    with _GATCHA_FAVLIST_LOCK:
+        _save_gatcha_favlist(payload)
+    return {
+        "uid": mid,
+        "folder_count": len(folders),
+        "matched_folder_count": len(matched_folders),
+        "item_count": len(deduped_entries),
+        "updated_at": payload["updated_at"],
+    }
+
+
+def _refresh_existing_gatcha_favlist_cache() -> dict | None:
+    if not _GATCHA_FAVLIST_FILE.exists():
+        return None
+    with _GATCHA_FAVLIST_LOCK:
+        payload = _load_gatcha_favlist()
+
+    uid = str(payload.get("uid") or "").strip()
+    folders = payload.get("folders") if isinstance(payload, dict) else []
+    if not uid or not isinstance(folders, list) or not folders:
+        return None
+
+    fresh_entries: list[dict] = []
+    refreshed_folders = 0
+    for folder in folders:
+        if not isinstance(folder, dict):
+            continue
+        if not _gatcha_favlist_media_id(folder):
+            continue
+        entries = _fetch_gatcha_favlist_entries_for_folder(uid, folder, max_pages=1)
+        refreshed_folders += 1
+        fresh_entries.extend(entries)
+
+    if not refreshed_folders:
+        return None
+
+    merged_entries, added_count = _merge_incremental_gatcha_entries(payload.get("items"), fresh_entries)
+    payload["items"] = merged_entries
+    payload["updated_at"] = time.time()
+    with _GATCHA_FAVLIST_LOCK:
+        _save_gatcha_favlist(payload)
+    return {
+        "uid": uid,
+        "mode": "incremental",
+        "folder_count": refreshed_folders,
+        "added_count": added_count,
+        "total_count": len(merged_entries),
+    }
+
+
 def preview_gatcha_uid(raw_mid: object) -> dict:
     if not effective_bilibili_cookie():
         raise BilibiliError(MISSING_BILIBILI_COOKIE_MESSAGE)
@@ -707,6 +977,10 @@ def refresh_gatcha_cache() -> dict:
             cache_profiles[str(profile["uid"])] = profile
             known_profiles[str(profile["uid"])] = profile
         _refresh_gatcha_uid_cache(cache_payload, mid)
+    try:
+        _refresh_existing_gatcha_favlist_cache()
+    except Exception:
+        pass
     return cache_payload
 
 
@@ -794,6 +1068,13 @@ def _local_gatcha_candidates() -> list[dict]:
     return candidates
 
 
+def _local_gatcha_favlist_candidates() -> list[dict]:
+    with _GATCHA_FAVLIST_LOCK:
+        payload = _load_gatcha_favlist()
+    items = payload.get("items") if isinstance(payload, dict) else []
+    return [entry for entry in _dedupe_gatcha_entries(items) if isinstance(entry, dict)]
+
+
 def _local_gatcha_candidates_by_uid() -> dict[str, list[dict]]:
     with _GATCHA_CACHE_LOCK:
         cache_payload = _load_gatcha_cache()
@@ -818,7 +1099,7 @@ def search_gatcha_cache(query: str, *, limit: int = 30) -> list[dict]:
     if not normalized_query:
         return []
 
-    local_candidates = _local_gatcha_candidates()
+    local_candidates = _local_gatcha_candidates() + _local_gatcha_favlist_candidates()
     if not local_candidates and not effective_bilibili_cookie():
         raise BilibiliError(MISSING_BILIBILI_COOKIE_MESSAGE)
 
@@ -1324,11 +1605,27 @@ def get_cached_wbi_keys():
     return keys
 
 def fetch_gatcha_candidate() -> dict | None:
-    candidates_by_uid = _local_gatcha_candidates_by_uid()
-    if not candidates_by_uid:
+    raw_candidates_by_uid = _local_gatcha_candidates_by_uid()
+    candidates_by_uid: dict[str, list[dict]] = {}
+    for mid, entries in raw_candidates_by_uid.items():
+        valid_entries = [entry for entry in entries if isinstance(entry, dict) and not _is_expired_gatcha_entry(entry)]
+        if valid_entries:
+            candidates_by_uid[mid] = valid_entries
+    favlist_candidates = [entry for entry in _local_gatcha_favlist_candidates() if not _is_expired_gatcha_entry(entry)]
+    if not candidates_by_uid and not favlist_candidates:
         if not effective_bilibili_cookie():
             raise BilibiliError(MISSING_BILIBILI_COOKIE_MESSAGE)
         raise BilibiliError("本地稿件缓存还没准备好，请稍后再试")
+
+    if favlist_candidates and (not candidates_by_uid or random.random() < 0.5):
+        chosen = random.choice(favlist_candidates)
+        return {
+            "mid": str(chosen.get("mid") or ""),
+            "bvid": str(chosen.get("bvid") or ""),
+            "title": str(chosen.get("title") or ""),
+            "url": str(chosen.get("url") or ""),
+            "source": "favlist",
+        }
 
     chosen_mid = random.choice(list(candidates_by_uid.keys()))
     chosen = random.choice(candidates_by_uid[chosen_mid])
@@ -1337,4 +1634,5 @@ def fetch_gatcha_candidate() -> dict | None:
         "bvid": str(chosen.get("bvid") or ""),
         "title": str(chosen.get("title") or ""),
         "url": str(chosen.get("url") or ""),
+        "source": "cache",
     }

--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -22,9 +22,11 @@ from .bilibili import (
     browse_gatcha_cache,
     effective_bilibili_cookie,
     fetch_gatcha_candidate,
+    gatcha_task_snapshot,
     fetch_owner_info,
     fetch_video_item,
     gatcha_uid_snapshot,
+    preview_gatcha_favlist,
     preview_gatcha_uid,
     refresh_gatcha_cache_in_background,
     refresh_gatcha_favlist,
@@ -74,7 +76,7 @@ class AppContext:
         self.cache_manager = CacheManager(
             self.store,
             max_cache_items=MAX_CACHE_ITEMS,
-            on_bbdown_login_success=refresh_gatcha_cache_in_background,
+            on_bbdown_login_success=self.refresh_startup_gatcha_cache_in_background,
         )
         self.cache_manager.prepare_session()
         self._closed = False
@@ -104,6 +106,7 @@ class AppContext:
         self._remote_access = self._build_remote_access_payload(self._host, self._port, [])
         self._startup_lock = threading.RLock()
         self._startup_started = False
+        self._startup_gatcha_refresh_bypass_available = True
 
     def snapshot(self) -> dict:
         with self._state_change_condition:
@@ -118,6 +121,7 @@ class AppContext:
             "auto_restored_backup": self.auto_restored_backup,
         }
         payload["remote_access"] = self.remote_access_snapshot()
+        payload["gatcha"] = gatcha_task_snapshot()
         payload["player_control_command"] = self.player_control_command_snapshot()
         payload["player_status"] = self.player_status_snapshot(payload.get("current_item"))
         payload["app"] = {
@@ -126,6 +130,19 @@ class AppContext:
         }
         payload["state_revision"] = state_revision
         return payload
+
+    def refresh_gatcha_cache_in_background(self) -> bool:
+        return refresh_gatcha_cache_in_background(
+            on_start=self._notify_state_changed,
+            on_done=self._notify_state_changed,
+        )
+
+    def refresh_startup_gatcha_cache_in_background(self) -> bool:
+        with self._startup_lock:
+            if not self._startup_gatcha_refresh_bypass_available:
+                return self.refresh_gatcha_cache_in_background()
+            self._startup_gatcha_refresh_bypass_available = False
+        return refresh_gatcha_cache_in_background(use_global_lock=False)
 
     def add_item(self, item, *, position: str, requester_name: str) -> None:
         self.store.add_item(item, position=position, requester_name=requester_name)
@@ -755,21 +772,42 @@ class BilikaraHandler(BaseHTTPRequestHandler):
                 self._write_json({"ok": True, "data": CONTEXT.snapshot()})
                 return
             if route == "/api/gatcha/uids/add":
-                result = add_gatcha_uid(body.get("uid"))
+                result = add_gatcha_uid(
+                    body.get("uid"),
+                    on_start=CONTEXT._notify_state_changed,
+                    on_done=CONTEXT._notify_state_changed,
+                )
                 self._write_json({"ok": True, "data": result})
                 return
             if route == "/api/gatcha/uids/preview":
+                gatcha_task = gatcha_task_snapshot()
+                if gatcha_task.get("busy"):
+                    raise ValueError(gatcha_task.get("message") or "拉取任务执行中，请等待任务结束")
                 result = preview_gatcha_uid(body.get("uid"))
                 self._write_json({"ok": True, "data": result})
                 return
             if route == "/api/gatcha/refresh":
                 if not effective_bilibili_cookie():
                     raise ValueError(MISSING_BILIBILI_COOKIE_MESSAGE)
-                started = refresh_gatcha_cache_in_background()
+                started = CONTEXT.refresh_gatcha_cache_in_background()
+                if not started:
+                    raise ValueError("拉取任务执行中，请等待任务结束")
                 self._write_json({"ok": True, "data": {"started": started}})
                 return
+            if route == "/api/gatcha/favlist/preview":
+                gatcha_task = gatcha_task_snapshot()
+                if gatcha_task.get("busy"):
+                    raise ValueError(gatcha_task.get("message") or "拉取任务执行中，请等待任务结束")
+                result = preview_gatcha_favlist(body.get("uid"))
+                self._write_json({"ok": True, "data": result})
+                return
             if route == "/api/gatcha/favlist":
-                result = refresh_gatcha_favlist(body.get("uid"))
+                result = refresh_gatcha_favlist(
+                    body.get("uid"),
+                    body.get("folder_ids"),
+                    on_start=CONTEXT._notify_state_changed,
+                    on_done=CONTEXT._notify_state_changed,
+                )
                 self._write_json({"ok": True, "data": result})
                 return
             if route == "/api/player/audio-variant":
@@ -888,7 +926,7 @@ class BilikaraHandler(BaseHTTPRequestHandler):
                     cfg.COOKIE = f"SESSDATA={sessdata}; bili_jct={jct}"
                 if not effective_bilibili_cookie():
                     raise ValueError(MISSING_BILIBILI_COOKIE_MESSAGE)
-                refresh_gatcha_cache_in_background()
+                CONTEXT.refresh_gatcha_cache_in_background()
                 self._write_json({"ok": True, "message": "配置已实时生效"})
                 return
             self._write_json(
@@ -1127,7 +1165,7 @@ def _serve(
     server = ThreadingHTTPServer((host, actual_port), BilikaraHandler)
     CONTEXT.bind_server(server, shutdown_on_last_client=shutdown_on_last_client)
     if CONTEXT.cache_manager.bbdown_login_status().get("logged_in"):
-        refresh_gatcha_cache_in_background()
+        CONTEXT.refresh_startup_gatcha_cache_in_background()
     browser_host = "127.0.0.1" if host == "0.0.0.0" else host
     url = f"http://{browser_host}:{actual_port}"
     print(f"{status_label} running on {url}")

--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -27,6 +27,7 @@ from .bilibili import (
     gatcha_uid_snapshot,
     preview_gatcha_uid,
     refresh_gatcha_cache_in_background,
+    refresh_gatcha_favlist,
     search_gatcha_cache,
 )
 from .cache import CacheManager
@@ -766,6 +767,10 @@ class BilikaraHandler(BaseHTTPRequestHandler):
                     raise ValueError(MISSING_BILIBILI_COOKIE_MESSAGE)
                 started = refresh_gatcha_cache_in_background()
                 self._write_json({"ok": True, "data": {"started": started}})
+                return
+            if route == "/api/gatcha/favlist":
+                result = refresh_gatcha_favlist(body.get("uid"))
+                self._write_json({"ok": True, "data": result})
                 return
             if route == "/api/player/audio-variant":
                 self._require_id(body)

--- a/bilikara/store.py
+++ b/bilikara/store.py
@@ -862,7 +862,7 @@ class PlaylistStore:
 
     def _delete_runtime_json_files_unlocked(self) -> None:
         data_dir = self.state_file.parent
-        keep_names = {"gatcha_cache.json", "gatcha_uids.json"}
+        keep_names = {"gatcha_cache.json", "gatcha_uids.json", "gatcha_favlist.json"}
         for path in data_dir.glob("*.json"):
             if path.name in keep_names:
                 continue

--- a/scripts/dev_smoke_test.py
+++ b/scripts/dev_smoke_test.py
@@ -189,6 +189,7 @@ class SmokeRunner:
                 "gatcha-uid-form",
                 "refresh-gatcha-cache-button",
                 "pull-gatcha-favlist-button",
+                "gatcha-favlist-modal",
             ],
             "/remote": [
                 "follow-browse-toggle",
@@ -197,6 +198,9 @@ class SmokeRunner:
                 "binding-sheet-actions",
                 "history-export-row",
                 "gatcha-uid-form",
+                "refresh-gatcha-cache-button",
+                "pull-gatcha-favlist-button",
+                "gatcha-favlist-sheet",
             ],
             "/app.js": [
                 "fetchGatchaBrowse",
@@ -204,6 +208,7 @@ class SmokeRunner:
                 "handleAddByUrl",
                 "downloadHistoryExport",
                 "previewGatchaUid",
+                "/api/gatcha/favlist/preview",
                 "/api/gatcha/refresh",
                 "/api/gatcha/favlist",
                 "/api/app/update",
@@ -214,6 +219,9 @@ class SmokeRunner:
                 "addByUrl",
                 "downloadHistoryExport",
                 "previewGatchaUid",
+                "/api/gatcha/favlist/preview",
+                "/api/gatcha/refresh",
+                "/api/gatcha/favlist",
             ],
             "/styles.css": [
                 "grid-template-rows: auto auto minmax(0, 1fr) auto",

--- a/scripts/dev_smoke_test.py
+++ b/scripts/dev_smoke_test.py
@@ -75,6 +75,13 @@ class PlayerTimeWindowResult:
     current_time: float | None = None
 
 
+@dataclass
+class DownloadResponse:
+    body: bytes
+    content_type: str
+    content_disposition: str
+
+
 class SmokeRunner:
     def __init__(self, args: argparse.Namespace, handle: ServerHandle) -> None:
         self.args = args
@@ -113,6 +120,7 @@ class SmokeRunner:
         self.check_users()
         self.check_song_flow()
         self.check_player_controls()
+        self.check_history_exports()
         self.check_gatcha()
 
         if self.args.destructive:
@@ -176,34 +184,46 @@ class SmokeRunner:
                 "follow-up-grid",
                 "follow-song-results",
                 "binding-modal-confirm",
+                "history-export-button",
                 "update-check-button",
+                "gatcha-uid-form",
+                "refresh-gatcha-cache-button",
             ],
             "/remote": [
                 "follow-browse-toggle",
                 "follow-up-grid",
                 "follow-song-results",
                 "binding-sheet-actions",
+                "history-export-row",
+                "gatcha-uid-form",
             ],
             "/app.js": [
                 "fetchGatchaBrowse",
                 "followSongResults",
                 "handleAddByUrl",
+                "downloadHistoryExport",
+                "previewGatchaUid",
+                "/api/gatcha/refresh",
                 "/api/app/update",
             ],
             "/remote.js": [
                 "fetchGatchaBrowse",
                 "followSongResults",
                 "addByUrl",
+                "downloadHistoryExport",
+                "previewGatchaUid",
             ],
             "/styles.css": [
                 "grid-template-rows: auto auto minmax(0, 1fr) auto",
                 ".selection-modal-actions",
                 ".follow-up-grid",
+                ".gatcha-uid-view .gatcha-uid-form",
             ],
             "/remote.css": [
                 "flex-direction: column",
                 ".binding-sheet-actions",
                 ".follow-up-grid",
+                ".gatcha-uid-form",
             ],
         }
         for path, tokens in expected_tokens.items():
@@ -405,10 +425,13 @@ class SmokeRunner:
             print_skip("Smoke download quality", "No 480P video quality choice was available")
             return {}
 
-        policy_payload: dict[str, Any] = {"video_quality": target_quality}
+        policy_payload: dict[str, Any] = {"video_quality": target_quality, "audio_hires": False}
         state = self.api_post("/api/cache-policy", policy_payload)
         policy = state.get("cache_policy") or {}
-        print_ok(f"Smoke download video quality set to {policy.get('video_quality')} before song downloads")
+        print_ok(
+            "Smoke download policy set before song downloads: "
+            f"quality={policy.get('video_quality')} hires={policy.get('audio_hires')}"
+        )
 
         restore_payload: dict[str, Any] = {}
         if "video_quality" in original_policy:
@@ -1016,6 +1039,45 @@ class SmokeRunner:
         )
         self.visual_checkpoint("Confirm the player reloaded while queue/history stayed intact.", seconds=8)
 
+    def check_history_exports(self) -> None:
+        print_header("History export downloads")
+        csv_cases = [
+            ("played", False),
+            ("history", True),
+        ]
+        for source, remote in csv_cases:
+            response = self.http_download_get(
+                f"/api/history/export?format=csv&source={source}",
+                timeout=20,
+                remote=remote,
+            )
+            self.assert_download_filename(response, expected_fragment=f"bilikara-{source}", expected_suffix=".csv")
+            if not response.content_type.lower().startswith("text/csv"):
+                raise RuntimeError(f"CSV export returned unexpected content type: {response.content_type}")
+            if not response.body.startswith(b"\xef\xbb\xbf"):
+                raise RuntimeError(f"CSV export for {source} did not include a UTF-8 BOM")
+            response.body.decode("utf-8-sig")
+            client_label = "Remote" if remote else "Host"
+            print_ok(f"{client_label} {source} CSV export downloads ({len(response.body)} bytes)")
+
+        image_response = self.http_download_get(
+            "/api/history/export?format=image&source=played",
+            timeout=30,
+        )
+        image_type = image_response.content_type.lower()
+        if image_type == "image/png":
+            self.assert_download_filename(image_response, expected_fragment="bilikara-played", expected_suffix=".png")
+            if not image_response.body.startswith(b"\x89PNG\r\n\x1a\n"):
+                raise RuntimeError("Played image export did not return PNG bytes")
+            print_ok(f"Played image export downloads as PNG ({len(image_response.body)} bytes)")
+        elif image_type == "application/zip":
+            self.assert_download_filename(image_response, expected_fragment="bilikara-played", expected_suffix=".zip")
+            if not image_response.body.startswith(b"PK"):
+                raise RuntimeError("Played image export did not return ZIP bytes")
+            print_ok(f"Played image export downloads as ZIP ({len(image_response.body)} bytes)")
+        else:
+            raise RuntimeError(f"Image export returned unexpected content type: {image_response.content_type}")
+
     def seek_current_item_near_end(self, item_id: str, *, tail_seconds: float) -> bool:
         state = self.get_state()
         item = self.find_item_by_id(state, item_id)
@@ -1245,6 +1307,7 @@ class SmokeRunner:
 
     def check_gatcha(self) -> None:
         print_header("Gatcha")
+        self.check_gatcha_uid_management_api()
         try:
             result = self.http_get(f"/api/gatcha/search?q={urllib.parse.quote(GATCHA_MULTI_PAGE_QUERY)}")
             items = ((result.get("data") or {}).get("items") or []) if isinstance(result, dict) else []
@@ -1262,6 +1325,29 @@ class SmokeRunner:
                 print_warn(f"Gatcha candidate returned no song: {result.get('error')}")
         except Exception as exc:  # noqa: BLE001
             print_warn(f"Gatcha candidate skipped/failed: {exc}")
+
+    def check_gatcha_uid_management_api(self) -> None:
+        try:
+            result = self.http_get("/api/gatcha/uids", timeout=10)
+        except Exception as exc:  # noqa: BLE001
+            raise RuntimeError(f"Gatcha UID snapshot API failed: {exc}") from exc
+        data = result.get("data") if isinstance(result, dict) else {}
+        uids = data.get("uids") if isinstance(data, dict) else None
+        count = data.get("count") if isinstance(data, dict) else None
+        if not isinstance(uids, list) or not isinstance(count, int):
+            raise RuntimeError("Gatcha UID snapshot returned an invalid payload")
+        if count != len(uids):
+            raise RuntimeError(f"Gatcha UID snapshot count mismatch: count={count} len={len(uids)}")
+        print_ok(f"Gatcha UID snapshot API works: {count} UID(s)")
+
+        try:
+            self.api_post("/api/gatcha/uids/preview", {"uid": "BV1xx411c7mD"}, timeout=10)
+        except ApiError as exc:
+            if exc.status != 400:
+                raise RuntimeError(f"Gatcha UID preview invalid-input check returned HTTP {exc.status}") from exc
+            print_ok("Gatcha UID preview rejects BV/video IDs before adding anything")
+            return
+        raise RuntimeError("Gatcha UID preview accepted a BV/video ID")
 
     def check_follow_browse_api(self, label: str, *, remote: bool) -> None:
         try:
@@ -1381,6 +1467,33 @@ class SmokeRunner:
         )
         return self.open_request(path, request, timeout=timeout, expect_json=expect_json)
 
+    def http_download_get(
+        self,
+        path: str,
+        *,
+        timeout: int | float = 20,
+        remote: bool = False,
+    ) -> DownloadResponse:
+        request = urllib.request.Request(
+            self.base_url + path,
+            headers=self.request_headers(remote=remote),
+            method="GET",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return DownloadResponse(
+                    body=response.read(),
+                    content_type=response.headers.get("Content-Type", ""),
+                    content_disposition=response.headers.get("Content-Disposition", ""),
+                )
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            try:
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                payload = {"ok": False, "error": raw or str(exc)}
+            raise ApiError(path, exc.code, payload) from exc
+
     def http_post(
         self,
         path: str,
@@ -1422,6 +1535,24 @@ class SmokeRunner:
             except json.JSONDecodeError:
                 payload = {"ok": False, "error": raw or str(exc)}
             raise ApiError(path, exc.code, payload) from exc
+
+    @staticmethod
+    def assert_download_filename(
+        response: DownloadResponse,
+        *,
+        expected_fragment: str,
+        expected_suffix: str,
+    ) -> None:
+        disposition = response.content_disposition
+        if "attachment" not in disposition.lower():
+            raise RuntimeError(f"Download response missing attachment disposition: {disposition}")
+        filename = disposition
+        if "filename*=" in disposition:
+            filename = urllib.parse.unquote(disposition.split("filename*=", 1)[1].split("''", 1)[-1])
+        elif "filename=" in disposition:
+            filename = disposition.split("filename=", 1)[1].strip().strip('"')
+        if expected_fragment not in filename or not filename.lower().endswith(expected_suffix):
+            raise RuntimeError(f"Unexpected download filename: {filename}")
 
     @staticmethod
     def item_ids(state: dict[str, Any]) -> set[str]:

--- a/scripts/dev_smoke_test.py
+++ b/scripts/dev_smoke_test.py
@@ -188,6 +188,7 @@ class SmokeRunner:
                 "update-check-button",
                 "gatcha-uid-form",
                 "refresh-gatcha-cache-button",
+                "pull-gatcha-favlist-button",
             ],
             "/remote": [
                 "follow-browse-toggle",
@@ -204,6 +205,7 @@ class SmokeRunner:
                 "downloadHistoryExport",
                 "previewGatchaUid",
                 "/api/gatcha/refresh",
+                "/api/gatcha/favlist",
                 "/api/app/update",
             ],
             "/remote.js": [
@@ -1346,8 +1348,17 @@ class SmokeRunner:
             if exc.status != 400:
                 raise RuntimeError(f"Gatcha UID preview invalid-input check returned HTTP {exc.status}") from exc
             print_ok("Gatcha UID preview rejects BV/video IDs before adding anything")
+        else:
+            raise RuntimeError("Gatcha UID preview accepted a BV/video ID")
+
+        try:
+            self.api_post("/api/gatcha/favlist", {"uid": "BV1xx411c7mD"}, timeout=10)
+        except ApiError as exc:
+            if exc.status != 400:
+                raise RuntimeError(f"Gatcha favlist invalid-input check returned HTTP {exc.status}") from exc
+            print_ok("Gatcha favlist pull rejects BV/video IDs before writing cache")
             return
-        raise RuntimeError("Gatcha UID preview accepted a BV/video ID")
+        raise RuntimeError("Gatcha favlist pull accepted a BV/video ID")
 
     def check_follow_browse_api(self, label: str, *, remote: bool) -> None:
         try:

--- a/static/app.js
+++ b/static/app.js
@@ -100,6 +100,7 @@ const state = {
   dragTargetAfter: false,
   confirmIntent: null,
   bindingIntent: null,
+  gatchaFavlistIntent: null,
   retryActivityById: {},
   gatchaCandidate: null,
   searchCookieVisible: false,
@@ -212,6 +213,13 @@ const elements = {
   bindingModalClose: document.getElementById("binding-modal-close"),
   bindingModalCancel: document.getElementById("binding-modal-cancel"),
   bindingModalConfirm: document.getElementById("binding-modal-confirm"),
+  gatchaFavlistModal: document.getElementById("gatcha-favlist-modal"),
+  gatchaFavlistModalBackdrop: document.getElementById("gatcha-favlist-modal-backdrop"),
+  gatchaFavlistModalText: document.getElementById("gatcha-favlist-modal-text"),
+  gatchaFavlistOptions: document.getElementById("gatcha-favlist-options"),
+  gatchaFavlistModalClose: document.getElementById("gatcha-favlist-modal-close"),
+  gatchaFavlistModalCancel: document.getElementById("gatcha-favlist-modal-cancel"),
+  gatchaFavlistModalConfirm: document.getElementById("gatcha-favlist-modal-confirm"),
   copyRemoteUrlButton: document.getElementById("copy-remote-url-button"),
   remoteQrImage: document.getElementById("remote-qr-image"),
   remoteQrPlaceholder: document.getElementById("remote-qr-placeholder"),
@@ -828,8 +836,15 @@ async function refreshGatchaCache() {
   return apiPost("/api/gatcha/refresh");
 }
 
-async function pullGatchaFavlist(uid) {
-  return apiPost("/api/gatcha/favlist", { uid: String(uid || "").trim() });
+async function previewGatchaFavlist(uid) {
+  return apiPost("/api/gatcha/favlist/preview", { uid: String(uid || "").trim() });
+}
+
+async function pullGatchaFavlist(uid, folderIds = []) {
+  return apiPost("/api/gatcha/favlist", {
+    uid: String(uid || "").trim(),
+    folder_ids: Array.isArray(folderIds) ? folderIds : [],
+  });
 }
 
 function gatchaUidResultMessage(result, fallbackUid = "") {
@@ -844,6 +859,11 @@ function gatchaUidResultMessage(result, fallbackUid = "") {
 
 async function confirmGatchaUidAdd(intent) {
   closeConfirm();
+  if (gatchaTaskBusy()) {
+    setGatchaUidMessage(gatchaTaskBusyMessage(), true);
+    renderGatchaUidFace();
+    return;
+  }
   state.gatchaUidSaving = true;
   renderGatchaUidFace();
   setGatchaUidMessage(`正在拉取 UP 主：${intent.name || intent.uid} 的稿件...`);
@@ -1082,6 +1102,14 @@ function setGatchaUidMessage(message, isError = false) {
   elements.gatchaUidMessage.classList.toggle("is-error", Boolean(isError));
 }
 
+function gatchaTaskBusy() {
+  return Boolean(state.data?.gatcha?.busy);
+}
+
+function gatchaTaskBusyMessage() {
+  return state.data?.gatcha?.message || "拉取任务执行中，请等待任务结束";
+}
+
 function syncSearchStageView(showCookie) {
   const nextView = showCookie ? "browse" : "search";
   const isInitialRender = !state.searchStageView;
@@ -1143,11 +1171,14 @@ function renderSearchCookieFace() {
 
 function renderGatchaUidFace() {
   const showUid = Boolean(state.gatchaUidVisible);
+  const taskBusy = gatchaTaskBusy();
   const signature = JSON.stringify({
     showUid,
     saving: state.gatchaUidSaving,
     refreshing: state.gatchaRefreshSaving,
     favlistSaving: state.gatchaFavlistSaving,
+    taskBusy,
+    taskMessage: gatchaTaskBusyMessage(),
   });
   if (signature === state.gatchaUidFaceRenderSignature) {
     return;
@@ -1163,16 +1194,24 @@ function renderGatchaUidFace() {
     elements.gatchaUidToggle.setAttribute("aria-pressed", String(showUid));
   }
   if (elements.addGatchaUidButton) {
-    elements.addGatchaUidButton.disabled = state.gatchaUidSaving;
+    elements.addGatchaUidButton.disabled = state.gatchaUidSaving || taskBusy;
     elements.addGatchaUidButton.textContent = state.gatchaUidSaving ? "处理中" : "添加";
   }
   if (elements.refreshGatchaCacheButton) {
-    elements.refreshGatchaCacheButton.disabled = state.gatchaRefreshSaving;
+    elements.refreshGatchaCacheButton.disabled = state.gatchaRefreshSaving || taskBusy;
     elements.refreshGatchaCacheButton.textContent = state.gatchaRefreshSaving ? "更新中" : "手动更新";
   }
   if (elements.pullGatchaFavlistButton) {
-    elements.pullGatchaFavlistButton.disabled = state.gatchaFavlistSaving;
+    elements.pullGatchaFavlistButton.disabled = state.gatchaFavlistSaving || taskBusy;
     elements.pullGatchaFavlistButton.textContent = state.gatchaFavlistSaving ? "拉取中" : "拉取收藏";
+  }
+  if (taskBusy) {
+    if (elements.refreshGatchaCacheButton) {
+      elements.refreshGatchaCacheButton.textContent = "全局冷却中";
+    }
+    if (elements.pullGatchaFavlistButton) {
+      elements.pullGatchaFavlistButton.textContent = "全局冷却中";
+    }
   }
 }
 
@@ -3793,6 +3832,92 @@ function openBindingModal(intent, payload) {
   elements.bindingModal.classList.remove("hidden");
 }
 
+function closeGatchaFavlistModal() {
+  state.gatchaFavlistIntent = null;
+  elements.gatchaFavlistModal?.classList.add("hidden");
+  if (elements.gatchaFavlistOptions) {
+    elements.gatchaFavlistOptions.innerHTML = "";
+  }
+}
+
+function selectedGatchaFavlistFolderIds() {
+  return [...(elements.gatchaFavlistOptions?.querySelectorAll('input[name="gatcha-favlist-folder"]:checked') || [])]
+    .map((input) => String(input.value || "").trim())
+    .filter(Boolean);
+}
+
+function renderGatchaFavlistOption(folder) {
+  const label = document.createElement("label");
+  label.className = "selection-option";
+
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.name = "gatcha-favlist-folder";
+  input.value = String(folder.id || "");
+  input.checked = Boolean(folder.selected);
+
+  const copy = document.createElement("div");
+  const title = document.createElement("div");
+  title.className = "selection-option-title";
+  title.textContent = folder.title || `收藏夹 ${folder.id || ""}`;
+  const meta = document.createElement("div");
+  meta.className = "selection-option-meta";
+  const count = Number(folder.media_count || 0);
+  meta.textContent = `${count || 0} 个稿件${folder.selected ? " · 命中默认筛选" : ""}`;
+  copy.append(title, meta);
+
+  label.append(input, copy);
+  return label;
+}
+
+function openGatchaFavlistModal(uid, payload) {
+  const folders = Array.isArray(payload?.folders) ? payload.folders : [];
+  if (!folders.length) {
+    setGatchaUidMessage("没有读取到公开收藏夹。", true);
+    return;
+  }
+  state.gatchaFavlistIntent = { uid, folders };
+  elements.gatchaFavlistModalText.textContent = `UID ${payload?.uid || uid} 共有 ${payload?.public_folder_count || folders.length} 个公开收藏夹，请选择要加入抽卡收藏池的收藏夹。`;
+  elements.gatchaFavlistOptions.innerHTML = "";
+  folders.forEach((folder) => {
+    elements.gatchaFavlistOptions.appendChild(renderGatchaFavlistOption(folder));
+  });
+  elements.gatchaFavlistModal.classList.remove("hidden");
+}
+
+async function confirmGatchaFavlistModal() {
+  const intent = state.gatchaFavlistIntent;
+  if (!intent?.uid) {
+    return;
+  }
+  const folderIds = selectedGatchaFavlistFolderIds();
+  if (!folderIds.length) {
+    setGatchaUidMessage("请选择至少一个收藏夹", true);
+    return;
+  }
+  if (gatchaTaskBusy()) {
+    setGatchaUidMessage(gatchaTaskBusyMessage(), true);
+    renderGatchaUidFace();
+    return;
+  }
+
+  state.gatchaFavlistSaving = true;
+  renderGatchaUidFace();
+  setGatchaUidMessage("正在拉取选中的公开收藏夹...");
+  try {
+    const result = await pullGatchaFavlist(intent.uid, folderIds);
+    closeGatchaFavlistModal();
+    setGatchaUidMessage(
+      `已拉取 ${result?.matched_folder_count || 0} 个收藏夹，加入 ${result?.item_count || 0} 个稿件。`,
+    );
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaFavlistSaving = false;
+    renderGatchaUidFace();
+  }
+}
+
 async function confirmBindingModal() {
   const intent = state.bindingIntent;
   if (!intent?.url) {
@@ -4975,6 +5100,22 @@ elements.bindingModalConfirm?.addEventListener("click", async () => {
   await confirmBindingModal();
 });
 
+elements.gatchaFavlistModalClose?.addEventListener("click", () => {
+  closeGatchaFavlistModal();
+});
+
+elements.gatchaFavlistModalCancel?.addEventListener("click", () => {
+  closeGatchaFavlistModal();
+});
+
+elements.gatchaFavlistModalBackdrop?.addEventListener("click", () => {
+  closeGatchaFavlistModal();
+});
+
+elements.gatchaFavlistModalConfirm?.addEventListener("click", async () => {
+  await confirmGatchaFavlistModal();
+});
+
 elements.confirmOk.addEventListener("click", async () => {
   const intent = state.confirmIntent;
   if (!intent) {
@@ -5079,6 +5220,9 @@ document.addEventListener("keydown", (event) => {
   }
   if (state.bindingIntent) {
     closeBindingModal();
+  }
+  if (state.gatchaFavlistIntent) {
+    closeGatchaFavlistModal();
   }
   if (state.confirmIntent) {
     closeConfirm();
@@ -5372,6 +5516,12 @@ elements.gatchaUidForm?.addEventListener("submit", async (event) => {
     return;
   }
 
+  if (gatchaTaskBusy()) {
+    setGatchaUidMessage(gatchaTaskBusyMessage(), true);
+    renderGatchaUidFace();
+    return;
+  }
+
   state.gatchaUidSaving = true;
   renderGatchaUidFace();
   setGatchaUidMessage("正在检测 UID...");
@@ -5398,11 +5548,19 @@ elements.gatchaUidForm?.addEventListener("submit", async (event) => {
 });
 
 elements.refreshGatchaCacheButton?.addEventListener("click", async () => {
+  if (gatchaTaskBusy()) {
+    setGatchaUidMessage(gatchaTaskBusyMessage(), true);
+    renderGatchaUidFace();
+    return;
+  }
   state.gatchaRefreshSaving = true;
   renderGatchaUidFace();
   setGatchaUidMessage("正在后台更新抽卡缓存...");
   try {
     const result = await refreshGatchaCache();
+    if (result?.started !== false && state.data) {
+      state.data.gatcha = { busy: true, message: gatchaTaskBusyMessage() };
+    }
     setGatchaUidMessage(result?.started === false ? "抽卡缓存已经在更新中。" : "已开始更新抽卡缓存。");
   } catch (error) {
     setGatchaUidMessage(error.message, true);
@@ -5419,14 +5577,19 @@ elements.pullGatchaFavlistButton?.addEventListener("click", async () => {
     return;
   }
 
+  if (gatchaTaskBusy()) {
+    setGatchaUidMessage(gatchaTaskBusyMessage(), true);
+    renderGatchaUidFace();
+    return;
+  }
+
   state.gatchaFavlistSaving = true;
   renderGatchaUidFace();
-  setGatchaUidMessage("正在拉取公开收藏夹...(标题含🎤/卡拉/k)");
+  setGatchaUidMessage("正在读取公开收藏夹...");
   try {
-    const result = await pullGatchaFavlist(uid);
-    setGatchaUidMessage(
-      `已拉取 ${result?.matched_folder_count || 0} 个收藏夹，加入 ${result?.item_count || 0} 个稿件。`
-    );
+    const result = await previewGatchaFavlist(uid);
+    openGatchaFavlistModal(result?.uid || uid, result);
+    setGatchaUidMessage("请选择要拉取的收藏夹。");
   } catch (error) {
     setGatchaUidMessage(error.message, true);
   } finally {

--- a/static/app.js
+++ b/static/app.js
@@ -113,6 +113,7 @@ const state = {
   gatchaUidVisible: false,
   gatchaUidSaving: false,
   gatchaRefreshSaving: false,
+  gatchaFavlistSaving: false,
   bbdownLoginRequesting: false,
   updateChecking: false,
   updatePreviewEnabled: false,
@@ -263,6 +264,7 @@ const elements = {
   gatchaUidInput: document.getElementById("gatcha-uid-input"),
   addGatchaUidButton: document.getElementById("add-gatcha-uid-button"),
   refreshGatchaCacheButton: document.getElementById("refresh-gatcha-cache-button"),
+  pullGatchaFavlistButton: document.getElementById("pull-gatcha-favlist-button"),
   gatchaUidMessage: document.getElementById("gatcha-uid-message"),
 };
 
@@ -826,6 +828,10 @@ async function refreshGatchaCache() {
   return apiPost("/api/gatcha/refresh");
 }
 
+async function pullGatchaFavlist(uid) {
+  return apiPost("/api/gatcha/favlist", { uid: String(uid || "").trim() });
+}
+
 function gatchaUidResultMessage(result, fallbackUid = "") {
   const cache = result?.cache || {};
   const addedCount = Number(cache.added_count || 0);
@@ -1141,6 +1147,7 @@ function renderGatchaUidFace() {
     showUid,
     saving: state.gatchaUidSaving,
     refreshing: state.gatchaRefreshSaving,
+    favlistSaving: state.gatchaFavlistSaving,
   });
   if (signature === state.gatchaUidFaceRenderSignature) {
     return;
@@ -1162,6 +1169,10 @@ function renderGatchaUidFace() {
   if (elements.refreshGatchaCacheButton) {
     elements.refreshGatchaCacheButton.disabled = state.gatchaRefreshSaving;
     elements.refreshGatchaCacheButton.textContent = state.gatchaRefreshSaving ? "更新中" : "手动更新";
+  }
+  if (elements.pullGatchaFavlistButton) {
+    elements.pullGatchaFavlistButton.disabled = state.gatchaFavlistSaving;
+    elements.pullGatchaFavlistButton.textContent = state.gatchaFavlistSaving ? "拉取中" : "拉取收藏";
   }
 }
 
@@ -5397,6 +5408,29 @@ elements.refreshGatchaCacheButton?.addEventListener("click", async () => {
     setGatchaUidMessage(error.message, true);
   } finally {
     state.gatchaRefreshSaving = false;
+    renderGatchaUidFace();
+  }
+});
+
+elements.pullGatchaFavlistButton?.addEventListener("click", async () => {
+  const uid = String(elements.gatchaUidInput?.value || "").trim();
+  if (!uid) {
+    setGatchaUidMessage("请输入 UID", true);
+    return;
+  }
+
+  state.gatchaFavlistSaving = true;
+  renderGatchaUidFace();
+  setGatchaUidMessage("正在拉取公开收藏夹...(标题含🎤/卡拉/k)");
+  try {
+    const result = await pullGatchaFavlist(uid);
+    setGatchaUidMessage(
+      `已拉取 ${result?.matched_folder_count || 0} 个收藏夹，加入 ${result?.item_count || 0} 个稿件。`
+    );
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaFavlistSaving = false;
     renderGatchaUidFace();
   }
 });

--- a/static/index.html
+++ b/static/index.html
@@ -686,6 +686,30 @@
       </div>
     </div>
 
+    <div class="selection-modal hidden" id="gatcha-favlist-modal" role="dialog" aria-modal="true">
+      <div class="selection-modal-backdrop" id="gatcha-favlist-modal-backdrop"></div>
+      <div class="selection-modal-card selection-modal-card-single">
+        <div class="selection-modal-head">
+          <div>
+            <p class="section-tag">Favlist Pull</p>
+            <h2>选择收藏夹</h2>
+          </div>
+          <button type="button" id="gatcha-favlist-modal-close" class="banner-close" aria-label="关闭">×</button>
+        </div>
+        <p class="selection-modal-text" id="gatcha-favlist-modal-text">请选择要拉取的公开收藏夹。</p>
+        <div class="selection-modal-grid selection-modal-grid-single">
+          <section class="selection-modal-column">
+            <h3>收藏夹</h3>
+            <div id="gatcha-favlist-options" class="selection-option-list"></div>
+          </section>
+        </div>
+        <div class="selection-modal-actions">
+          <button type="button" id="gatcha-favlist-modal-cancel" class="toolbar-button">取消</button>
+          <button type="button" id="gatcha-favlist-modal-confirm" class="next-button">拉取选中收藏夹</button>
+        </div>
+      </div>
+    </div>
+
     <script src="/app.js" defer></script>
   </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -498,6 +498,9 @@
                       <button type="button" id="refresh-gatcha-cache-button" class="toolbar-button gatcha-refresh-button">
                         手动更新
                       </button>
+                      <button type="button" id="pull-gatcha-favlist-button" class="toolbar-button gatcha-refresh-button">
+                        拉取收藏
+                      </button>
                       <p class="gatcha-message" id="gatcha-uid-message" role="status"></p>
                     </div>
                   </div>

--- a/static/remote.css
+++ b/static/remote.css
@@ -805,6 +805,14 @@ h1 {
   gap: 10px;
 }
 
+#gatcha-favlist-sheet .binding-sheet-section {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  padding-right: 4px;
+}
+
 .binding-accordion {
   min-height: 0;
   gap: 12px;
@@ -1357,6 +1365,11 @@ select:disabled {
 }
 
 .gatcha-uid-form .primary-button {
+  min-height: 48px;
+}
+
+.gatcha-refresh-button {
+  width: 100%;
   min-height: 48px;
 }
 

--- a/static/remote.html
+++ b/static/remote.html
@@ -263,6 +263,12 @@
             />
             <button type="submit" id="add-gatcha-uid-button" class="primary-button">添加</button>
           </form>
+          <button type="button" id="refresh-gatcha-cache-button" class="secondary-button gatcha-refresh-button">
+            手动更新
+          </button>
+          <button type="button" id="pull-gatcha-favlist-button" class="secondary-button gatcha-refresh-button">
+            拉取收藏
+          </button>
           <p class="gatcha-message" id="gatcha-uid-message" role="status"></p>
         </div>
       </section>
@@ -312,6 +318,27 @@
           <div class="binding-sheet-actions">
             <button type="button" id="binding-sheet-cancel" class="ghost-button">取消</button>
             <button type="button" id="binding-sheet-confirm" class="primary-button">加入点歌列表</button>
+          </div>
+        </div>
+      </div>
+      <div id="gatcha-favlist-sheet" class="binding-sheet hidden" aria-hidden="true">
+        <div id="gatcha-favlist-sheet-backdrop" class="binding-sheet-backdrop"></div>
+        <div class="binding-sheet-panel">
+          <div class="binding-sheet-handle" aria-hidden="true"></div>
+          <div class="binding-sheet-head">
+            <div>
+              <p class="panel-tag">Favlist Pull</p>
+              <h2>选择收藏夹</h2>
+            </div>
+            <button type="button" id="gatcha-favlist-sheet-close" class="ghost-button binding-sheet-close">关闭</button>
+          </div>
+          <p id="gatcha-favlist-sheet-text" class="muted">请选择要拉取的公开收藏夹。</p>
+          <section class="binding-sheet-section">
+            <div id="gatcha-favlist-sheet-options" class="binding-option-list"></div>
+          </section>
+          <div class="binding-sheet-actions">
+            <button type="button" id="gatcha-favlist-sheet-cancel" class="ghost-button">取消</button>
+            <button type="button" id="gatcha-favlist-sheet-confirm" class="primary-button">拉取选中收藏夹</button>
           </div>
         </div>
       </div>

--- a/static/remote.js
+++ b/static/remote.js
@@ -30,6 +30,8 @@ const state = {
   audioVariantBarItemId: "",
   bindingSheetOpen: false,
   bindingIntent: null,
+  gatchaFavlistSheetOpen: false,
+  gatchaFavlistIntent: null,
   bindingAccordion: {
     video: false,
     audio: false,
@@ -40,6 +42,8 @@ const state = {
   gatchaCandidate: null,
   gatchaUidVisible: false,
   gatchaUidSaving: false,
+  gatchaRefreshSaving: false,
+  gatchaFavlistSaving: false,
   followBrowseVisible: false,
   followBrowseData: null,
   followBrowseSelectedUid: "",
@@ -91,6 +95,13 @@ const elements = {
   bindingSheetClose: document.getElementById("binding-sheet-close"),
   bindingSheetCancel: document.getElementById("binding-sheet-cancel"),
   bindingSheetConfirm: document.getElementById("binding-sheet-confirm"),
+  gatchaFavlistSheet: document.getElementById("gatcha-favlist-sheet"),
+  gatchaFavlistSheetBackdrop: document.getElementById("gatcha-favlist-sheet-backdrop"),
+  gatchaFavlistSheetText: document.getElementById("gatcha-favlist-sheet-text"),
+  gatchaFavlistSheetOptions: document.getElementById("gatcha-favlist-sheet-options"),
+  gatchaFavlistSheetClose: document.getElementById("gatcha-favlist-sheet-close"),
+  gatchaFavlistSheetCancel: document.getElementById("gatcha-favlist-sheet-cancel"),
+  gatchaFavlistSheetConfirm: document.getElementById("gatcha-favlist-sheet-confirm"),
   requestForm: document.getElementById("request-form"),
   requesterSelect: document.getElementById("requester-select"),
   urlInput: document.getElementById("url-input"),
@@ -128,6 +139,8 @@ const elements = {
   gatchaUidForm: document.getElementById("gatcha-uid-form"),
   gatchaUidInput: document.getElementById("gatcha-uid-input"),
   addGatchaUidButton: document.getElementById("add-gatcha-uid-button"),
+  refreshGatchaCacheButton: document.getElementById("refresh-gatcha-cache-button"),
+  pullGatchaFavlistButton: document.getElementById("pull-gatcha-favlist-button"),
   gatchaUidMessage: document.getElementById("gatcha-uid-message"),
   listTag: document.getElementById("list-tag"),
   listTitle: document.getElementById("list-title"),
@@ -691,6 +704,29 @@ async function addGatchaUid(uid) {
   return apiPost("/api/gatcha/uids/add", { uid: String(uid || "").trim() });
 }
 
+async function refreshGatchaCache() {
+  return apiPost("/api/gatcha/refresh");
+}
+
+async function previewGatchaFavlist(uid) {
+  return apiPost("/api/gatcha/favlist/preview", { uid: String(uid || "").trim() });
+}
+
+async function pullGatchaFavlist(uid, folderIds = []) {
+  return apiPost("/api/gatcha/favlist", {
+    uid: String(uid || "").trim(),
+    folder_ids: Array.isArray(folderIds) ? folderIds : [],
+  });
+}
+
+function gatchaTaskBusy() {
+  return Boolean(state.data?.gatcha?.busy);
+}
+
+function gatchaTaskBusyMessage() {
+  return state.data?.gatcha?.message || "拉取任务执行中，请等待任务结束";
+}
+
 function gatchaUidResultMessage(result, fallbackUid = "") {
   const cache = result?.cache || {};
   const addedCount = Number(cache.added_count || 0);
@@ -967,6 +1003,7 @@ function setGatchaUidMessage(message, isError = false) {
 function renderGatchaUidView() {
   const showUid = Boolean(state.gatchaUidVisible);
   const hasCandidate = Boolean(state.gatchaCandidate);
+  const taskBusy = gatchaTaskBusy();
   if (elements.gatchaCandidateTitle && state.gatchaCandidate?.title) {
     elements.gatchaCandidateTitle.textContent = state.gatchaCandidate.title;
   }
@@ -989,8 +1026,24 @@ function renderGatchaUidView() {
     elements.gatchaUidInput.disabled = state.gatchaUidSaving;
   }
   if (elements.addGatchaUidButton) {
-    elements.addGatchaUidButton.disabled = state.gatchaUidSaving;
+    elements.addGatchaUidButton.disabled = state.gatchaUidSaving || taskBusy;
     elements.addGatchaUidButton.textContent = state.gatchaUidSaving ? "处理中" : "添加";
+  }
+  if (elements.refreshGatchaCacheButton) {
+    elements.refreshGatchaCacheButton.disabled = state.gatchaRefreshSaving || taskBusy;
+    elements.refreshGatchaCacheButton.textContent = state.gatchaRefreshSaving ? "更新中" : "手动更新";
+  }
+  if (elements.pullGatchaFavlistButton) {
+    elements.pullGatchaFavlistButton.disabled = state.gatchaFavlistSaving || taskBusy;
+    elements.pullGatchaFavlistButton.textContent = state.gatchaFavlistSaving ? "拉取中" : "拉取收藏";
+  }
+  if (taskBusy) {
+    if (elements.refreshGatchaCacheButton) {
+      elements.refreshGatchaCacheButton.textContent = "全局冷却中";
+    }
+    if (elements.pullGatchaFavlistButton) {
+      elements.pullGatchaFavlistButton.textContent = "全局冷却中";
+    }
   }
 }
 
@@ -1002,6 +1055,11 @@ async function handleGatchaUidSubmit(event) {
     return;
   }
   if (state.gatchaUidSaving) {
+    return;
+  }
+  if (gatchaTaskBusy()) {
+    setGatchaUidMessage(gatchaTaskBusyMessage(), true);
+    renderGatchaUidView();
     return;
   }
 
@@ -1021,6 +1079,11 @@ async function handleGatchaUidSubmit(event) {
     }
 
     const normalizedUid = preview?.uid || uid;
+    if (gatchaTaskBusy()) {
+      setGatchaUidMessage(gatchaTaskBusyMessage(), true);
+      renderGatchaUidView();
+      return;
+    }
     setGatchaUidMessage(`正在拉取 UP 主：${ownerName} 的稿件...`);
     const result = await addGatchaUid(normalizedUid);
     setGatchaUidMessage(gatchaUidResultMessage(result, normalizedUid));
@@ -1445,6 +1508,101 @@ function closeBindingSheet() {
     elements.bindingSheetAudioOptions.innerHTML = "";
     renderBindingAccordion();
   }, 280);
+}
+
+function selectedGatchaFavlistFolderIds() {
+  return [...(elements.gatchaFavlistSheetOptions?.querySelectorAll('input[name="gatcha-favlist-folder"]:checked') || [])]
+    .map((input) => String(input.value || "").trim())
+    .filter(Boolean);
+}
+
+function renderGatchaFavlistOption(folder) {
+  const label = document.createElement("label");
+  label.className = "binding-option";
+
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.name = "gatcha-favlist-folder";
+  input.value = String(folder.id || "");
+  input.checked = Boolean(folder.selected);
+
+  const copy = document.createElement("div");
+  const title = document.createElement("div");
+  title.className = "binding-option-title";
+  title.textContent = folder.title || `收藏夹 ${folder.id || ""}`;
+  const meta = document.createElement("div");
+  meta.className = "binding-option-meta";
+  const count = Number(folder.media_count || 0);
+  meta.textContent = `${count || 0} 个稿件${folder.selected ? " · 命中默认筛选" : ""}`;
+  copy.append(title, meta);
+
+  label.append(input, copy);
+  return label;
+}
+
+function openGatchaFavlistSheet(uid, payload) {
+  const folders = Array.isArray(payload?.folders) ? payload.folders : [];
+  if (!folders.length) {
+    setGatchaUidMessage("没有读取到公开收藏夹。", true);
+    return;
+  }
+  state.gatchaFavlistIntent = { uid, folders };
+  elements.gatchaFavlistSheetText.textContent = `UID ${payload?.uid || uid} 共有 ${payload?.public_folder_count || folders.length} 个公开收藏夹，请选择要加入抽卡收藏池的收藏夹。`;
+  elements.gatchaFavlistSheetOptions.innerHTML = "";
+  folders.forEach((folder) => {
+    elements.gatchaFavlistSheetOptions.appendChild(renderGatchaFavlistOption(folder));
+  });
+  state.gatchaFavlistSheetOpen = true;
+  elements.gatchaFavlistSheet.classList.remove("hidden");
+  elements.gatchaFavlistSheet.setAttribute("aria-hidden", "false");
+  requestAnimationFrame(() => {
+    elements.gatchaFavlistSheet.classList.add("is-open");
+  });
+}
+
+function closeGatchaFavlistSheet() {
+  state.gatchaFavlistSheetOpen = false;
+  state.gatchaFavlistIntent = null;
+  elements.gatchaFavlistSheet.classList.remove("is-open");
+  elements.gatchaFavlistSheet.setAttribute("aria-hidden", "true");
+  window.setTimeout(() => {
+    if (state.gatchaFavlistSheetOpen) {
+      return;
+    }
+    elements.gatchaFavlistSheet.classList.add("hidden");
+    elements.gatchaFavlistSheetOptions.innerHTML = "";
+  }, 280);
+}
+
+async function confirmGatchaFavlistSheet() {
+  const intent = state.gatchaFavlistIntent;
+  if (!intent?.uid) {
+    return;
+  }
+  const folderIds = selectedGatchaFavlistFolderIds();
+  if (!folderIds.length) {
+    setGatchaUidMessage("请选择至少一个收藏夹", true);
+    return;
+  }
+  if (gatchaTaskBusy()) {
+    setGatchaUidMessage(gatchaTaskBusyMessage(), true);
+    renderGatchaUidView();
+    return;
+  }
+
+  state.gatchaFavlistSaving = true;
+  renderGatchaUidView();
+  setGatchaUidMessage("正在拉取选中的公开收藏夹...");
+  try {
+    const result = await pullGatchaFavlist(intent.uid, folderIds);
+    closeGatchaFavlistSheet();
+    setGatchaUidMessage(`已拉取 ${result?.matched_folder_count || 0} 个收藏夹，加入 ${result?.item_count || 0} 个稿件。`);
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaFavlistSaving = false;
+    renderGatchaUidView();
+  }
 }
 
 function renderBindingAccordion() {
@@ -2271,6 +2429,55 @@ elements.gatchaUidToggle?.addEventListener("click", () => {
 
 elements.gatchaUidForm?.addEventListener("submit", handleGatchaUidSubmit);
 
+elements.refreshGatchaCacheButton?.addEventListener("click", async () => {
+  if (gatchaTaskBusy()) {
+    setGatchaUidMessage(gatchaTaskBusyMessage(), true);
+    renderGatchaUidView();
+    return;
+  }
+  state.gatchaRefreshSaving = true;
+  renderGatchaUidView();
+  setGatchaUidMessage("正在后台更新抽卡缓存...");
+  try {
+    const result = await refreshGatchaCache();
+    if (result?.started !== false && state.data) {
+      state.data.gatcha = { busy: true, message: gatchaTaskBusyMessage() };
+    }
+    setGatchaUidMessage(result?.started === false ? "拉取任务执行中，请等待任务结束" : "已开始后台更新抽卡缓存。");
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaRefreshSaving = false;
+    renderGatchaUidView();
+  }
+});
+
+elements.pullGatchaFavlistButton?.addEventListener("click", async () => {
+  const uid = String(elements.gatchaUidInput?.value || "").trim();
+  if (!uid) {
+    setGatchaUidMessage("请输入 UID", true);
+    return;
+  }
+  if (gatchaTaskBusy()) {
+    setGatchaUidMessage(gatchaTaskBusyMessage(), true);
+    renderGatchaUidView();
+    return;
+  }
+  state.gatchaFavlistSaving = true;
+  renderGatchaUidView();
+  setGatchaUidMessage("正在读取公开收藏夹...");
+  try {
+    const result = await previewGatchaFavlist(uid);
+    openGatchaFavlistSheet(result?.uid || uid, result);
+    setGatchaUidMessage("请选择要拉取的收藏夹。");
+  } catch (error) {
+    setGatchaUidMessage(error.message, true);
+  } finally {
+    state.gatchaFavlistSaving = false;
+    renderGatchaUidView();
+  }
+});
+
 elements.gatchaConfirmButton.addEventListener("click", async () => {
   if (!state.gatchaCandidate?.url) {
     return;
@@ -2292,6 +2499,22 @@ elements.bindingSheetBackdrop?.addEventListener("click", () => {
 
 elements.bindingSheetConfirm?.addEventListener("click", async () => {
   await confirmBindingSheet();
+});
+
+elements.gatchaFavlistSheetClose?.addEventListener("click", () => {
+  closeGatchaFavlistSheet();
+});
+
+elements.gatchaFavlistSheetCancel?.addEventListener("click", () => {
+  closeGatchaFavlistSheet();
+});
+
+elements.gatchaFavlistSheetBackdrop?.addEventListener("click", () => {
+  closeGatchaFavlistSheet();
+});
+
+elements.gatchaFavlistSheetConfirm?.addEventListener("click", async () => {
+  await confirmGatchaFavlistSheet();
 });
 
 elements.bindingVideoToggle?.addEventListener("click", () => {
@@ -2432,8 +2655,14 @@ elements.historyList.addEventListener("click", async (event) => {
 });
 
 document.addEventListener("keydown", (event) => {
-  if (event.key === "Escape" && state.bindingSheetOpen) {
+  if (event.key !== "Escape") {
+    return;
+  }
+  if (state.bindingSheetOpen) {
     closeBindingSheet();
+  }
+  if (state.gatchaFavlistSheetOpen) {
+    closeGatchaFavlistSheet();
   }
 });
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -2711,7 +2711,7 @@ select:disabled {
 }
 
 .gatcha-panel {
-  padding: 20px;
+  padding: 16px 20px;
   border-radius: 28px;
   border: 1px solid var(--line);
   background: var(--panel);
@@ -2724,15 +2724,18 @@ select:disabled {
 .gatcha-head {
   align-items: flex-start;
   gap: 12px;
+  flex-wrap: nowrap;
 }
 
 .gatcha-head > div {
-  min-height: 45px;
+  display: grid;
+  gap: 4px;
+  min-height: 0;
 }
 
 .gatcha-head h2 {
-  line-height: 1.2;
-  min-height: 29px;
+  line-height: 1.15;
+  min-height: 0;
 }
 
 .gatcha-uid-toggle,
@@ -2817,6 +2820,11 @@ select:disabled {
   display: grid;
   gap: 12px;
   align-items: stretch;
+}
+
+.gatcha-uid-view .gatcha-uid-form {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
 }
 
 .gatcha-panel.is-cookie-view .request-head h2,
@@ -2942,9 +2950,16 @@ select:disabled {
 }
 
 .gatcha-cookie-view .next-button,
-.gatcha-uid-view .next-button,
 .search-cookie-view .next-button {
   width: 100%;
+}
+
+.gatcha-uid-view .next-button {
+  width: auto;
+  height: 38px;
+  min-width: 72px;
+  border-radius: 10px;
+  padding: 0 16px;
 }
 
 .cookie-config-bar {
@@ -3188,6 +3203,10 @@ select:disabled {
   align-items: stretch;
 }
 
+.bottom-grid .gatcha-uid-view .gatcha-uid-form {
+  align-items: end;
+}
+
 .search-results.hidden {
   display: none;
 }
@@ -3306,6 +3325,10 @@ select:disabled {
   }
 
   .search-inputs {
+    grid-template-columns: 1fr;
+  }
+
+  .gatcha-uid-form {
     grid-template-columns: 1fr;
   }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -162,6 +162,10 @@ p {
   box-shadow: var(--shadow);
 }
 
+.selection-modal-card-single {
+  width: min(560px, calc(100vw - 32px));
+}
+
 .selection-modal-head,
 .selection-modal-actions {
   display: flex;
@@ -183,6 +187,10 @@ p {
   min-height: 0;
   margin-top: 18px;
   overflow: hidden;
+}
+
+.selection-modal-grid-single {
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .selection-modal-column {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -49,6 +49,23 @@ class AppContextRemoteAccessTest(unittest.TestCase):
 
 
 class AppContextStateRevisionTest(unittest.TestCase):
+    def test_startup_gatcha_refresh_bypasses_global_lock_only_once(self):
+        context = AppContext.__new__(AppContext)
+        context._startup_lock = threading.RLock()
+        context._startup_gatcha_refresh_bypass_available = True
+        context._state_change_condition = threading.Condition()
+        context._state_revision = 0
+
+        with patch("bilikara.server.refresh_gatcha_cache_in_background", return_value=True) as refresh:
+            self.assertTrue(context.refresh_startup_gatcha_cache_in_background())
+            self.assertTrue(context.refresh_startup_gatcha_cache_in_background())
+
+        self.assertEqual(refresh.call_count, 2)
+        self.assertEqual(refresh.call_args_list[0].kwargs, {"use_global_lock": False})
+        self.assertIn("on_start", refresh.call_args_list[1].kwargs)
+        self.assertIn("on_done", refresh.call_args_list[1].kwargs)
+        self.assertNotIn("use_global_lock", refresh.call_args_list[1].kwargs)
+
     def test_wait_for_state_change_unblocks_after_notify(self):
         context = AppContext.__new__(AppContext)
         context._closed = False

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -1071,6 +1071,31 @@ class BilibiliParserTest(unittest.TestCase):
             cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
             self.assertEqual(cache_payload["uids"]["42"][0]["bvid"], "BVADDED42")
 
+    def test_add_gatcha_uid_rejects_while_global_gatcha_task_is_running(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+            cache_file = data_dir / "gatcha_cache.json"
+            uid_file.write_text(json.dumps({"uids": ["1"]}), encoding="utf-8")
+            cache_file.write_text(json.dumps({"schema_version": 2, "uids": {}, "profiles": {}}), encoding="utf-8")
+            refresh_lock = threading.Lock()
+            self.assertTrue(refresh_lock.acquire(blocking=False))
+            try:
+                with (
+                    patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                    patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+                    patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
+                    patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", refresh_lock),
+                    patch.object(bilibili_module, "preview_gatcha_uid") as preview,
+                ):
+                    with self.assertRaisesRegex(bilibili_module.BilibiliError, "拉取任务执行中，请等待任务结束"):
+                        bilibili_module.add_gatcha_uid("42")
+                    preview.assert_not_called()
+            finally:
+                refresh_lock.release()
+
+            self.assertEqual(json.loads(uid_file.read_text(encoding="utf-8"))["uids"], ["1"])
+
     def test_refresh_gatcha_favlist_filters_folder_titles_and_persists_items(self):
         with TemporaryDirectory() as temp_dir:
             data_dir = Path(temp_dir)
@@ -1117,6 +1142,60 @@ class BilibiliParserTest(unittest.TestCase):
             self.assertEqual(payload["uid"], "42")
             self.assertEqual(payload["folders"][0]["title"], "🎤 卡拉收藏")
             self.assertEqual(payload["items"][0]["bvid"], "BVFAV1")
+
+    def test_preview_gatcha_favlist_marks_keyword_matches_as_selected(self):
+        folders = [
+            {"id": 100, "fid": 10, "title": "K songs", "attr": 0, "media_count": 2},
+            {"id": 200, "fid": 20, "title": "normal fav", "attr": 0, "media_count": 1},
+            {"id": 300, "fid": 30, "title": "private k", "attr": 1, "media_count": 1},
+        ]
+        with patch.object(bilibili_module, "_request_gatcha_favlist_folders", return_value=folders):
+            result = bilibili_module.preview_gatcha_favlist("https://space.bilibili.com/42")
+
+        self.assertEqual(result["uid"], "42")
+        self.assertEqual(result["folder_count"], 3)
+        self.assertEqual(result["public_folder_count"], 2)
+        self.assertEqual([folder["id"] for folder in result["folders"]], ["100", "200"])
+        self.assertEqual(result["selected_folder_ids"], ["100"])
+        self.assertTrue(result["folders"][0]["selected"])
+        self.assertFalse(result["folders"][1]["selected"])
+
+    def test_refresh_gatcha_favlist_uses_explicit_folder_selection(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            favlist_file = data_dir / "gatcha_favlist.json"
+            folders = [
+                {"id": 100, "fid": 10, "title": "K songs", "attr": 0, "media_count": 1},
+                {"id": 200, "fid": 20, "title": "normal fav", "attr": 0, "media_count": 1},
+            ]
+            fetched_folder_ids: list[int] = []
+
+            def fake_fetch(uid, folder):
+                fetched_folder_ids.append(int(folder["id"]))
+                return [
+                    {
+                        "mid": "9",
+                        "bvid": f"BVFAV{folder['id']}",
+                        "title": "selected fav item",
+                        "url": f"https://www.bilibili.com/video/BVFAV{folder['id']}",
+                    }
+                ]
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_FAVLIST_FILE", favlist_file),
+                patch.object(bilibili_module, "_GATCHA_FAVLIST_LOCK", threading.Lock()),
+                patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", threading.Lock()),
+                patch.object(bilibili_module, "_request_gatcha_favlist_folders", return_value=folders),
+                patch.object(bilibili_module, "_fetch_gatcha_favlist_entries_for_folder", side_effect=fake_fetch),
+            ):
+                result = bilibili_module.refresh_gatcha_favlist("42", ["200"])
+
+            self.assertEqual(result["matched_folder_count"], 1)
+            self.assertEqual(fetched_folder_ids, [200])
+            payload = json.loads(favlist_file.read_text(encoding="utf-8"))
+            self.assertEqual([folder["id"] for folder in payload["folders"]], ["200"])
+            self.assertEqual(payload["items"][0]["bvid"], "BVFAV200")
 
     def test_gatcha_favlist_joins_search_and_draw_but_not_follow_browse(self):
         with TemporaryDirectory() as temp_dir:
@@ -1299,6 +1378,30 @@ class BilibiliParserTest(unittest.TestCase):
 
             payload = json.loads(favlist_file.read_text(encoding="utf-8"))
             self.assertEqual([entry["bvid"] for entry in payload["items"]], ["BVNEW", "BVOLD"])
+
+    def test_startup_gatcha_refresh_can_bypass_global_refresh_lock(self):
+        class FakeThread:
+            def __init__(self, *, target, daemon=None, name=None):
+                self.target = target
+
+            def start(self):
+                self.target()
+
+        refresh_lock = threading.Lock()
+        self.assertTrue(refresh_lock.acquire(blocking=False))
+        try:
+            with (
+                patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", refresh_lock),
+                patch.object(bilibili_module, "refresh_gatcha_cache", return_value={}) as refresh,
+                patch.object(bilibili_module.threading, "Thread", FakeThread),
+            ):
+                self.assertFalse(bilibili_module.refresh_gatcha_cache_in_background())
+                self.assertTrue(bilibili_module.refresh_gatcha_cache_in_background(use_global_lock=False))
+
+            self.assertEqual(refresh.call_count, 1)
+            self.assertTrue(refresh_lock.locked())
+        finally:
+            refresh_lock.release()
 
     @patch("bilikara.bilibili.request_json")
     def test_fetch_video_item(self, mock_request_json):

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -571,6 +571,8 @@ class PlaylistStoreTest(unittest.TestCase):
         gatcha_file.write_text("{}", encoding="utf-8")
         gatcha_uid_file = self.state_file.parent / "gatcha_uids.json"
         gatcha_uid_file.write_text("{}", encoding="utf-8")
+        gatcha_favlist_file = self.state_file.parent / "gatcha_favlist.json"
+        gatcha_favlist_file.write_text("{}", encoding="utf-8")
         played_file = self.session_archive_dir / "played-keep.json"
         played_file.parent.mkdir(parents=True, exist_ok=True)
         played_file.write_text("{}", encoding="utf-8")
@@ -579,6 +581,7 @@ class PlaylistStoreTest(unittest.TestCase):
 
         self.assertTrue(gatcha_file.exists())
         self.assertTrue(gatcha_uid_file.exists())
+        self.assertTrue(gatcha_favlist_file.exists())
         self.assertTrue(played_file.exists())
         self.assertFalse(self.backup_file.exists())
         self.assertEqual(self.store.playback_mode, "local")
@@ -778,6 +781,7 @@ class BilibiliParserTest(unittest.TestCase):
     def test_gatcha_missing_cookie_message_when_cache_empty(self):
         with (
             patch.object(bilibili_module, "_local_gatcha_candidates_by_uid", return_value={}),
+            patch.object(bilibili_module, "_local_gatcha_favlist_candidates", return_value=[]),
             patch.object(bilibili_module, "effective_bilibili_cookie", return_value=""),
         ):
             with self.assertRaisesRegex(
@@ -1066,6 +1070,235 @@ class BilibiliParserTest(unittest.TestCase):
             self.assertEqual(json.loads(uid_file.read_text(encoding="utf-8"))["uids"], ["1", "42"])
             cache_payload = json.loads(cache_file.read_text(encoding="utf-8"))
             self.assertEqual(cache_payload["uids"]["42"][0]["bvid"], "BVADDED42")
+
+    def test_refresh_gatcha_favlist_filters_folder_titles_and_persists_items(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            favlist_file = data_dir / "gatcha_favlist.json"
+            folders = [
+                {"id": 100, "fid": 10, "title": "🎤 卡拉收藏", "attr": 0, "media_count": 2},
+                {"id": 200, "fid": 20, "title": "普通收藏", "attr": 0, "media_count": 1},
+                {"id": 300, "fid": 30, "title": "K歌私密", "attr": 1, "media_count": 1},
+            ]
+            fetched_folder_ids: list[int] = []
+
+            def fake_fetch(uid, folder):
+                fetched_folder_ids.append(int(folder["id"]))
+                return [
+                    {
+                        "mid": "9",
+                        "bvid": "BVFAV1",
+                        "title": "any title is accepted inside matched folders",
+                        "url": "https://www.bilibili.com/video/BVFAV1",
+                    },
+                    {
+                        "mid": "9",
+                        "bvid": "BVFAV1",
+                        "title": "duplicate",
+                        "url": "https://www.bilibili.com/video/BVFAV1",
+                    },
+                ]
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_FAVLIST_FILE", favlist_file),
+                patch.object(bilibili_module, "_GATCHA_FAVLIST_LOCK", threading.Lock()),
+                patch.object(bilibili_module, "_request_gatcha_favlist_folders", return_value=folders),
+                patch.object(bilibili_module, "_fetch_gatcha_favlist_entries_for_folder", side_effect=fake_fetch),
+            ):
+                result = bilibili_module.refresh_gatcha_favlist("https://space.bilibili.com/42")
+
+            self.assertEqual(result["uid"], "42")
+            self.assertEqual(result["folder_count"], 3)
+            self.assertEqual(result["matched_folder_count"], 1)
+            self.assertEqual(result["item_count"], 1)
+            self.assertEqual(fetched_folder_ids, [100])
+            payload = json.loads(favlist_file.read_text(encoding="utf-8"))
+            self.assertEqual(payload["uid"], "42")
+            self.assertEqual(payload["folders"][0]["title"], "🎤 卡拉收藏")
+            self.assertEqual(payload["items"][0]["bvid"], "BVFAV1")
+
+    def test_gatcha_favlist_joins_search_and_draw_but_not_follow_browse(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+            cache_file = data_dir / "gatcha_cache.json"
+            favlist_file = data_dir / "gatcha_favlist.json"
+            uid_file.write_text(json.dumps({"uids": []}), encoding="utf-8")
+            cache_file.write_text(json.dumps({"schema_version": 2, "uids": {}, "profiles": {}}), encoding="utf-8")
+            favlist_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "uid": "42",
+                        "folders": [{"id": "100", "title": "K songs"}],
+                        "items": [
+                            {
+                                "mid": "9",
+                                "bvid": "BVFAV2",
+                                "title": "fav local search title",
+                                "url": "https://www.bilibili.com/video/BVFAV2",
+                            }
+                        ],
+                        "updated_at": 1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+                patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
+                patch.object(bilibili_module, "_GATCHA_FAVLIST_FILE", favlist_file),
+            ):
+                results = bilibili_module.search_gatcha_cache("fav local")
+                candidate = bilibili_module.fetch_gatcha_candidate()
+                browse = bilibili_module.browse_gatcha_cache()
+
+            self.assertEqual(results[0]["bvid"], "BVFAV2")
+            self.assertEqual(candidate["bvid"], "BVFAV2")
+            self.assertEqual(candidate["source"], "favlist")
+            self.assertEqual(browse["owners"], [])
+
+    def test_gatcha_favlist_request_retries_412_with_three_second_delay(self):
+        payloads = [
+            {"code": 412, "message": "412 Precondition Failed"},
+            {"code": 0, "data": {"list": []}},
+        ]
+
+        with (
+            patch.object(bilibili_module, "request_json", side_effect=payloads) as request_json,
+            patch.object(bilibili_module, "_wait_for_gatcha_favlist_request_slot") as wait_slot,
+            patch.object(bilibili_module.time, "sleep") as sleep,
+        ):
+            result = bilibili_module._request_gatcha_favlist_json("https://example.invalid", "failed")
+
+        self.assertEqual(result["code"], 0)
+        self.assertEqual(request_json.call_count, 2)
+        self.assertEqual(wait_slot.call_count, 2)
+        sleep.assert_called_once_with(bilibili_module.GATCHA_FAVLIST_RETRY_DELAY_SECONDS)
+
+    def test_gatcha_favlist_pagination_uses_media_count_over_false_has_more(self):
+        folder = {"id": "100", "title": "卡拉", "media_count": 40}
+        seen_pages: list[int] = []
+
+        def fake_page(media_id, page_number, page_size=20):
+            seen_pages.append(page_number)
+            return {
+                "code": 0,
+                "data": {
+                    "info": {"media_count": 40},
+                    "has_more": False,
+                    "medias": [
+                        {
+                            "bvid": f"BV{page_number:02d}{index:02d}",
+                            "title": f"title {page_number}-{index}",
+                            "upper": {"mid": "9", "name": "up"},
+                        }
+                        for index in range(20)
+                    ],
+                },
+            }
+
+        with patch.object(bilibili_module, "_request_gatcha_favlist_page", side_effect=fake_page):
+            entries = bilibili_module._fetch_gatcha_favlist_entries_for_folder("42", folder)
+
+        self.assertEqual(seen_pages, [1, 2])
+        self.assertEqual(len(entries), 40)
+
+    def test_gatcha_draw_skips_expired_video_titles(self):
+        with (
+            patch.object(
+                bilibili_module,
+                "_local_gatcha_candidates_by_uid",
+                return_value={
+                    "1": [
+                        {
+                            "mid": "1",
+                            "bvid": "BVDEAD",
+                            "title": "已失效视频",
+                            "url": "https://www.bilibili.com/video/BVDEAD",
+                        },
+                        {
+                            "mid": "1",
+                            "bvid": "BVALIVE",
+                            "title": "alive karaoke",
+                            "url": "https://www.bilibili.com/video/BVALIVE",
+                        },
+                    ]
+                },
+            ),
+            patch.object(
+                bilibili_module,
+                "_local_gatcha_favlist_candidates",
+                return_value=[
+                    {
+                        "mid": "2",
+                        "bvid": "BVFAVDEAD",
+                        "title": "已失效视频",
+                        "url": "https://www.bilibili.com/video/BVFAVDEAD",
+                    }
+                ],
+            ),
+            patch.object(bilibili_module.random, "random", return_value=0.9),
+        ):
+            candidate = bilibili_module.fetch_gatcha_candidate()
+
+        self.assertEqual(candidate["bvid"], "BVALIVE")
+
+    def test_refresh_gatcha_cache_incrementally_refreshes_existing_favlist(self):
+        with TemporaryDirectory() as temp_dir:
+            data_dir = Path(temp_dir)
+            uid_file = data_dir / "gatcha_uids.json"
+            cache_file = data_dir / "gatcha_cache.json"
+            favlist_file = data_dir / "gatcha_favlist.json"
+            uid_file.write_text(json.dumps({"uids": []}), encoding="utf-8")
+            favlist_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "uid": "42",
+                        "folders": [{"id": "100", "title": "卡拉", "media_count": 2}],
+                        "items": [
+                            {
+                                "mid": "9",
+                                "bvid": "BVOLD",
+                                "title": "old",
+                                "url": "https://www.bilibili.com/video/BVOLD",
+                            }
+                        ],
+                        "updated_at": 1,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            def fake_fav_page(media_id, page_number, page_size=20):
+                return {
+                    "code": 0,
+                    "data": {
+                        "info": {"media_count": 2},
+                        "medias": [
+                            {"bvid": "BVNEW", "title": "new", "upper": {"mid": "10", "name": "new-up"}},
+                            {"bvid": "BVOLD", "title": "old", "upper": {"mid": "9", "name": "old-up"}},
+                        ],
+                    },
+                }
+
+            with (
+                patch.object(bilibili_module.cfg, "DATA_DIR", data_dir),
+                patch.object(bilibili_module, "_GATCHA_UIDS_FILE", uid_file),
+                patch.object(bilibili_module, "_GATCHA_CACHE_FILE", cache_file),
+                patch.object(bilibili_module, "_GATCHA_FAVLIST_FILE", favlist_file),
+                patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", threading.Lock()),
+                patch.object(bilibili_module, "effective_bilibili_cookie", return_value="cookie"),
+                patch.object(bilibili_module, "_request_gatcha_favlist_page", side_effect=fake_fav_page),
+            ):
+                bilibili_module.refresh_gatcha_cache()
+
+            payload = json.loads(favlist_file.read_text(encoding="utf-8"))
+            self.assertEqual([entry["bvid"] for entry in payload["items"]], ["BVNEW", "BVOLD"])
 
     @patch("bilikara.bilibili.request_json")
     def test_fetch_video_item(self, mock_request_json):


### PR DESCRIPTION
微调gatcha模块ui，测试脚本更新最新的几个接口，同时测试脚本放弃下载hires，减少测试缓冲压力