### PR TITLE
Add HEVC compatibility detection and AVC quality fallback

### DIFF
--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -85,6 +85,8 @@ class CacheManager:
         self.max_cache_items = self._bounded_cache_items(max_cache_items)
         self.video_quality = DEFAULT_VIDEO_QUALITY
         self.audio_hires = DEFAULT_AUDIO_HIRES
+        self.hevc_supported: bool | None = None
+        self.client_media_capabilities: dict[str, Any] = {}
         self.on_bbdown_login_success = on_bbdown_login_success
         self.tasks: "queue.Queue[str]" = queue.Queue()
         self.pending_ids: set[str] = set()
@@ -126,6 +128,7 @@ class CacheManager:
                 "cached_items": cache_metrics["item_count"],
                 "logged_in": login_status["logged_in"],
                 "login": login_status,
+                "media_capabilities": self.media_capabilities_snapshot(),
             }
 
     def ffmpeg_status(self) -> dict[str, Any]:
@@ -206,10 +209,48 @@ class CacheManager:
                     for quality in VIDEO_QUALITY_CHOICES
                 ],
                 "audio_hires": self.audio_hires,
+                "force_avc": self._should_force_avc_locked(),
+                "media_capabilities": dict(self.client_media_capabilities),
                 "clear_on_exit": True,
                 "usage_bytes": cache_metrics["total_bytes"],
                 "cached_item_count": cache_metrics["item_count"],
             }
+
+    def media_capabilities_snapshot(self) -> dict[str, Any]:
+        with self.lock:
+            return dict(self.client_media_capabilities)
+
+    def set_client_media_capabilities(self, payload: dict[str, Any]) -> dict[str, Any]:
+        hevc_supported = payload.get("hevc_supported")
+        if not isinstance(hevc_supported, bool):
+            raise ValueError("hevc_supported must be a boolean")
+
+        can_play_type = payload.get("can_play_type")
+        if not isinstance(can_play_type, dict):
+            can_play_type = {}
+
+        next_capabilities = {
+            "hevc_supported": hevc_supported,
+            "force_avc": not hevc_supported,
+            "can_play_type": {
+                str(key): str(value)
+                for key, value in can_play_type.items()
+            },
+            "user_agent": str(payload.get("user_agent") or "")[:500],
+            "platform": str(payload.get("platform") or "")[:100],
+            "reported_at": datetime.now().timestamp(),
+        }
+
+        with self.lock:
+            previous_hevc_supported = self.hevc_supported
+            self.hevc_supported = hevc_supported
+            self.client_media_capabilities = next_capabilities
+            should_recache = previous_hevc_supported is not False and not hevc_supported
+
+        if should_recache:
+            self._request_desired_recaching("HEVC unsupported; switching video cache to AVC")
+
+        return self.media_capabilities_snapshot()
 
     def enrich_snapshot(
         self,
@@ -989,14 +1030,51 @@ class CacheManager:
         with self.lock:
             video_quality = self.video_quality
             audio_hires = self.audio_hires
+            force_avc = self._should_force_avc_locked()
         if stream_kind == "video":
-            return ["-q", self._video_quality_priority(video_quality)]
+            args = ["-q", self._video_quality_priority(video_quality)]
+            if force_avc:
+                args.extend(["-e", "avc"])
+            return args
         if stream_kind == "audio" and not audio_hires:
             # BBDown 1.6.x does not expose a direct "highest non-Hi-Res"
             # selector. The closest safe fallback is to prefer the smaller
             # audio stream when Hi-Res is disabled.
             return ["--audio-ascending"]
         return []
+
+    def _should_force_avc_locked(self) -> bool:
+        return self.hevc_supported is False
+
+    def _request_desired_recaching(self, message: str) -> None:
+        with self.lock:
+            item_ids = set(self.desired_ids)
+            active_item_id = self.active_item_id if self.active_item_id in item_ids else None
+            active_process = self.active_process if active_item_id else None
+            pending_ids = set(self.pending_ids)
+            for item_id in item_ids:
+                if item_id == active_item_id or item_id in pending_ids:
+                    self.retry_requested_ids.add(item_id)
+
+        for item_id in item_ids:
+            self.store.update_item(
+                item_id,
+                cache_status="pending",
+                cache_progress=0.0,
+                cache_message=message,
+                video_relative_path="",
+                video_media_url="",
+                audio_variants=[],
+                selected_audio_variant_id="",
+                persist_backup=False,
+            )
+            self._record_item_activity(item_id)
+            if item_id == active_item_id or item_id in pending_ids:
+                continue
+            self._remove_cache_dir(item_id)
+            self.enqueue(item_id)
+
+        self._terminate_process(active_process)
 
     @staticmethod
     def _video_quality_priority(video_quality: object) -> str:

--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -86,6 +86,7 @@ class CacheManager:
         self.video_quality = DEFAULT_VIDEO_QUALITY
         self.audio_hires = DEFAULT_AUDIO_HIRES
         self.hevc_supported: bool | None = None
+        self.avc_quality_cap = ""
         self.client_media_capabilities: dict[str, Any] = {}
         self.on_bbdown_login_success = on_bbdown_login_success
         self.tasks: "queue.Queue[str]" = queue.Queue()
@@ -210,6 +211,7 @@ class CacheManager:
                 ],
                 "audio_hires": self.audio_hires,
                 "force_avc": self._should_force_avc_locked(),
+                "avc_quality_cap": self.avc_quality_cap,
                 "media_capabilities": dict(self.client_media_capabilities),
                 "clear_on_exit": True,
                 "usage_bytes": cache_metrics["total_bytes"],
@@ -228,29 +230,82 @@ class CacheManager:
         can_play_type = payload.get("can_play_type")
         if not isinstance(can_play_type, dict):
             can_play_type = {}
+        avc_levels = payload.get("avc_levels")
+        if not isinstance(avc_levels, list):
+            avc_levels = []
+        avc_supported = payload.get("avc_supported")
+        if not isinstance(avc_supported, bool):
+            avc_supported = False
+        max_avc_quality = self._quality_from_choice_index(
+            payload.get("max_avc_quality_index")
+        ) or self._optional_video_quality(payload.get("max_avc_quality"))
+        if not hevc_supported and not max_avc_quality:
+            max_avc_quality = VIDEO_QUALITY_CHOICES[-1]
 
         next_capabilities = {
             "hevc_supported": hevc_supported,
             "force_avc": not hevc_supported,
+            "avc_supported": avc_supported,
+            "max_avc_quality": max_avc_quality or "",
+            "max_avc_quality_index": (
+                VIDEO_QUALITY_CHOICES.index(max_avc_quality)
+                if max_avc_quality in VIDEO_QUALITY_CHOICES
+                else None
+            ),
             "can_play_type": {
                 str(key): str(value)
                 for key, value in can_play_type.items()
             },
+            "avc_levels": [
+                {
+                    "name": str(entry.get("name") or "")[:50],
+                    "codec": str(entry.get("codec") or "")[:120],
+                    "can_play_type": str(entry.get("can_play_type") or "")[:20],
+                    "max_avc_quality_index": entry.get("max_avc_quality_index"),
+                }
+                for entry in avc_levels[:20]
+                if isinstance(entry, dict)
+            ],
             "user_agent": str(payload.get("user_agent") or "")[:500],
             "platform": str(payload.get("platform") or "")[:100],
             "reported_at": datetime.now().timestamp(),
         }
 
         with self.lock:
-            previous_hevc_supported = self.hevc_supported
+            previous_force_avc = self._should_force_avc_locked()
+            previous_avc_quality_cap = self.avc_quality_cap
             self.hevc_supported = hevc_supported
+            self.avc_quality_cap = max_avc_quality or ""
             self.client_media_capabilities = next_capabilities
-            should_recache = previous_hevc_supported is not False and not hevc_supported
+            should_recache = (
+                self._should_force_avc_locked()
+                and (
+                    not previous_force_avc
+                    or previous_avc_quality_cap != self.avc_quality_cap
+                )
+            )
 
         if should_recache:
             self._request_desired_recaching("HEVC unsupported; switching video cache to AVC")
 
         return self.media_capabilities_snapshot()
+
+    @staticmethod
+    def _quality_from_choice_index(index: object) -> str | None:
+        try:
+            normalized_index = int(index)
+        except (TypeError, ValueError):
+            return None
+        if 0 <= normalized_index < len(VIDEO_QUALITY_CHOICES):
+            return VIDEO_QUALITY_CHOICES[normalized_index]
+        return None
+
+    @staticmethod
+    def _optional_video_quality(video_quality: object) -> str | None:
+        value = str(video_quality or "").strip()
+        if value in VIDEO_QUALITY_CHOICES:
+            return value
+        return None
 
     def enrich_snapshot(
         self,
@@ -1031,8 +1086,9 @@ class CacheManager:
             video_quality = self.video_quality
             audio_hires = self.audio_hires
             force_avc = self._should_force_avc_locked()
+            avc_quality_cap = self.avc_quality_cap if force_avc else ""
         if stream_kind == "video":
-            args = ["-q", self._video_quality_priority(video_quality)]
+            args = ["-q", self._video_quality_priority(video_quality, avc_quality_cap)]
             if force_avc:
                 args.extend(["-e", "avc"])
             return args
@@ -1077,9 +1133,12 @@ class CacheManager:
         self._terminate_process(active_process)
 
     @staticmethod
-    def _video_quality_priority(video_quality: object) -> str:
+    def _video_quality_priority(video_quality: object, quality_cap: object = "") -> str:
         normalized_quality = CacheManager._normalize_video_quality(video_quality)
         start_index = VIDEO_QUALITY_CHOICES.index(normalized_quality)
+        cap_quality = CacheManager._optional_video_quality(quality_cap)
+        if cap_quality:
+            start_index = max(start_index, VIDEO_QUALITY_CHOICES.index(cap_quality))
         return ",".join(VIDEO_QUALITY_CHOICES[start_index:])
 
     def _run_item_command(

--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -197,6 +197,11 @@ class AppContext:
         )
         self._notify_state_changed()
 
+    def set_client_media_capabilities(self, payload: dict[str, object]) -> dict[str, object]:
+        result = self.cache_manager.set_client_media_capabilities(payload)
+        self._notify_state_changed()
+        return result
+
     def retry_cache_item(self, item_id: str, *, force: bool = False) -> None:
         self.cache_manager.retry_item(item_id, force=force)
 
@@ -728,6 +733,10 @@ class BilikaraHandler(BaseHTTPRequestHandler):
             if route == "/api/client/disconnect":
                 CONTEXT.disconnect_client(str(body.get("client_id") or ""))
                 self._write_json({"ok": True})
+                return
+            if route == "/api/client/media-capabilities":
+                result = CONTEXT.set_client_media_capabilities(body)
+                self._write_json({"ok": True, "data": result})
                 return
             if route == "/api/bbdown/login/start":
                 CONTEXT.cache_manager.start_bbdown_login(force_refresh_qr=bool(body.get("force")))

--- a/static/app.js
+++ b/static/app.js
@@ -103,6 +103,8 @@ const state = {
   gatchaCooldownTimer: null,
   gatchaCookieVisible: false,
   bbdownLoginRequesting: false,
+  mediaCapabilitiesReported: false,
+  mediaCapabilitiesSignature: "",
   appToastTimer: null,
   layoutMode: "full",
 };
@@ -656,6 +658,45 @@ async function apiPost(url, payload = {}) {
     throw error;
   }
   return data.data;
+}
+
+const hevcCanPlayTypes = [
+  'video/mp4; codecs="hvc1.1.6.L93.B0"',
+  'video/mp4; codecs="hev1.1.6.L93.B0"',
+  'video/mp4; codecs="hvc1"',
+  'video/mp4; codecs="hev1"',
+];
+
+function detectMediaCapabilities() {
+  const video = document.createElement("video");
+  const canPlayType = {};
+  let hevcSupported = false;
+  for (const mimeType of hevcCanPlayTypes) {
+    const result = typeof video.canPlayType === "function"
+      ? video.canPlayType(mimeType)
+      : "";
+    canPlayType[mimeType] = result;
+    if (result === "probably" || result === "maybe") {
+      hevcSupported = true;
+    }
+  }
+  return {
+    hevc_supported: hevcSupported,
+    can_play_type: canPlayType,
+    user_agent: window.navigator?.userAgent || "",
+    platform: window.navigator?.platform || "",
+  };
+}
+
+async function reportMediaCapabilities() {
+  const capabilities = detectMediaCapabilities();
+  const signature = JSON.stringify(capabilities);
+  if (state.mediaCapabilitiesReported && state.mediaCapabilitiesSignature === signature) {
+    return;
+  }
+  await apiPost("/api/client/media-capabilities", capabilities);
+  state.mediaCapabilitiesReported = true;
+  state.mediaCapabilitiesSignature = signature;
 }
 
 async function fetchState() {
@@ -4753,6 +4794,11 @@ elements.saveCookieButton.addEventListener("click", async () => {
 async function startPolling() {
   hydrateLocalPreferences();
   renderLayoutMode();
+  try {
+    await reportMediaCapabilities();
+  } catch {
+    // Playback capability reporting should not block the host UI from loading.
+  }
   try {
     await fetchState();
   } catch (error) {

--- a/static/app.js
+++ b/static/app.js
@@ -667,6 +667,25 @@ const hevcCanPlayTypes = [
   'video/mp4; codecs="hev1"',
 ];
 
+const avcPlaybackLevels = [
+  { name: "High@L5.2", codec: 'video/mp4; codecs="avc1.640034"', maxAvcQualityIndex: 0 },
+  { name: "High@L5.1", codec: 'video/mp4; codecs="avc1.640033"', maxAvcQualityIndex: 0 },
+  { name: "High@L5.0", codec: 'video/mp4; codecs="avc1.640032"', maxAvcQualityIndex: 1 },
+  { name: "High@L4.2", codec: 'video/mp4; codecs="avc1.64002A"', maxAvcQualityIndex: 1 },
+  { name: "High@L4.1", codec: 'video/mp4; codecs="avc1.640029"', maxAvcQualityIndex: 2 },
+  { name: "Main@L4.1", codec: 'video/mp4; codecs="avc1.4D0029"', maxAvcQualityIndex: 2 },
+  { name: "High@L4.0", codec: 'video/mp4; codecs="avc1.640028"', maxAvcQualityIndex: 3 },
+  { name: "Main@L4.0", codec: 'video/mp4; codecs="avc1.4D0028"', maxAvcQualityIndex: 3 },
+  { name: "High@L3.2", codec: 'video/mp4; codecs="avc1.640020"', maxAvcQualityIndex: 3 },
+  { name: "Main@L3.2", codec: 'video/mp4; codecs="avc1.4D0020"', maxAvcQualityIndex: 3 },
+  { name: "High@L3.1", codec: 'video/mp4; codecs="avc1.64001F"', maxAvcQualityIndex: 4 },
+  { name: "Main@L3.1", codec: 'video/mp4; codecs="avc1.4D001F"', maxAvcQualityIndex: 4 },
+  { name: "Main@L3.0", codec: 'video/mp4; codecs="avc1.4D001E"', maxAvcQualityIndex: 5 },
+  { name: "Baseline@L3.0", codec: 'video/mp4; codecs="avc1.42E01E"', maxAvcQualityIndex: 5 },
+  { name: "Main@L2.1", codec: 'video/mp4; codecs="avc1.4D0015"', maxAvcQualityIndex: 6 },
+  { name: "Baseline@L2.1", codec: 'video/mp4; codecs="avc1.42E015"', maxAvcQualityIndex: 6 },
+];
+
 function detectMediaCapabilities() {
   const video = document.createElement("video");
   const canPlayType = {};
@@ -680,8 +699,28 @@ function detectMediaCapabilities() {
       hevcSupported = true;
     }
   }
+  let supportedAvcLevel = null;
+  const avcLevels = avcPlaybackLevels.map((level) => {
+    const result = typeof video.canPlayType === "function"
+      ? video.canPlayType(level.codec)
+      : "";
+    canPlayType[level.codec] = result;
+    const supported = result === "probably" || result === "maybe";
+    if (!supportedAvcLevel && supported) {
+      supportedAvcLevel = level;
+    }
+    return {
+      name: level.name,
+      codec: level.codec,
+      can_play_type: result,
+      max_avc_quality_index: level.maxAvcQualityIndex,
+    };
+  });
   return {
     hevc_supported: hevcSupported,
+    avc_supported: Boolean(supportedAvcLevel),
+    max_avc_quality_index: supportedAvcLevel ? supportedAvcLevel.maxAvcQualityIndex : 6,
+    avc_levels: avcLevels,
     can_play_type: canPlayType,
     user_agent: window.navigator?.userAgent || "",
     platform: window.navigator?.platform || "",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,7 +7,7 @@ from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from bilikara.cache import CacheManager, DownloadCommandError
+from bilikara.cache import CacheManager, DownloadCommandError, VIDEO_QUALITY_CHOICES
 from bilikara.models import PlaylistItem
 from bilikara.store import PlaylistStore
 
@@ -151,17 +151,52 @@ class CacheManagerPolicyTest(unittest.TestCase):
                 snapshot = manager.set_client_media_capabilities(
                     {
                         "hevc_supported": False,
+                        "avc_supported": True,
+                        "max_avc_quality_index": 4,
                         "can_play_type": {'video/mp4; codecs="hvc1"': ""},
                         "user_agent": "Firefox on Windows 7",
                         "platform": "Win32",
                     }
                 )
                 self.assertTrue(snapshot["force_avc"])
+                self.assertEqual(snapshot["max_avc_quality"], VIDEO_QUALITY_CHOICES[4])
                 self.assertEqual(
-                    manager._bbdown_stream_preference_args("video")[-2:],
-                    ["-e", "avc"],
+                    manager._bbdown_stream_preference_args("video"),
+                    ["-q", ",".join(VIDEO_QUALITY_CHOICES[4:]), "-e", "avc"],
                 )
                 self.assertEqual(manager._bbdown_stream_preference_args("audio"), [])
+            finally:
+                manager.shutdown()
+
+    def test_avc_quality_cap_does_not_raise_lower_manual_quality(self):
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir):
+            manager = CacheManager(self.store, max_cache_items=3)
+            try:
+                manager.set_cache_policy(video_quality=VIDEO_QUALITY_CHOICES[5])
+                manager.set_client_media_capabilities(
+                    {
+                        "hevc_supported": False,
+                        "avc_supported": True,
+                        "max_avc_quality_index": 4,
+                    }
+                )
+                self.assertEqual(
+                    manager._bbdown_stream_preference_args("video"),
+                    ["-q", ",".join(VIDEO_QUALITY_CHOICES[5:]), "-e", "avc"],
+                )
+            finally:
+                manager.shutdown()
+
+    def test_hevc_unsupported_without_avc_level_falls_back_to_lowest_quality(self):
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir):
+            manager = CacheManager(self.store, max_cache_items=3)
+            try:
+                snapshot = manager.set_client_media_capabilities({"hevc_supported": False})
+                self.assertEqual(snapshot["max_avc_quality"], VIDEO_QUALITY_CHOICES[-1])
+                self.assertEqual(
+                    manager._bbdown_stream_preference_args("video"),
+                    ["-q", VIDEO_QUALITY_CHOICES[-1], "-e", "avc"],
+                )
             finally:
                 manager.shutdown()
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -144,6 +144,64 @@ class CacheManagerPolicyTest(unittest.TestCase):
             finally:
                 manager.shutdown()
 
+    def test_bbdown_stream_preference_args_force_avc_when_hevc_unsupported(self):
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir):
+            manager = CacheManager(self.store, max_cache_items=3)
+            try:
+                snapshot = manager.set_client_media_capabilities(
+                    {
+                        "hevc_supported": False,
+                        "can_play_type": {'video/mp4; codecs="hvc1"': ""},
+                        "user_agent": "Firefox on Windows 7",
+                        "platform": "Win32",
+                    }
+                )
+                self.assertTrue(snapshot["force_avc"])
+                self.assertEqual(
+                    manager._bbdown_stream_preference_args("video")[-2:],
+                    ["-e", "avc"],
+                )
+                self.assertEqual(manager._bbdown_stream_preference_args("audio"), [])
+            finally:
+                manager.shutdown()
+
+    def test_hevc_unsupported_requeues_desired_ready_items_for_avc(self):
+        item_dir = self.cache_dir / "song-a"
+        video_file = item_dir / "video-p1" / "video.mp4"
+        video_file.parent.mkdir(parents=True, exist_ok=True)
+        video_file.write_bytes(b"media")
+
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir):
+            manager = CacheManager(self.store, max_cache_items=3)
+            try:
+                item = self.make_item("song-a")
+                self.store.add_item(item, requester_name="cache-test-user")
+                self.store.update_item(
+                    "song-a",
+                    cache_status="ready",
+                    cache_progress=100.0,
+                    cache_message="ready",
+                    video_relative_path="song-a/video-p1/video.mp4",
+                    video_media_url="/media/song-a/video-p1/video.mp4",
+                    audio_variants=[{"id": "p1", "audio_url": "/media/song-a/audio-p1/audio.m4a"}],
+                    selected_audio_variant_id="p1",
+                    persist_backup=False,
+                )
+                with manager.lock:
+                    manager.desired_ids = {"song-a"}
+                with patch.object(manager, "enqueue") as enqueue_mock:
+                    manager.set_client_media_capabilities({"hevc_supported": False})
+
+                refreshed = self.store.get_item("song-a")
+                self.assertIsNotNone(refreshed)
+                self.assertEqual(refreshed.cache_status, "pending")
+                self.assertEqual(refreshed.video_media_url, "")
+                self.assertEqual(refreshed.audio_variants, [])
+                self.assertFalse(item_dir.exists())
+                enqueue_mock.assert_called_once_with("song-a")
+            finally:
+                manager.shutdown()
+
     def test_hidden_process_kwargs_hides_windows_console(self):
         with patch("bilikara.cache.os.name", "nt"):
             kwargs = CacheManager._hidden_process_kwargs()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -166,6 +166,30 @@ class PlayerResetRouteTest(unittest.TestCase):
         self.assertEqual(writes[1], {"ok": True, "data": {"playback_mode": "local"}})
 
 
+class ClientMediaCapabilitiesRouteTest(unittest.TestCase):
+    def test_client_media_capabilities_route_returns_cache_manager_result(self):
+        handler = BilikaraHandler.__new__(BilikaraHandler)
+        writes: list[dict] = []
+        payload = {"hevc_supported": False}
+        context = SimpleNamespace(
+            touch_client=lambda client_id, is_host=True: None,
+            set_client_media_capabilities=lambda body: {
+                "hevc_supported": body["hevc_supported"],
+                "force_avc": not body["hevc_supported"],
+            },
+        )
+
+        handler.path = "/api/client/media-capabilities"
+        handler.headers = {}
+        handler._read_json_body = lambda: payload
+        handler._write_json = lambda response, status=None: writes.append(response)
+
+        with patch("bilikara.server.CONTEXT", context):
+            handler.do_POST()
+
+        self.assertEqual(writes, [{"ok": True, "data": {"hevc_supported": False, "force_avc": True}}])
+
+
 class PlaylistResortRouteTest(unittest.TestCase):
     def test_playlist_resort_route_returns_fresh_snapshot(self):
         handler = BilikaraHandler.__new__(BilikaraHandler)


### PR DESCRIPTION
## 中文：
增加 HEVC 兼容性检测与 AVC 清晰度降档回退

## 描述:

本 PR 包含两部分热修：
#### 1. 增加 HEVC / H.265 兼容性检测与 AVC 回退
前端启动时通过 HTMLMediaElement.canPlayType() 检测当前浏览器/系统是否支持 HEVC/H.265。
   - 如果不支持 HEVC，会把检测结果上报给后端。
   - 后端随后强制 BBDown 使用 `-e avc` 下载 H.264/AVC 编码版本，提升 Win7、Firefox 等环境的播放兼容性。
   - 当前缓存窗口内已有缓存或正在下载的任务会重新排队，避免继续使用已下载的 HEVC 文件。
#### 2. 增加 AVC / H.264 profile-level 检测与清晰度封顶
在 HEVC 不支持并切到 AVC 后，进一步检测浏览器对不同 AVC/H.264 profile-level 的支持情况。
   - 探测范围包含 High/Main/Baseline 多个 level，例如 High@L5.2、High@L5.1、High@L5.0、High@L4.1、Main@L3.1、Baseline@L3.0 等。
   - 根据最高可支持的 AVC level，自动封顶 BBDown 的默认清晰度优先级。
   - 例如较弱环境会从 1080P60 / 1080P 高码率降到 720P、480P 或 360P，避免下载到浏览器仍无法解码的视频。
   - 如果用户手动选择了更低清晰度，不会被自动抬高。

### 已做验证
- `python -m unittest tests.test_cache tests.test_server`
- `python -m py_compile bilikara\cache.py bilikara\server.py`

注意：
由于我手头没有 Win7 / 旧版 Firefox / 对应硬件解码环境，无法实际验证这些设备上的播放可用性。请有相关设备的同学协助验证：
- Win7 + Firefox 是否会正确上报 HEVC 不支持；
- BBDown 命令是否带上 `-e avc`；
- 下载后的 AVC 文件是否能正常播放；
- 不同 AVC level 下是否会按预期降低清晰度。

## English:
Add HEVC compatibility detection and AVC quality fallback

## Descrpition:

This PR includes two hotfixes:
#### 1. Add HEVC / H.265 compatibility detection and AVC fallback
The frontend now uses HTMLMediaElement.canPlayType() on startup to detect whether the current browser/system supports HEVC/H.265.
   - If HEVC is unsupported, the result is reported to the backend.
   - The backend then forces BBDown to use `-e avc`, downloading the H.264/AVC version for better compatibility on environments such as Windows 7 and Firefox.
   - Existing cached or in-progress items in the cache window are requeued so the app does not keep using previously downloaded HEVC files.
   - 
#### 2. Add AVC / H.264 profile-level probing and quality capping
When HEVC is unsupported and AVC fallback is enabled, the frontend also probes browser support for AVC/H.264 profile-level combinations.
   - The probing list covers multiple High/Main/Baseline levels, such as High@L5.2, High@L5.1, High@L5.0, High@L4.1, Main@L3.1, Baseline@L3.0, and others.
   - Based on the highest supported AVC level, the backend caps BBDown's default video quality priority.
   - Weaker environments may automatically fall back from 1080P60 / high-bitrate 1080P to 720P, 480P, or 360P to avoid downloading videos the browser still cannot decode.
   - If the user manually selects an even lower quality, the app will not raise it.

Validation performed:
- `python -m unittest tests.test_cache tests.test_server`
- `python -m py_compile bilikara\cache.py bilikara\server.py`

### Note:
I could not verify actual playback on Windows 7, older Firefox, or the relevant hardware decoding environments due to device limitations. Please help validate on real target devices:
- Whether Windows 7 + Firefox correctly reports HEVC as unsupported;
- Whether BBDown receives `-e avc`;
- Whether the downloaded AVC file plays correctly;
- Whether quality is capped as expected for different AVC profile-level support.
EOF
