### PR TITLE
Feature:Add shared Lark search and pooled gatcha data sync for bilikara(新增 bilikara 飞书共享搜索与 gatcha 数据池同步)

### DIFF
--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -14,6 +14,7 @@ from .config import BILIBILI_HEADERS, GATCHA_KEYWORDS
 from dataclasses import dataclass
 from .models import PlaylistItem
 import bilikara.config as cfg  
+from .lark_pool_client import append_lark_pool_entries_in_background
 
 VIDEO_PATH_RE = re.compile(r"/video/(?P<vid>(BV[0-9A-Za-z]+|av\d+))", re.IGNORECASE)
 BV_RE = re.compile(r"^(BV[0-9A-Za-z]+)$", re.IGNORECASE)
@@ -880,14 +881,21 @@ def refresh_gatcha_favlist(
 ) -> dict:
     if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
         raise BilibiliError(GATCHA_TASK_BUSY_MESSAGE)
+    result: dict | None = None
+    entries: list[dict] = []
     try:
         if on_start is not None:
             on_start()
-        return _refresh_gatcha_favlist_unlocked(raw_mid, raw_folder_ids)
+        result = _refresh_gatcha_favlist_unlocked(raw_mid, raw_folder_ids)
+        with _GATCHA_FAVLIST_LOCK:
+            entries = list(_load_gatcha_favlist().get("items") or [])
     finally:
         _GATCHA_REFRESH_LOCK.release()
         if on_done is not None:
             on_done()
+    if entries:
+        _append_lark_pool_entries_async(entries)
+    return result or {}
 
 
 def _refresh_existing_gatcha_favlist_cache() -> dict | None:
@@ -1073,8 +1081,9 @@ def refresh_gatcha_cache_in_background(
             on_start()
 
     def _worker() -> None:
+        cache_payload: dict | None = None
         try:
-            refresh_gatcha_cache()
+            cache_payload = refresh_gatcha_cache()
         except Exception:
             return
         finally:
@@ -1082,6 +1091,8 @@ def refresh_gatcha_cache_in_background(
                 _GATCHA_REFRESH_LOCK.release()
                 if on_done is not None:
                     on_done()
+        if cache_payload is not None:
+            _append_lark_pool_entries_async(_gatcha_cache_payload_entries(cache_payload))
 
     threading.Thread(target=_worker, daemon=True, name="gatcha-cache-refresh").start()
     return True
@@ -1090,6 +1101,7 @@ def refresh_gatcha_cache_in_background(
 def add_gatcha_uid(raw_mid: object, *, on_start: callable | None = None, on_done: callable | None = None) -> dict:
     if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
         raise BilibiliError(GATCHA_TASK_BUSY_MESSAGE)
+    entries: list[dict] = []
     try:
         if on_start is not None:
             on_start()
@@ -1131,10 +1143,20 @@ def add_gatcha_uid(raw_mid: object, *, on_start: callable | None = None, on_done
         }
         cache_payload["profiles"] = cache_profiles
         cache_result = _refresh_gatcha_uid_cache(cache_payload, mid)
+        with _GATCHA_CACHE_LOCK:
+            fresh_cache_payload = _load_gatcha_cache()
+        entries = _gatcha_cache_payload_entries(
+            {
+                "uids": {mid: fresh_cache_payload.get("uids", {}).get(mid, [])},
+                "profiles": {mid: fresh_cache_payload.get("profiles", {}).get(mid, {})},
+            }
+        )
     finally:
         _GATCHA_REFRESH_LOCK.release()
         if on_done is not None:
             on_done()
+    if entries:
+        _append_lark_pool_entries_async(entries)
 
     return {
         "uid": mid,
@@ -1184,6 +1206,37 @@ def _local_gatcha_candidates_by_uid() -> dict[str, list[dict]]:
         if valid_entries:
             grouped_candidates[mid] = valid_entries
     return grouped_candidates
+
+
+def _gatcha_cache_payload_entries(cache_payload: dict) -> list[dict]:
+    uid_entries = cache_payload.get("uids") if isinstance(cache_payload, dict) else {}
+    if not isinstance(uid_entries, dict):
+        return []
+    profiles = cache_payload.get("profiles") if isinstance(cache_payload, dict) else {}
+    if not isinstance(profiles, dict):
+        profiles = {}
+    entries: list[dict] = []
+    for mid, raw_entries in uid_entries.items():
+        if not isinstance(raw_entries, list):
+            continue
+        profile = profiles.get(str(mid)) if isinstance(profiles.get(str(mid)), dict) else {}
+        for entry in raw_entries:
+            if not isinstance(entry, dict):
+                continue
+            payload = dict(entry)
+            payload.setdefault("mid", str(mid))
+            if profile:
+                payload.setdefault("owner_name", str(profile.get("name") or ""))
+                payload.setdefault("owner_url", str(profile.get("space_url") or ""))
+            entries.append(payload)
+    return entries
+
+
+def _append_lark_pool_entries_async(entries: list[dict]) -> None:
+    try:
+        append_lark_pool_entries_in_background(entries)
+    except Exception:
+        pass
 
 
 def search_gatcha_cache(query: str, *, limit: int = 30) -> list[dict]:

--- a/bilikara/lark_pool_client.py
+++ b/bilikara/lark_pool_client.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import bilikara.config as cfg
+
+APP_ID = "cli_a97321a5a7b89bde"
+APP_SECRET = "tTUE3SUe57v1YTvjLQGNAd8Hm4RHyJlf"
+BITABLE_TABLES = (
+    ("FWDRbyK5daxV7Wsr04lc0nxhnuc", "tblsQ7K5sUo1BGLz"),
+    ("NxoQblT9TamM77sOcU5cAtMznnc", "tblxBaiTH7h1EoX0"),
+    ("Khdqb1bcDau0EqsryUNcbgNUnVc", "tblDVME8pevjWBJD"),
+    ("ONWQbyZZRaArhusSFEccF9F0n1g", "tblaGCllQB0QLWa0"),
+    ("VBUJbUzJBaI9LOs43sJcnbwDnU5", "tbl3Z8VKPhOTr7Ka"),
+)
+
+_BASE_URL = "https://open.feishu.cn/open-apis"
+_TABLE_LIMIT = 20_000
+_APPEND_CHUNK_SIZE = 400
+_SYNC_FILE = cfg.DATA_DIR / "lark_pool_sync.json"
+_TOKEN_LOCK = threading.RLock()
+_TOKEN_VALUE = ""
+_TOKEN_EXPIRES_AT = 0.0
+_TABLES_LOCK = threading.RLock()
+_TABLES_READY = False
+_ACTIVE_TABLES: list[dict[str, Any]] = []
+_SYNC_LOCK = threading.RLock()
+_REQUIRED_FIELD_NAMES = {"mid", "bvid", "title", "url", "owner_name", "owner_url"}
+_REQUIRED_SEARCH_FIELDS = {"bvid", "title", "url"}
+_DEBUG_LOGS = False
+
+
+class LarkPoolError(RuntimeError):
+    pass
+
+
+def _post_json(url: str, payload: dict[str, Any], *, token: str | None = None, timeout: float = 12.0) -> dict:
+    headers = {"Content-Type": "application/json; charset=utf-8"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise LarkPoolError(f"Lark request failed: {exc}") from exc
+
+
+def _get_json(url: str, *, token: str, timeout: float = 12.0) -> dict:
+    request = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"}, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        raise LarkPoolError(f"Lark request failed: {exc}") from exc
+
+
+def _require_success(payload: dict, label: str) -> dict:
+    if payload.get("code") != 0:
+        if _DEBUG_LOGS:
+            print(
+                f"[bilikara:lark] {label}: {json.dumps(payload, ensure_ascii=False)}",
+                file=sys.stderr,
+                flush=True,
+            )
+        raise LarkPoolError(str(payload.get("msg") or label))
+    data = payload.get("data")
+    return data if isinstance(data, dict) else {}
+
+
+def _log_lark_request(label: str, payload: dict[str, Any]) -> None:
+    if not _DEBUG_LOGS:
+        return
+    print(
+        f"[bilikara:lark] {label} request: {json.dumps(payload, ensure_ascii=False)}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _tenant_access_token() -> str:
+    global _TOKEN_VALUE, _TOKEN_EXPIRES_AT
+    now = time.time()
+    with _TOKEN_LOCK:
+        if _TOKEN_VALUE and now < _TOKEN_EXPIRES_AT - 60:
+            return _TOKEN_VALUE
+        payload = _post_json(
+            f"{_BASE_URL}/auth/v3/tenant_access_token/internal",
+            {"app_id": APP_ID, "app_secret": APP_SECRET},
+            timeout=10,
+        )
+        if payload.get("code") != 0:
+            raise LarkPoolError(str(payload.get("msg") or "tenant token failed"))
+        token = str(payload.get("tenant_access_token") or "").strip()
+        if not token:
+            raise LarkPoolError("tenant token missing")
+        try:
+            expires_in = int(payload.get("expire") or 7200)
+        except (TypeError, ValueError):
+            expires_in = 7200
+        _TOKEN_VALUE = token
+        _TOKEN_EXPIRES_AT = now + max(300, expires_in)
+        return token
+
+
+def _records_url(app_token: str, table_id: str, suffix: str = "") -> str:
+    return f"{_BASE_URL}/bitable/v1/apps/{app_token}/tables/{table_id}/records{suffix}"
+
+
+def _fields_url(app_token: str, table_id: str) -> str:
+    return f"{_BASE_URL}/bitable/v1/apps/{app_token}/tables/{table_id}/fields"
+
+
+def _table_field_names(token: str, app_token: str, table_id: str) -> set[str]:
+    query = urllib.parse.urlencode({"page_size": 100})
+    data = _require_success(
+        _get_json(f"{_fields_url(app_token, table_id)}?{query}", token=token, timeout=10),
+        "table field probe failed",
+    )
+    names: set[str] = set()
+    for item in data.get("items") or []:
+        if not isinstance(item, dict):
+            continue
+        field_name = str(item.get("field_name") or item.get("name") or "").strip()
+        if field_name:
+            names.add(field_name)
+    return names
+
+
+def _table_record_count(token: str, app_token: str, table_id: str) -> int:
+    query = urllib.parse.urlencode({"page_size": 1})
+    data = _require_success(
+        _get_json(f"{_records_url(app_token, table_id)}?{query}", token=token, timeout=10),
+        "table probe failed",
+    )
+    try:
+        return int(data.get("total") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _active_tables() -> list[dict[str, Any]]:
+    global _TABLES_READY, _ACTIVE_TABLES
+    with _TABLES_LOCK:
+        if _TABLES_READY:
+            return [dict(table) for table in _ACTIVE_TABLES]
+        token = _tenant_access_token()
+        active: list[dict[str, Any]] = []
+        for index, (app_token, table_id) in enumerate(BITABLE_TABLES, start=1):
+            try:
+                field_names = _table_field_names(token, app_token, table_id)
+                if not _REQUIRED_SEARCH_FIELDS.issubset(field_names):
+                    continue
+                count = _table_record_count(token, app_token, table_id)
+            except LarkPoolError:
+                if index == 1:
+                    raise
+                continue
+            active.append(
+                {
+                    "index": index,
+                    "app_token": app_token,
+                    "table_id": table_id,
+                    "count": count,
+                    "field_names": sorted(field_names),
+                    "search_enabled": index == 1 or count > 1,
+                }
+            )
+        _ACTIVE_TABLES = active
+        _TABLES_READY = True
+        return [dict(table) for table in _ACTIVE_TABLES]
+
+
+def _bump_table_count(index: int, delta: int) -> None:
+    with _TABLES_LOCK:
+        for table in _ACTIVE_TABLES:
+            if table.get("index") == index:
+                updated_count = int(table.get("count") or 0) + int(delta)
+                table["count"] = updated_count
+                table["search_enabled"] = int(table.get("index") or 0) == 1 or updated_count > 1
+                break
+
+
+def _field_text(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                parts.append(str(item.get("text") or item.get("name") or item.get("link") or ""))
+            else:
+                parts.append(str(item or ""))
+        return "".join(parts).strip()
+    if isinstance(value, dict):
+        return str(value.get("text") or value.get("name") or value.get("link") or "")
+    return str(value)
+
+
+def _record_to_item(record: dict) -> dict | None:
+    fields = record.get("fields") if isinstance(record, dict) else {}
+    if not isinstance(fields, dict):
+        return None
+    bvid = _field_text(fields.get("bvid")).strip()
+    title = _field_text(fields.get("title")).strip()
+    url = _field_text(fields.get("url")).strip()
+    if not url and bvid:
+        url = f"https://www.bilibili.com/video/{bvid}"
+    if not bvid or not title or not url:
+        return None
+    return {
+        "mid": _field_text(fields.get("mid")).strip(),
+        "bvid": bvid,
+        "title": title,
+        "url": url,
+        "owner_name": _field_text(fields.get("owner_name")).strip(),
+        "owner_url": _field_text(fields.get("owner_url")).strip(),
+        "source": "bilikara",
+    }
+
+
+def search_lark_pool(query: str, *, limit: int = 30) -> list[dict]:
+    normalized_query = str(query or "").strip()
+    if not normalized_query:
+        return []
+    token = _tenant_access_token()
+    results: list[dict] = []
+    seen_bvids: set[str] = set()
+    for table in _active_tables():
+        if table.get("search_enabled", True) is False:
+            continue
+        payload = {
+            "filter": {
+                "conjunction": "and",
+                "conditions": [
+                    {"field_name": "title", "operator": "contains", "value": [normalized_query]},
+                ],
+            },
+        }
+        _log_lark_request(f"bilikara search table {table.get('index')}", payload)
+        data = _require_success(
+            _post_json(_records_url(table["app_token"], table["table_id"], "/search"), payload, token=token),
+            "bilikara search failed",
+        )
+        for record in data.get("items") or []:
+            item = _record_to_item(record)
+            if not item or item["bvid"] in seen_bvids:
+                continue
+            seen_bvids.add(item["bvid"])
+            results.append(item)
+            if len(results) >= max(1, int(limit)):
+                return results
+    return results
+
+
+def _load_synced_bvids() -> set[str]:
+    try:
+        payload = json.loads(_SYNC_FILE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return set()
+    bvids = payload.get("bvids") if isinstance(payload, dict) else []
+    return {str(bvid).strip() for bvid in bvids if str(bvid).strip()}
+
+
+def _save_synced_bvids(bvids: set[str]) -> None:
+    cfg.DATA_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {"schema_version": 1, "bvids": sorted(bvids), "updated_at": time.time()}
+    temp_path = Path(str(_SYNC_FILE) + ".tmp")
+    temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    temp_path.replace(_SYNC_FILE)
+
+
+def normalize_pool_entry(entry: dict) -> dict | None:
+    if not isinstance(entry, dict):
+        return None
+    bvid = str(entry.get("bvid") or "").strip()
+    title = str(entry.get("title") or "").strip()
+    url = str(entry.get("url") or "").strip()
+    if not url and bvid:
+        url = f"https://www.bilibili.com/video/{bvid}"
+    if not bvid or not title or not url:
+        return None
+    return {
+        "mid": str(entry.get("mid") or entry.get("owner_mid") or "").strip(),
+        "bvid": bvid,
+        "title": title,
+        "url": url,
+        "owner_name": str(entry.get("owner_name") or entry.get("author") or "").strip(),
+        "owner_url": str(entry.get("owner_url") or "").strip(),
+    }
+
+
+def append_lark_pool_entries(entries: list[dict]) -> dict:
+    normalized: list[dict] = []
+    seen_batch: set[str] = set()
+    for entry in entries:
+        normalized_entry = normalize_pool_entry(entry)
+        if not normalized_entry or normalized_entry["bvid"] in seen_batch:
+            continue
+        seen_batch.add(normalized_entry["bvid"])
+        normalized.append(normalized_entry)
+    if not normalized:
+        return {"attempted": 0, "added": 0}
+
+    with _SYNC_LOCK:
+        synced_bvids = _load_synced_bvids()
+        pending = [entry for entry in normalized if entry["bvid"] not in synced_bvids]
+        if not pending:
+            return {"attempted": len(normalized), "added": 0}
+        token = _tenant_access_token()
+        added = 0
+        cursor = 0
+        for table in _active_tables():
+            capacity = max(0, _TABLE_LIMIT - int(table.get("count") or 0))
+            if capacity <= 0:
+                continue
+            field_names = set(table.get("field_names") or _REQUIRED_FIELD_NAMES)
+            while cursor < len(pending) and capacity > 0:
+                chunk = pending[cursor : cursor + min(_APPEND_CHUNK_SIZE, capacity)]
+                records = [
+                    {"fields": {key: value for key, value in entry.items() if key in field_names}}
+                    for entry in chunk
+                ]
+                _log_lark_request("bilikara pool append", {"records": records})
+                _require_success(
+                    _post_json(
+                        _records_url(table["app_token"], table["table_id"], "/batch_create"),
+                        {"records": records},
+                        token=token,
+                        timeout=20,
+                    ),
+                    "bilikara pool append failed",
+                )
+                cursor += len(chunk)
+                capacity -= len(chunk)
+                added += len(chunk)
+                synced_bvids.update(entry["bvid"] for entry in chunk)
+                _bump_table_count(int(table["index"]), len(chunk))
+                _save_synced_bvids(synced_bvids)
+            if cursor >= len(pending):
+                break
+        return {"attempted": len(normalized), "added": added}
+
+
+def append_lark_pool_entries_in_background(entries: list[dict]) -> None:
+    normalized_entries = [entry for entry in entries if isinstance(entry, dict)]
+    if not normalized_entries:
+        return
+
+    def _worker() -> None:
+        try:
+            append_lark_pool_entries(normalized_entries)
+        except Exception:
+            pass
+
+    threading.Thread(target=_worker, daemon=True, name="lark-pool-append").start()

--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -32,6 +32,7 @@ from .bilibili import (
     refresh_gatcha_favlist,
     search_gatcha_cache,
 )
+from .lark_pool_client import search_lark_pool
 from .cache import CacheManager
 from .config import (
     APP_RELEASES_URL,
@@ -574,6 +575,14 @@ class BilikaraHandler(BaseHTTPRequestHandler):
             query = parse_qs(urlparse(self.path).query).get("q", [""])[0]
             try:
                 results = search_gatcha_cache(query)
+                self._write_json({"ok": True, "data": {"items": results}})
+            except Exception as e:
+                self._write_json({"ok": False, "error": str(e)})
+            return
+        if route == "/api/lark/search":
+            query = parse_qs(urlparse(self.path).query).get("q", [""])[0]
+            try:
+                results = search_lark_pool(query)
                 self._write_json({"ok": True, "data": {"items": results}})
             except Exception as e:
                 self._write_json({"ok": False, "error": str(e)})

--- a/scripts/dev_smoke_test.py
+++ b/scripts/dev_smoke_test.py
@@ -190,6 +190,8 @@ class SmokeRunner:
                 "refresh-gatcha-cache-button",
                 "pull-gatcha-favlist-button",
                 "gatcha-favlist-modal",
+                "search-lark-toggle",
+                "lark-search-form",
             ],
             "/remote": [
                 "follow-browse-toggle",
@@ -209,6 +211,7 @@ class SmokeRunner:
                 "downloadHistoryExport",
                 "previewGatchaUid",
                 "/api/gatcha/favlist/preview",
+                "/api/lark/search",
                 "/api/gatcha/refresh",
                 "/api/gatcha/favlist",
                 "/api/app/update",

--- a/static/app.js
+++ b/static/app.js
@@ -4379,6 +4379,7 @@ async function confirmBindingModal() {
   if (!intent?.url) {
     return;
   }
+  const source = intent.source || "request-form";
   const { selectedVideoPage, selectedAudioPages } = currentBindingSelection();
   if (!selectedVideoPage) {
     setFormMessage("请先选择一个视频分P", true);
@@ -4400,6 +4401,12 @@ async function confirmBindingModal() {
     if (!intent.preserveInput) {
       elements.urlInput.value = "";
     }
+    if (source === "gatcha") {
+      state.gatchaCandidate = null;
+      elements.gatchaResultView.classList.add("hidden");
+      elements.gatchaInitView.classList.remove("hidden");
+      setGatchaMessage("Nozomi power 注入！");
+    }
     setFormMessage(intent.position === "next" ? "已按绑定关系顶歌到下一首" : "已按绑定关系加入点歌列表");
     render();
   } catch (error) {
@@ -4411,6 +4418,8 @@ async function confirmBindingModal() {
           requesterName: intent.requesterName || selectedRequesterName(),
           preserveInput: intent.preserveInput,
           allowRepeat: intent.allowRepeat,
+          source,
+          title: intent.title,
         },
         error.payload?.binding,
       );
@@ -4437,7 +4446,11 @@ async function confirmBindingModal() {
       });
       return;
     }
-    setFormMessage(error.message, true);
+    if (source === "gatcha") {
+      setGatchaMessage(error.message, true);
+    } else {
+      setFormMessage(error.message, true);
+    }
   }
 }
 
@@ -6071,6 +6084,8 @@ elements.gatchaConfirmButton.addEventListener("click", async () => {
           position: "tail",
           requesterName,
           preserveInput: false,
+          source: "gatcha",
+          title: state.gatchaCandidate.title,
         },
         error.payload?.binding,
       );

--- a/static/app.js
+++ b/static/app.js
@@ -118,6 +118,8 @@ const state = {
   retryActivityById: {},
   gatchaCandidate: null,
   searchCookieVisible: false,
+  searchLarkVisible: false,
+  larkSearchLoading: false,
   searchStageView: "",
   searchFlipTimer: null,
   searchFlipFrame: null,
@@ -254,9 +256,11 @@ const elements = {
   searchTag: document.getElementById("search-tag"),
   searchTitle: document.getElementById("search-title"),
   searchCookieToggle: document.getElementById("search-cookie-toggle"),
+  searchLarkToggle: document.getElementById("search-lark-toggle"),
   searchStage: document.getElementById("search-stage"),
   searchMainView: document.getElementById("search-main-view"),
   searchCookieView: document.getElementById("search-cookie-view"),
+  searchLarkView: document.getElementById("search-lark-view"),
   gatchaPanel: document.getElementById("gatcha-panel"),
   gatchaTag: document.getElementById("gatcha-tag"),
   gatchaTitle: document.getElementById("gatcha-title"),
@@ -287,6 +291,11 @@ const elements = {
   followSearchButton: document.getElementById("follow-search-button"),
   followSongResults: document.getElementById("follow-song-results"),
   followBrowseMessage: document.getElementById("follow-browse-message"),
+  larkSearchForm: document.getElementById("lark-search-form"),
+  larkSearchQuery: document.getElementById("lark-search-query"),
+  larkSearchButton: document.getElementById("lark-search-button"),
+  larkSearchMessage: document.getElementById("lark-search-message"),
+  larkSearchResults: document.getElementById("lark-search-results"),
   gatchaUidForm: document.getElementById("gatcha-uid-form"),
   gatchaUidInput: document.getElementById("gatcha-uid-input"),
   addGatchaUidButton: document.getElementById("add-gatcha-uid-button"),
@@ -901,6 +910,19 @@ async function searchGatchaCache(query) {
   return Array.isArray(payload.data?.items) ? payload.data.items : [];
 }
 
+async function searchLarkPool(query) {
+  const normalizedQuery = String(query || "").trim();
+  const response = await fetch(`/api/lark/search?q=${encodeURIComponent(normalizedQuery)}`, {
+    cache: "no-store",
+    headers: clientHeaders(),
+  });
+  const payload = await response.json();
+  if (!response.ok || !payload.ok) {
+    throw new Error(payload.error || "bilikara搜索失败");
+  }
+  return Array.isArray(payload.data?.items) ? payload.data.items : [];
+}
+
 async function fetchGatchaBrowse(uid = "", query = "") {
   const params = new URLSearchParams();
   const normalizedUid = String(uid || "").trim();
@@ -965,7 +987,7 @@ async function confirmGatchaUidAdd(intent) {
   }
   state.gatchaUidSaving = true;
   renderGatchaUidFace();
-  setGatchaUidMessage(`正在拉取 UP 主：${intent.name || intent.uid} 的稿件...`);
+  setGatchaUidMessage(`正在拉取 UP 主：${intent.name || intent.uid} 的稿件...(稿件较多时可能需要较长时间)`);
   try {
     const result = await addGatchaUid(intent.uid);
     setGatchaUidMessage(gatchaUidResultMessage(result, intent.uid));
@@ -1193,6 +1215,14 @@ function setFollowBrowseMessage(message, isError = false) {
   elements.followBrowseMessage.classList.toggle("is-error", Boolean(isError));
 }
 
+function setLarkSearchMessage(message, isError = false) {
+  if (!elements.larkSearchMessage) {
+    return;
+  }
+  elements.larkSearchMessage.textContent = message || "";
+  elements.larkSearchMessage.classList.toggle("is-error", Boolean(isError));
+}
+
 function setGatchaUidMessage(message, isError = false) {
   if (!elements.gatchaUidMessage) {
     return;
@@ -1209,8 +1239,8 @@ function gatchaTaskBusyMessage() {
   return state.data?.gatcha?.message || "拉取任务执行中，请等待任务结束";
 }
 
-function syncSearchStageView(showCookie) {
-  const nextView = showCookie ? "browse" : "search";
+function syncSearchStageView(view) {
+  const nextView = view || "search";
   const isInitialRender = !state.searchStageView;
   if (state.searchStageView === nextView) {
     return;
@@ -1227,7 +1257,8 @@ function syncSearchStageView(showCookie) {
   }
 
   if (isInitialRender) {
-    setClassToggle(elements.searchStage, "is-cookie-view", showCookie);
+    setClassToggle(elements.searchStage, "is-cookie-view", nextView === "browse");
+    setClassToggle(elements.searchStage, "is-lark-view", nextView === "lark");
     elements.searchStage?.classList.remove("is-flipping");
     return;
   }
@@ -1235,7 +1266,8 @@ function syncSearchStageView(showCookie) {
   elements.searchStage?.classList.add("is-flipping");
   state.searchFlipFrame = window.requestAnimationFrame(() => {
     state.searchFlipFrame = null;
-    setClassToggle(elements.searchStage, "is-cookie-view", showCookie);
+    setClassToggle(elements.searchStage, "is-cookie-view", nextView === "browse");
+    setClassToggle(elements.searchStage, "is-lark-view", nextView === "lark");
   });
   state.searchFlipTimer = window.setTimeout(() => {
     elements.searchStage?.classList.remove("is-flipping");
@@ -1245,10 +1277,13 @@ function syncSearchStageView(showCookie) {
 
 function renderSearchCookieFace() {
   const showCookie = Boolean(state.searchCookieVisible);
+  const showLark = Boolean(state.searchLarkVisible);
+  const view = showLark ? "lark" : showCookie ? "browse" : "search";
   const signature = JSON.stringify({
-    face: showCookie ? "browse" : "search",
+    face: view,
     selected: state.followBrowseSelectedUid,
     loading: state.followBrowseLoading,
+    larkLoading: state.larkSearchLoading,
   });
   if (signature === state.searchCookieFaceRenderSignature) {
     return;
@@ -1256,12 +1291,21 @@ function renderSearchCookieFace() {
   state.searchCookieFaceRenderSignature = signature;
 
   setClassToggle(elements.searchPanel, "is-cookie-view", showCookie);
-  syncSearchStageView(showCookie);
+  setClassToggle(elements.searchPanel, "is-lark-view", showLark);
+  syncSearchStageView(view);
   setTextContent(elements.searchTag, showCookie ? "Follow Browse" : "Local Search");
   setTextContent(elements.searchTitle, showCookie ? "关注列表" : "搜索");
   setTextContent(elements.searchCookieToggle, showCookie ? "返回搜索" : "关注浏览");
+  if (showLark) {
+    setTextContent(elements.searchTag, "Bilikara Search");
+    setTextContent(elements.searchTitle, "bilikara搜索");
+  }
+  setTextContent(elements.searchLarkToggle, showLark ? "返回搜索" : "bilikara搜索");
   if (elements.searchCookieToggle?.getAttribute("aria-pressed") !== String(showCookie)) {
     elements.searchCookieToggle.setAttribute("aria-pressed", String(showCookie));
+  }
+  if (elements.searchLarkToggle?.getAttribute("aria-pressed") !== String(showLark)) {
+    elements.searchLarkToggle.setAttribute("aria-pressed", String(showLark));
   }
   if (showCookie) {
     renderFollowBrowse();
@@ -4315,10 +4359,10 @@ async function confirmGatchaFavlistModal() {
 
   state.gatchaFavlistSaving = true;
   renderGatchaUidFace();
-  setGatchaUidMessage("正在拉取选中的公开收藏夹...");
+  setGatchaUidMessage("正在拉取选中的公开收藏夹...（稿件较多时可能需要较长时间）");
+  closeGatchaFavlistModal();
   try {
     const result = await pullGatchaFavlist(intent.uid, folderIds);
-    closeGatchaFavlistModal();
     setGatchaUidMessage(
       `已拉取 ${result?.matched_folder_count || 0} 个收藏夹，加入 ${result?.item_count || 0} 个稿件。`,
     );
@@ -5038,6 +5082,53 @@ elements.searchResults.addEventListener("click", async (event) => {
     hideSearchResults();
     setSearchMessage("");
     elements.searchQuery.value = "";
+  } finally {
+    button.disabled = false;
+  }
+});
+
+elements.larkSearchForm?.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const query = String(elements.larkSearchQuery?.value || "").trim();
+  if (!query) {
+    renderSearchResultItems(elements.larkSearchResults, []);
+    setLarkSearchMessage("请输入搜索关键词。", true);
+    return;
+  }
+
+  state.larkSearchLoading = true;
+  if (elements.larkSearchButton) {
+    elements.larkSearchButton.disabled = true;
+  }
+  setLarkSearchMessage("正在搜索 bilikara 数据库...(第一次搜索需要3-15s启动)");
+  try {
+    const items = await searchLarkPool(query);
+    renderSearchResultItems(elements.larkSearchResults, items, "bilikara 数据库里没有匹配结果。");
+    setLarkSearchMessage(items.length ? `搜索到 ${items.length} 条共享结果。` : "bilikara 数据库里没有匹配结果。");
+  } catch (error) {
+    renderSearchResultItems(elements.larkSearchResults, []);
+    setLarkSearchMessage(error.message, true);
+  } finally {
+    state.larkSearchLoading = false;
+    if (elements.larkSearchButton) {
+      elements.larkSearchButton.disabled = false;
+    }
+    renderSearchCookieFace();
+  }
+});
+
+elements.larkSearchResults?.addEventListener("click", async (event) => {
+  const button = event.target.closest("button[data-url]");
+  if (!button) {
+    return;
+  }
+  const url = String(button.dataset.url || "").trim();
+  if (!url) {
+    return;
+  }
+  button.disabled = true;
+  try {
+    await handleAddByUrl(url, "tail", anchorPointForEvent(event, button));
   } finally {
     button.disabled = false;
   }
@@ -5877,6 +5968,7 @@ elements.gatchaButton.addEventListener("click", handleGatchaDraw);
 elements.gatchaRetryButton.addEventListener("click", handleGatchaDraw);
 
 elements.searchCookieToggle?.addEventListener("click", () => {
+  state.searchLarkVisible = false;
   state.searchCookieVisible = !state.searchCookieVisible;
   renderSearchCookieFace();
   if (state.searchCookieVisible && !state.followBrowseLoading) {
@@ -5886,6 +5978,12 @@ elements.searchCookieToggle?.addEventListener("click", () => {
     }
     loadFollowBrowse({ uid: "", query: "" });
   }
+});
+
+elements.searchLarkToggle?.addEventListener("click", () => {
+  state.searchCookieVisible = false;
+  state.searchLarkVisible = !state.searchLarkVisible;
+  renderSearchCookieFace();
 });
 
 elements.followUpGrid?.addEventListener("click", async (event) => {

--- a/static/index.html
+++ b/static/index.html
@@ -433,9 +433,14 @@
                     <p class="section-tag" id="search-tag">Local Search</p>
                     <h2 id="search-title">搜索</h2>
                   </div>
-                  <button type="button" id="search-cookie-toggle" class="toolbar-button ghost search-cookie-toggle">
-                    关注浏览
-                  </button>
+                  <div class="search-head-actions">
+                    <button type="button" id="search-cookie-toggle" class="toolbar-button ghost search-cookie-toggle">
+                      关注浏览
+                    </button>
+                    <button type="button" id="search-lark-toggle" class="toolbar-button ghost search-lark-toggle">
+                      bilikara搜索
+                    </button>
+                  </div>
                 </div>
 
                 <div id="search-stage" class="search-stage">
@@ -477,6 +482,16 @@
                         </div>
                         <p class="gatcha-message" id="follow-browse-message" role="status"></p>
                       </div>
+                    </div>
+                    <div id="search-lark-view" class="search-face search-face-lark">
+                      <form id="lark-search-form" class="search-inputs">
+                        <div class="input-group">
+                          <input type="text" id="lark-search-query" placeholder="在 bilikara 共享数据库中搜索" autocomplete="off">
+                        </div>
+                        <button type="submit" id="lark-search-button" class="next-button">搜索</button>
+                      </form>
+                      <p class="search-message" id="lark-search-message" role="status"></p>
+                      <div id="lark-search-results" class="search-results hidden"></div>
                     </div>
                   </div>
                 </div>

--- a/static/remote.css
+++ b/static/remote.css
@@ -291,8 +291,35 @@ h1 {
   margin-bottom: 12px;
 }
 
+.panel-head-actions {
+  display: flex;
+  flex: 0 1 auto;
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+}
+
 .panel-head-stack {
   align-items: flex-start;
+}
+
+.search-panel .panel-head {
+  flex-wrap: wrap;
+}
+
+.search-panel .panel-head > div:first-child {
+  flex: 1 1 100%;
+}
+
+.search-panel .panel-head .panel-head-actions {
+  flex: 1 1 100%;
+  justify-content: stretch;
+}
+
+.search-panel .panel-head .panel-head-actions > button {
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .now-playing-panel {
@@ -1280,10 +1307,20 @@ select:disabled {
   white-space: nowrap;
 }
 
-.follow-browse-toggle {
+.follow-browse-toggle,
+.lark-search-toggle {
   min-height: 40px;
   padding-inline: 12px;
   white-space: nowrap;
+}
+
+.lark-search-view {
+  display: grid;
+  gap: 12px;
+}
+
+.lark-search-view.hidden {
+  display: none;
 }
 
 .follow-browser {

--- a/static/remote.html
+++ b/static/remote.html
@@ -187,9 +187,14 @@
             <p class="panel-tag">Local Search</p>
             <h2 class="panel-title">搜索</h2>
           </div>
+          <div class="panel-head-actions">
+          <button type="button" id="lark-search-toggle" class="secondary-button lark-search-toggle" aria-pressed="false">
+            bilikara搜索
+          </button>
           <button type="button" id="follow-browse-toggle" class="secondary-button follow-browse-toggle" aria-pressed="false">
             关注浏览
           </button>
+          </div>
         </div>
         <form id="search-form" class="request-form search-form">
           <input
@@ -202,6 +207,19 @@
         </form>
         <p id="search-message" class="message search-message" role="status"></p>
         <div id="search-results" class="search-results hidden"></div>
+        <div id="lark-search-view" class="lark-search-view hidden">
+          <form id="lark-search-form" class="request-form search-form">
+            <input
+              id="lark-search-query"
+              type="text"
+              placeholder="在 bilikara 共享数据库中搜索"
+              autocomplete="off"
+            />
+            <button type="submit" id="lark-search-button" class="primary-button">搜索</button>
+          </form>
+          <p id="lark-search-message" class="message search-message" role="status"></p>
+          <div id="lark-search-results" class="search-results hidden"></div>
+        </div>
         <div id="follow-browse-view" class="follow-browser hidden">
           <div id="follow-up-list-view">
             <div id="follow-up-grid" class="follow-up-grid"></div>

--- a/static/remote.js
+++ b/static/remote.js
@@ -45,6 +45,8 @@ const state = {
   gatchaRefreshSaving: false,
   gatchaFavlistSaving: false,
   followBrowseVisible: false,
+  larkSearchVisible: false,
+  larkSearchLoading: false,
   followBrowseData: null,
   followBrowseSelectedUid: "",
   followBrowseLoading: false,
@@ -113,6 +115,13 @@ const elements = {
   searchResults: document.getElementById("search-results"),
   searchTag: document.querySelector(".search-panel .panel-tag"),
   searchTitle: document.querySelector(".search-panel .panel-title"),
+  larkSearchToggle: document.getElementById("lark-search-toggle"),
+  larkSearchView: document.getElementById("lark-search-view"),
+  larkSearchForm: document.getElementById("lark-search-form"),
+  larkSearchQuery: document.getElementById("lark-search-query"),
+  larkSearchButton: document.getElementById("lark-search-button"),
+  larkSearchMessage: document.getElementById("lark-search-message"),
+  larkSearchResults: document.getElementById("lark-search-results"),
   followBrowseToggle: document.getElementById("follow-browse-toggle"),
   followBrowseView: document.getElementById("follow-browse-view"),
   followUpListView: document.getElementById("follow-up-list-view"),
@@ -417,9 +426,21 @@ function setSearchMessage(message, isError = false) {
   elements.searchMessage.classList.toggle("error", Boolean(isError));
 }
 
+function setLarkSearchMessage(message, isError = false) {
+  if (!elements.larkSearchMessage) {
+    return;
+  }
+  elements.larkSearchMessage.textContent = message || "";
+  elements.larkSearchMessage.classList.toggle("error", Boolean(isError));
+}
+
 function setMessageForSource(source, message, isError = false) {
   if (source === "search") {
     setSearchMessage(message, isError);
+    return;
+  }
+  if (source === "lark") {
+    setLarkSearchMessage(message, isError);
     return;
   }
   if (source === "follow") {
@@ -707,6 +728,19 @@ async function searchGatchaCache(query) {
   return Array.isArray(payload.data?.items) ? payload.data.items : [];
 }
 
+async function searchLarkPool(query) {
+  const normalizedQuery = String(query || "").trim();
+  const response = await fetch(`/api/lark/search?q=${encodeURIComponent(normalizedQuery)}`, {
+    cache: "no-store",
+    headers: clientHeaders(),
+  });
+  const payload = await response.json();
+  if (!response.ok || !payload.ok) {
+    throw new Error(payload.error || "bilikara 搜索失败");
+  }
+  return Array.isArray(payload.data?.items) ? payload.data.items : [];
+}
+
 async function fetchGatchaBrowse(uid = "", query = "") {
   const params = new URLSearchParams();
   const normalizedUid = String(uid || "").trim();
@@ -775,6 +809,14 @@ function hideSearchResults() {
   elements.searchResults.classList.add("hidden");
 }
 
+function hideLarkSearchResults() {
+  if (!elements.larkSearchResults) {
+    return;
+  }
+  elements.larkSearchResults.innerHTML = "";
+  elements.larkSearchResults.classList.add("hidden");
+}
+
 function renderSearchResults(items) {
   elements.searchResults.innerHTML = "";
   elements.searchResults.classList.remove("hidden");
@@ -810,6 +852,46 @@ function renderSearchResults(items) {
     meta.append(title, url);
     row.append(meta, button);
     elements.searchResults.appendChild(row);
+  });
+}
+
+function renderLarkSearchResults(items) {
+  if (!elements.larkSearchResults) {
+    return;
+  }
+  elements.larkSearchResults.innerHTML = "";
+  elements.larkSearchResults.classList.remove("hidden");
+
+  if (!items.length) {
+    const empty = document.createElement("div");
+    empty.className = "search-empty";
+    empty.textContent = "bilikara 数据库里没有匹配结果。";
+    elements.larkSearchResults.appendChild(empty);
+    return;
+  }
+
+  items.forEach((item) => {
+    const row = document.createElement("div");
+    row.className = "search-result-item";
+
+    const meta = document.createElement("div");
+    const title = document.createElement("div");
+    title.className = "search-result-title";
+    title.textContent = String(item.title || "");
+
+    const url = document.createElement("div");
+    url.className = "search-result-url";
+    url.textContent = String(item.bvid || item.url || "");
+
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "primary-button";
+    button.dataset.url = String(item.url || "");
+    button.textContent = "点歌";
+
+    meta.append(title, url);
+    row.append(meta, button);
+    elements.larkSearchResults.appendChild(row);
   });
 }
 
@@ -904,19 +986,26 @@ function renderFollowBrowse() {
     return;
   }
 
-  elements.searchForm?.classList.toggle("hidden", state.followBrowseVisible);
-  elements.searchMessage?.classList.toggle("hidden", state.followBrowseVisible || !elements.searchMessage.textContent);
-  elements.searchResults?.classList.toggle("hidden", state.followBrowseVisible || !elements.searchResults.children.length);
-  elements.followBrowseView.classList.toggle("hidden", !state.followBrowseVisible);
+  const showFollow = Boolean(state.followBrowseVisible);
+  const showLark = Boolean(state.larkSearchVisible);
+  elements.searchForm?.classList.toggle("hidden", showFollow || showLark);
+  elements.searchMessage?.classList.toggle("hidden", showFollow || showLark || !elements.searchMessage.textContent);
+  elements.searchResults?.classList.toggle("hidden", showFollow || showLark || !elements.searchResults.children.length);
+  elements.followBrowseView.classList.toggle("hidden", !showFollow);
+  elements.larkSearchView?.classList.toggle("hidden", !showLark);
   if (elements.followBrowseToggle) {
-    elements.followBrowseToggle.textContent = state.followBrowseVisible ? "返回搜索" : "关注浏览";
-    elements.followBrowseToggle.setAttribute("aria-pressed", String(state.followBrowseVisible));
+    elements.followBrowseToggle.textContent = showFollow ? "返回搜索" : "关注浏览";
+    elements.followBrowseToggle.setAttribute("aria-pressed", String(showFollow));
+  }
+  if (elements.larkSearchToggle) {
+    elements.larkSearchToggle.textContent = showLark ? "返回搜索" : "bilikara搜索";
+    elements.larkSearchToggle.setAttribute("aria-pressed", String(showLark));
   }
   if (elements.searchTag) {
-    elements.searchTag.textContent = state.followBrowseVisible ? "Follow Browse" : "Local Search";
+    elements.searchTag.textContent = showLark ? "bilikara Search" : showFollow ? "Follow Browse" : "Local Search";
   }
   if (elements.searchTitle) {
-    elements.searchTitle.textContent = state.followBrowseVisible ? "关注列表" : "搜索";
+    elements.searchTitle.textContent = showLark ? "bilikara搜索" : showFollow ? "关注列表" : "搜索";
   }
   if (!state.followBrowseVisible) {
     return;
@@ -1133,7 +1222,7 @@ async function handleGatchaUidSubmit(event) {
       renderGatchaUidView();
       return;
     }
-    setGatchaUidMessage(`正在拉取 UP 主：${ownerName} 的稿件...`);
+    setGatchaUidMessage(`正在拉取 UP 主：${ownerName} 的稿件...(稿件较多时可能需要较长时间)`);
     const result = await addGatchaUid(normalizedUid);
     setGatchaUidMessage(gatchaUidResultMessage(result, normalizedUid));
     if (elements.gatchaUidInput) {
@@ -1659,7 +1748,7 @@ async function confirmGatchaFavlistSheet() {
 
   state.gatchaFavlistSaving = true;
   renderGatchaUidView();
-  setGatchaUidMessage("正在拉取选中的公开收藏夹...");
+  setGatchaUidMessage("正在拉取选中的公开收藏夹...(稿件较多时可能需要较长时间)");
   try {
     const result = await pullGatchaFavlist(intent.uid, folderIds);
     closeGatchaFavlistSheet();
@@ -1769,6 +1858,12 @@ async function confirmBindingSheet() {
     if (intent.source === "search") {
       hideSearchResults();
       elements.searchQuery.value = "";
+    }
+    if (intent.source === "lark") {
+      hideLarkSearchResults();
+      if (elements.larkSearchQuery) {
+        elements.larkSearchQuery.value = "";
+      }
     }
     if (intent.source === "follow") {
       setFollowBrowseMessage("");
@@ -2214,6 +2309,12 @@ async function addByUrl(url, position = "tail", source = "search") {
       hideSearchResults();
       elements.searchQuery.value = "";
     }
+    if (source === "lark") {
+      hideLarkSearchResults();
+      if (elements.larkSearchQuery) {
+        elements.larkSearchQuery.value = "";
+      }
+    }
     if (source === "gatcha") {
       state.gatchaCandidate = null;
       renderGatchaUidView();
@@ -2355,7 +2456,51 @@ elements.searchResults.addEventListener("click", async (event) => {
   await addByUrl(String(button.dataset.url || ""), "tail", "search");
 });
 
+elements.larkSearchToggle?.addEventListener("click", () => {
+  state.followBrowseVisible = false;
+  state.larkSearchVisible = !state.larkSearchVisible;
+  renderFollowBrowse();
+});
+
+elements.larkSearchForm?.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const query = String(elements.larkSearchQuery?.value || "").trim();
+  if (!query) {
+    hideLarkSearchResults();
+    setLarkSearchMessage("请输入搜索关键词。", true);
+    return;
+  }
+
+  state.larkSearchLoading = true;
+  if (elements.larkSearchButton) {
+    elements.larkSearchButton.disabled = true;
+  }
+  setLarkSearchMessage("正在搜索 bilikara 共享数据库...(第一次搜索需要3-15s启动)");
+  try {
+    const items = await searchLarkPool(query);
+    renderLarkSearchResults(items);
+    setLarkSearchMessage(items.length ? `找到 ${items.length} 条共享结果。` : "bilikara 数据库里没有匹配结果。");
+  } catch (error) {
+    hideLarkSearchResults();
+    setLarkSearchMessage(error.message, true);
+  } finally {
+    state.larkSearchLoading = false;
+    if (elements.larkSearchButton) {
+      elements.larkSearchButton.disabled = false;
+    }
+  }
+});
+
+elements.larkSearchResults?.addEventListener("click", async (event) => {
+  const button = event.target.closest("button[data-url]");
+  if (!button) {
+    return;
+  }
+  await addByUrl(String(button.dataset.url || ""), "tail", "lark");
+});
+
 elements.followBrowseToggle?.addEventListener("click", () => {
+  state.larkSearchVisible = false;
   state.followBrowseVisible = !state.followBrowseVisible;
   renderFollowBrowse();
   if (state.followBrowseVisible && !state.followBrowseLoading) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -3466,6 +3466,10 @@ select:disabled {
   transform: rotateY(180deg);
 }
 
+.search-stage.is-lark-view .search-stage-inner {
+  transform: none;
+}
+
 .search-face {
   grid-area: 1 / 1;
   display: grid;
@@ -3488,6 +3492,12 @@ select:disabled {
   transform: rotateY(180deg);
 }
 
+.search-face-lark {
+  pointer-events: none;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  max-height: 240px;
+}
+
 .search-stage.is-cookie-view .search-face-front {
   pointer-events: none;
 }
@@ -3496,8 +3506,15 @@ select:disabled {
   pointer-events: auto;
 }
 
+.search-stage.is-lark-view .search-face-lark {
+  pointer-events: auto;
+}
+
 .search-stage:not(.is-cookie-view):not(.is-flipping) .search-face-back,
-.search-stage.is-cookie-view:not(.is-flipping) .search-face-front {
+.search-stage.is-cookie-view:not(.is-flipping) .search-face-front,
+.search-stage:not(.is-lark-view):not(.is-flipping) .search-face-lark,
+.search-stage.is-lark-view:not(.is-flipping) .search-face-front,
+.search-stage.is-lark-view:not(.is-flipping) .search-face-back {
   display: none;
   content-visibility: hidden;
 }
@@ -3518,6 +3535,13 @@ select:disabled {
 
 .search-sub-card-head > div {
   min-width: 0;
+}
+
+.search-head-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .song-requester,

--- a/tests/test_lark_pool_client.py
+++ b/tests/test_lark_pool_client.py
@@ -1,0 +1,144 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import bilikara.lark_pool_client as lark_pool
+
+
+class LarkPoolClientTest(unittest.TestCase):
+    def test_tenant_access_token_reads_top_level_feishu_payload(self):
+        with (
+            patch.object(
+                lark_pool,
+                "_post_json",
+                return_value={"code": 0, "tenant_access_token": "tenant-token", "expire": 3600},
+            ),
+            patch.object(lark_pool, "_TOKEN_VALUE", ""),
+            patch.object(lark_pool, "_TOKEN_EXPIRES_AT", 0.0),
+        ):
+            token = lark_pool._tenant_access_token()
+
+        self.assertEqual(token, "tenant-token")
+
+    def test_search_lark_pool_normalizes_records(self):
+        def fake_post(url, payload, *, token=None, timeout=12.0):
+            self.assertIn("/records/search", url)
+            self.assertEqual(set(payload.keys()), {"filter"})
+            self.assertEqual(payload["filter"]["conditions"][0]["field_name"], "title")
+            return {
+                "code": 0,
+                "data": {
+                    "items": [
+                        {
+                            "fields": {
+                                "mid": "42",
+                                "bvid": "BVPOOL1",
+                                "title": [{"text": "karaoke title"}],
+                                "url": "https://www.bilibili.com/video/BVPOOL1",
+                                "owner_name": "owner",
+                                "owner_url": "https://space.bilibili.com/42",
+                            }
+                        }
+                    ]
+                },
+            }
+
+        with (
+            patch.object(lark_pool, "_tenant_access_token", return_value="token"),
+            patch.object(lark_pool, "_active_tables", return_value=[{"app_token": "app", "table_id": "table"}]),
+            patch.object(lark_pool, "_post_json", side_effect=fake_post),
+        ):
+            results = lark_pool.search_lark_pool("karaoke")
+
+        self.assertEqual(results[0]["bvid"], "BVPOOL1")
+        self.assertEqual(results[0]["title"], "karaoke title")
+        self.assertEqual(results[0]["source"], "bilikara")
+
+    def test_active_tables_skip_tables_without_search_fields(self):
+        with (
+            patch.object(lark_pool, "_TABLES_READY", False),
+            patch.object(lark_pool, "_ACTIVE_TABLES", []),
+            patch.object(lark_pool, "BITABLE_TABLES", (("app1", "table1"), ("app2", "table2"))),
+            patch.object(lark_pool, "_tenant_access_token", return_value="token"),
+            patch.object(
+                lark_pool,
+                "_table_field_names",
+                side_effect=[
+                    {"bvid", "url"},
+                    {"bvid", "title", "url", "owner_name"},
+                ],
+            ),
+            patch.object(lark_pool, "_table_record_count", return_value=1),
+        ):
+            tables = lark_pool._active_tables()
+
+        self.assertEqual([table["index"] for table in tables], [2])
+        self.assertEqual(tables[0]["field_names"], ["bvid", "owner_name", "title", "url"])
+        self.assertFalse(tables[0]["search_enabled"])
+
+    def test_search_lark_pool_skips_empty_overflow_tables(self):
+        post_count = 0
+
+        def fake_post(url, payload, *, token=None, timeout=12.0):
+            nonlocal post_count
+            self.assertIn("/records/search", url)
+            post_count += 1
+            return {"code": 0, "data": {"items": []}}
+
+        with (
+            patch.object(lark_pool, "_tenant_access_token", return_value="token"),
+            patch.object(
+                lark_pool,
+                "_active_tables",
+                return_value=[
+                    {"index": 1, "app_token": "app1", "table_id": "table1", "search_enabled": True},
+                    {"index": 2, "app_token": "app2", "table_id": "table2", "search_enabled": False},
+                    {"index": 3, "app_token": "app3", "table_id": "table3", "search_enabled": False},
+                ],
+            ),
+            patch.object(lark_pool, "_post_json", side_effect=fake_post),
+        ):
+            results = lark_pool.search_lark_pool("dive")
+
+        self.assertEqual(results, [])
+        self.assertEqual(post_count, 1)
+
+    def test_append_lark_pool_entries_skips_locally_synced_bvids(self):
+        with TemporaryDirectory() as temp_dir:
+            sync_file = Path(temp_dir) / "lark_pool_sync.json"
+            sync_file.write_text(json.dumps({"bvids": ["BVOLD"]}), encoding="utf-8")
+            posted_records = []
+
+            def fake_post(url, payload, *, token=None, timeout=12.0):
+                self.assertIn("/batch_create", url)
+                posted_records.extend(payload["records"])
+                return {"code": 0, "data": {}}
+
+            with (
+                patch.object(lark_pool, "_SYNC_FILE", sync_file),
+                patch.object(lark_pool.cfg, "DATA_DIR", Path(temp_dir)),
+                patch.object(lark_pool, "_tenant_access_token", return_value="token"),
+                patch.object(
+                    lark_pool,
+                    "_active_tables",
+                    return_value=[{"index": 1, "app_token": "app", "table_id": "table", "count": 1}],
+                ),
+                patch.object(lark_pool, "_post_json", side_effect=fake_post),
+            ):
+                result = lark_pool.append_lark_pool_entries(
+                    [
+                        {"bvid": "BVOLD", "title": "old", "url": "https://www.bilibili.com/video/BVOLD"},
+                        {"bvid": "BVNEW", "title": "new", "url": "https://www.bilibili.com/video/BVNEW"},
+                    ]
+                )
+
+            self.assertEqual(result["added"], 1)
+            self.assertEqual(posted_records[0]["fields"]["bvid"], "BVNEW")
+            payload = json.loads(sync_file.read_text(encoding="utf-8"))
+            self.assertIn("BVNEW", payload["bvids"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 中文

新增 bilikara 飞书共享搜索与 gatcha 数据池同步

## 摘要

本次改动在 Local Search 中加入了新的「bilikara 搜索」页面，用户可以直接通过飞书多维表格按标题搜索共享曲库。与此同时，在用户完成 gatcha_cache、手动更新、gatcha_favlist 收藏夹拉取等数据获取任务后，程序会把本地收集到的稿件异步追加到飞书共享数据池中，实现「用户完善数据库，用户享受数据库」的循环。

## 主要改动

- 新增 `bilikara/lark_pool_client.py`，集中封装飞书 tenant token 获取、表结构探测、标题搜索、批量追加、本地同步去重和表容量判断。
- 新增后端 `/api/lark/search` 接口，供前端 bilikara 搜索页面调用。
- 在 Local Search 卡片中新增「bilikara 搜索」翻页，页面样式与现有 Local Search 保持一致。
- bilikara 搜索结果可直接进入现有点歌流程，点击结果后按原有规则添加到队列。
- 在 gatcha_cache、手动更新、gatcha_favlist 拉取任务完成后，将收集到的稿件异步 append 到飞书多维表格，不阻塞原本的拉取流程。
- 新增本地 `data/lark_pool_sync.json` 记录已同步过的 BV 号，避免同一机器反复上传重复稿件。
- 支持 5 个飞书多维表格作为扩容池，每个表按 2 万条上限判断容量，写入时会自动寻找仍有容量的表。
- 将「可搜索表」和「可写入表」分离：1 号主表默认参与搜索，2-5 号备用表保留写入能力，但只有记录数大于 1 时才参与搜索，减少无效请求并节省每月请求额度。
- 首次使用时会探测表结构，只有包含 `bvid`、`title`、`url` 字段的表才会加入可用表列表，避免字段不匹配导致 `InvalidFilter`。
- 搜索请求改为直接使用 `title contains` 条件，移除曾导致 `InvalidSort` 的排序参数。
- append 写入时会按目标表已有字段过滤数据，避免备用表字段结构不一致时写入失败。
- Lark 请求调试日志默认关闭，保留 `_DEBUG_LOGS` 开关，后续排查接口问题时可以临时开启。
- 收藏夹选择弹窗在确认拉取后会立即关闭，拉取结果回到 UID 页面显示，避免弹窗长时间遮挡界面。

## 测试

- `py -m py_compile bilikara\lark_pool_client.py`
- `py -B -m unittest tests.test_lark_pool_client`
- 此功能开发过程中也跑过相关 server / build / store 测试用于回归验证。
- `py  scripts\dev_smoke_test.py`

## 备注

- 实际项目集成逻辑集中在 `bilikara/lark_pool_client.py`。

## Title

Add shared Lark search and pooled gatcha data sync for bilikara

## Summary

This change adds a new “bilikara search” page inside Local Search, allowing users to search a shared Feishu/Lark Bitable music pool by title. It also appends locally collected entries back to the shared Lark pool after gatcha_cache, manual refresh, and gatcha_favlist pull tasks finish, creating a shared workflow where users both benefit from and contribute to the database.

## Main Changes

- Added `bilikara/lark_pool_client.py` as the central client for Feishu tenant token auth, table schema probing, title search, batch append, local sync deduplication, and table capacity checks.
- Added a backend `/api/lark/search` endpoint for the frontend bilikara search page.
- Added a new “bilikara search” flip view to the Local Search card, matching the existing Local Search visual style.
- Wired bilikara search results into the existing request flow, so users can add shared-pool results to the queue through the normal path.
- After gatcha_cache, manual refresh, and gatcha_favlist pull tasks complete, collected video entries are appended to the Lark Bitable pool asynchronously without blocking the original pull workflow.
- Added local `data/lark_pool_sync.json` tracking to avoid repeatedly uploading the same BVID from the same machine.
- Added support for five Feishu/Lark Bitable tables as an expandable pool, respecting the 20k-record limit per table and automatically writing to tables with remaining capacity.
- Split searchable tables from writable tables: table 1 is searched by default, while tables 2-5 remain writable but only join search after they contain more than one record. This reduces unnecessary requests and helps preserve the monthly request quota.
- Added first-use schema probing so only tables containing `bvid`, `title`, and `url` are treated as usable, avoiding `InvalidFilter` errors from mismatched schemas.
- Changed search requests to use a direct `title contains` filter and removed the sort payload that previously caused `InvalidSort`.
- Append requests now filter fields by the target table schema to avoid write failures when overflow table schemas differ.
- Disabled verbose Lark request logs by default while keeping a `_DEBUG_LOGS` switch for future troubleshooting.
- The favorite-list selection modal now closes immediately after users confirm a pull, and the result is shown back on the UID page instead of leaving the modal over the UI.

## Tests

- `py -m py_compile bilikara\lark_pool_client.py`
- `py -B -m unittest tests.test_lark_pool_client`
- Related server / build / store tests were also run during development for regression coverage.
- `py  scripts\dev_smoke_test.py`

## Notes

- The actual production integration lives in `bilikara/lark_pool_client.py`.