### PR TITLE
chore:Cloudflare-first bilikara search and submission pipeline with resilient tagging sync(基于 Cloudflare 优先的 bilikara 搜索、投稿入库与标签同步流程)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build/
 dist/
 .vscode/
 APP_VERSION
+.tmp/
+bilikara-api/

--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -40,6 +40,7 @@ _GATCHA_PROFILE_CACHE_LOCK = threading.Lock()
 _GATCHA_CACHE_LOCK = threading.Lock()
 _GATCHA_UIDS_LOCK = threading.Lock()
 _GATCHA_REFRESH_LOCK = threading.Lock()
+_GATCHA_TASK_STATUS_LOCK = threading.Lock()
 _GATCHA_REQUEST_LOCK = threading.Lock()
 _GATCHA_LAST_REQUEST_AT = 0.0
 _GATCHA_CACHE_FILE = cfg.DATA_DIR / "gatcha_cache.json"
@@ -56,6 +57,13 @@ GATCHA_FAVLIST_RETRY_DELAY_SECONDS = 3
 GATCHA_PROFILE_CACHE_TTL_SECONDS = 300
 GATCHA_TASK_BUSY_MESSAGE = "拉取任务执行中，请等待任务结束"
 MISSING_BILIBILI_COOKIE_MESSAGE = "请登录 Bilibili 账号或输入 Cookie"
+_GATCHA_TASK_STATUS = {
+    "status": "idle",
+    "message": "",
+    "error": "",
+    "updated_at": 0.0,
+    "result": None,
+}
 _COOKIE_REQUIRED_KEYS = {"sessdata", "bili_jct"}
 _COOKIE_PREFERRED_ORDER = (
     "SESSDATA",
@@ -203,10 +211,37 @@ def _save_gatcha_uid_payload(uid_payload: dict) -> None:
     temp_path.replace(_GATCHA_UIDS_FILE)
 
 
+def _set_gatcha_task_status(
+    status: str,
+    *,
+    message: str = "",
+    error: str = "",
+    result: dict | None = None,
+) -> None:
+    with _GATCHA_TASK_STATUS_LOCK:
+        _GATCHA_TASK_STATUS.update(
+            {
+                "status": status,
+                "message": message,
+                "error": error,
+                "updated_at": time.time(),
+                "result": result,
+            }
+        )
+
+
 def gatcha_task_snapshot() -> dict:
+    busy = _GATCHA_REFRESH_LOCK.locked()
+    with _GATCHA_TASK_STATUS_LOCK:
+        last_status = dict(_GATCHA_TASK_STATUS)
     return {
-        "busy": _GATCHA_REFRESH_LOCK.locked(),
-        "message": GATCHA_TASK_BUSY_MESSAGE if _GATCHA_REFRESH_LOCK.locked() else "",
+        "busy": busy,
+        "message": GATCHA_TASK_BUSY_MESSAGE if busy else "",
+        "last_status": last_status.get("status") or "idle",
+        "last_message": last_status.get("message") or "",
+        "last_error": last_status.get("error") or "",
+        "last_updated_at": last_status.get("updated_at") or 0.0,
+        "last_result": last_status.get("result"),
     }
 
 
@@ -1066,6 +1101,38 @@ def _refresh_gatcha_uid_cache(cache_payload: dict, mid: str, *, force_full: bool
     }
 
 
+def _gatcha_refresh_task_result(cache_payload: dict | None) -> dict:
+    if not isinstance(cache_payload, dict):
+        return {"uid_count": 0, "entry_count": 0, "errors": []}
+    uids = cache_payload.get("uids")
+    entry_count = 0
+    uid_count = 0
+    if isinstance(uids, dict):
+        uid_count = len(uids)
+        for entries in uids.values():
+            if isinstance(entries, list):
+                entry_count += len(entries)
+    summary = cache_payload.get("refresh_summary")
+    errors = []
+    uid_results = []
+    favlist_error = ""
+    if isinstance(summary, dict):
+        raw_errors = summary.get("errors")
+        if isinstance(raw_errors, list):
+            errors = [error for error in raw_errors if isinstance(error, dict)]
+        raw_results = summary.get("uids")
+        if isinstance(raw_results, list):
+            uid_results = [result for result in raw_results if isinstance(result, dict)]
+        favlist_error = str(summary.get("favlist_error") or "")
+    return {
+        "uid_count": uid_count,
+        "entry_count": entry_count,
+        "uid_results": uid_results,
+        "errors": errors,
+        "favlist_error": favlist_error,
+    }
+
+
 def refresh_gatcha_cache() -> dict:
     if not effective_bilibili_cookie():
         raise BilibiliError(MISSING_BILIBILI_COOKIE_MESSAGE)
@@ -1091,20 +1158,30 @@ def refresh_gatcha_cache() -> dict:
         cache_profiles = {}
     cache_payload["profiles"] = cache_profiles
 
+    refresh_summary = {
+        "uids": [],
+        "errors": [],
+        "favlist_error": "",
+        "updated_at": time.time(),
+    }
     cache_payload["updated_at"] = time.time()
     for raw_mid in configured_uids:
         mid = str(raw_mid).strip()
         if not mid:
             continue
-        profile = _resolve_gatcha_uid_profile(mid, known_profiles)
-        if profile is not None:
-            cache_profiles[str(profile["uid"])] = profile
-            known_profiles[str(profile["uid"])] = profile
-        _refresh_gatcha_uid_cache(cache_payload, mid)
+        try:
+            profile = _resolve_gatcha_uid_profile(mid, known_profiles)
+            if profile is not None:
+                cache_profiles[str(profile["uid"])] = profile
+                known_profiles[str(profile["uid"])] = profile
+            refresh_summary["uids"].append(_refresh_gatcha_uid_cache(cache_payload, mid))
+        except Exception as exc:
+            refresh_summary["errors"].append({"uid": mid, "error": str(exc)})
     try:
         _refresh_existing_gatcha_favlist_cache()
-    except Exception:
-        pass
+    except Exception as exc:
+        refresh_summary["favlist_error"] = str(exc)
+    cache_payload["refresh_summary"] = refresh_summary
     return cache_payload
 
 
@@ -1118,8 +1195,11 @@ def refresh_gatcha_cache_in_background(
     if use_global_lock:
         if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
             return False
+        _set_gatcha_task_status("running", message=GATCHA_TASK_BUSY_MESSAGE)
         if on_start is not None:
             on_start()
+    else:
+        _set_gatcha_task_status("running", message=GATCHA_TASK_BUSY_MESSAGE)
 
     cached_default_uids_before_refresh: set[str] = set()
     if not upload_default_uids_to_lark:
@@ -1136,16 +1216,31 @@ def refresh_gatcha_cache_in_background(
 
     def _worker() -> None:
         cache_payload: dict | None = None
+        task_status = "failed"
         try:
             cache_payload = refresh_gatcha_cache()
-        except Exception:
+            result = _gatcha_refresh_task_result(cache_payload)
+            has_errors = bool(result.get("errors") or result.get("favlist_error"))
+            has_uid_success = bool(result.get("uid_results"))
+            if has_errors and not has_uid_success:
+                task_status = "failed"
+                message = "抽卡缓存更新失败，未成功拉取任何 UID。"
+            elif has_errors:
+                task_status = "partial"
+                message = "抽卡缓存已部分更新，但有 UID 或收藏夹拉取失败。"
+            else:
+                task_status = "success"
+                message = "抽卡缓存更新完成。"
+            _set_gatcha_task_status(task_status, message=message, result=result)
+        except Exception as exc:
+            _set_gatcha_task_status("failed", message="抽卡缓存更新失败。", error=str(exc))
             return
         finally:
             if use_global_lock:
                 _GATCHA_REFRESH_LOCK.release()
                 if on_done is not None:
                     on_done()
-        if cache_payload is not None:
+        if cache_payload is not None and task_status != "failed":
             excluded_uids = set()
             if not upload_default_uids_to_lark:
                 excluded_uids = set(_default_gatcha_uids()) - cached_default_uids_before_refresh

--- a/bilikara/config.py
+++ b/bilikara/config.py
@@ -235,7 +235,7 @@ FFMPEG_BUNDLED_PATH = VENDOR_DIR / ("ffmpeg.exe" if os.name == "nt" else "ffmpeg
 FFPROBE_BUNDLED_PATH = VENDOR_DIR / ("ffprobe.exe" if os.name == "nt" else "ffprobe")
 BB_DOWN_VERSION_FILE = BB_DOWN_DIR / "VERSION"
 GATCHA_UIDS = ["3145040", "671767", "33091201", "3494356589742209", "44627483", "8474818", "10077309", "74089392", "1879151", "87101327", "99061404", "602998", "1159885664", "215040", "31624333", "21129450", "2625848", "29955371", "3014315", "80148988", "464873", "41924655", "356716", "174980119", "1326466", "13775191", "524220885"]
-GATCHA_KEYWORDS = ["卡拉", "カラ", "投屏","KTV","纯K","纯k","kara","Kara"]
+GATCHA_KEYWORDS = ["卡拉", "カラ", "投屏","KTV","纯K","纯k","kara","Kara","karaoke","Karaoke"]
 USER_VIDEO_API = "https://api.bilibili.com/x/space/wbi/arc/search?mid={mid}&ps=50&tid=0&pn=1&order=pubdate"
 
 HOST = _default_host()

--- a/bilikara/config.py
+++ b/bilikara/config.py
@@ -235,7 +235,7 @@ FFMPEG_BUNDLED_PATH = VENDOR_DIR / ("ffmpeg.exe" if os.name == "nt" else "ffmpeg
 FFPROBE_BUNDLED_PATH = VENDOR_DIR / ("ffprobe.exe" if os.name == "nt" else "ffprobe")
 BB_DOWN_VERSION_FILE = BB_DOWN_DIR / "VERSION"
 GATCHA_UIDS = ["3145040", "671767", "33091201", "3494356589742209", "44627483", "8474818", "10077309", "74089392", "1879151", "87101327", "99061404", "602998", "1159885664", "215040", "31624333", "21129450", "2625848", "29955371", "3014315", "80148988", "464873", "41924655", "356716", "174980119", "1326466", "13775191", "524220885"]
-GATCHA_KEYWORDS = ["卡拉", "カラ", "投屏","KTV","纯K","纯k","kara","Kara","karaoke","Karaoke"]
+GATCHA_KEYWORDS = ["卡拉", "カラ", "投屏","KTV","纯K","纯k","kara","Kara","karaoke","Karaoke","vocal","Vocal","伴奏"]
 USER_VIDEO_API = "https://api.bilibili.com/x/space/wbi/arc/search?mid={mid}&ps=50&tid=0&pn=1&order=pubdate"
 
 HOST = _default_host()

--- a/bilikara/lark_pool_client.py
+++ b/bilikara/lark_pool_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 import threading
 import time
@@ -44,6 +45,7 @@ _WRITE_FIELD_NAMES = _REQUIRED_FIELD_NAMES | _OPTIONAL_FIELD_NAMES
 _REQUIRED_SEARCH_FIELDS = {"bvid", "title", "url"}
 _DEBUG_LOGS = str(os.environ.get("BILIKARA_LARK_DEBUG") or "").strip().lower() in {"1", "true", "yes", "on"}
 _INVALID_VIDEO_TITLES = {"已失效视频"}
+_VALID_BVID_RE = re.compile(r"^BV[0-9A-Za-z]{10}$")
 
 
 class LarkPoolError(RuntimeError):
@@ -615,6 +617,8 @@ def normalize_pool_entry(entry: dict) -> dict | None:
     title = str(entry.get("title") or "").strip()
     url = str(entry.get("url") or "").strip()
     if title in _INVALID_VIDEO_TITLES:
+        return None
+    if not _VALID_BVID_RE.match(bvid):
         return None
     if not url and bvid:
         url = f"https://www.bilibili.com/video/{bvid}"

--- a/bilikara/lark_pool_client.py
+++ b/bilikara/lark_pool_client.py
@@ -36,6 +36,7 @@ _TABLES_LOCK = threading.RLock()
 _TABLES_READY = False
 _ACTIVE_TABLES: list[dict[str, Any]] = []
 _TABLE_PROBED: set[int] = set()
+_FIELD_TYPES_BY_TABLE: dict[tuple[str, str], dict[str, Any]] = {}
 _SYNC_LOCK = threading.RLock()
 _REQUIRED_FIELD_NAMES = {"mid", "bvid", "title", "url", "owner_name", "owner_url"}
 _OPTIONAL_FIELD_NAMES = {"tag_1", "tag_2", "tag_3", "tag_4", "tag_5", "tag_status"}
@@ -199,12 +200,19 @@ def _table_field_names(token: str, app_token: str, table_id: str) -> set[str]:
         "table field probe failed",
     )
     names: set[str] = set()
+    field_types: dict[str, Any] = {}
     for item in data.get("items") or []:
         if not isinstance(item, dict):
             continue
         field_name = str(item.get("field_name") or item.get("name") or "").strip()
         if field_name:
             names.add(field_name)
+            field_type = item.get("type")
+            if field_type is None:
+                field_type = item.get("field_type")
+            if field_type is not None:
+                field_types[field_name] = field_type
+    _FIELD_TYPES_BY_TABLE[(app_token, table_id)] = field_types
     return names
 
 
@@ -227,6 +235,7 @@ def _table_payload(index: int, app_token: str, table_id: str, field_names: set[s
         "table_id": table_id,
         "count": count,
         "field_names": sorted(field_names),
+        "field_types": dict(_FIELD_TYPES_BY_TABLE.get((app_token, table_id), {})),
         "search_enabled": index == 1 or count > 0,
     }
 
@@ -356,6 +365,7 @@ def _bump_table_count(index: int, delta: int) -> None:
                     "table_id": table_id,
                     "count": int(delta),
                     "field_names": sorted(_WRITE_FIELD_NAMES),
+                    "field_types": {},
                     "search_enabled": True,
                 }
             )
@@ -443,7 +453,7 @@ def _search_lark_pool_table(
     return results
 
 
-def search_lark_pool_table(query: str, table_index: int, *, limit: int = 30) -> list[dict]:
+def search_lark_pool_table(query: str, table_index: int, *, limit: int = 80) -> list[dict]:
     normalized_query = str(query or "").strip()
     if not normalized_query:
         return []
@@ -505,7 +515,7 @@ def _cloudflare_search_items(payload: Any) -> list[Any]:
     return []
 
 
-def _search_cloudflare_pool(query: str, *, limit: int = 30) -> list[dict] | None:
+def _search_cloudflare_pool(query: str, *, limit: int = 80) -> list[dict] | None:
     normalized_query = str(query or "").strip()
     if not normalized_query:
         return []
@@ -541,7 +551,7 @@ def _search_cloudflare_pool(query: str, *, limit: int = 30) -> list[dict] | None
     return results
 
 
-def _search_lark_pool_legacy(query: str, *, limit: int = 30) -> list[dict]:
+def _search_lark_pool_legacy(query: str, *, limit: int = 80) -> list[dict]:
     normalized_query = str(query or "").strip()
     if not normalized_query:
         return []
@@ -558,7 +568,7 @@ def _search_lark_pool_legacy(query: str, *, limit: int = 30) -> list[dict]:
     return results
 
 
-def search_lark_pool(query: str, *, limit: int = 30) -> list[dict]:
+def search_lark_pool(query: str, *, limit: int = 80) -> list[dict]:
     normalized_query = str(query or "").strip()
     if not normalized_query:
         return []
@@ -657,6 +667,37 @@ def append_cloudflare_pool_entries(entries: list[dict]) -> dict:
     }
 
 
+def _is_number_field_type(field_type: Any) -> bool:
+    return str(field_type).strip().lower() in {"2", "number"}
+
+
+def _coerce_feishu_field_value(field_name: str, value: Any, field_type: Any = None) -> Any:
+    if value is None:
+        return None
+    text = str(value).strip() if not isinstance(value, (int, float)) else value
+    if text == "":
+        return None
+    if _is_number_field_type(field_type):
+        try:
+            number = float(text)
+        except (TypeError, ValueError):
+            return None
+        return int(number) if number.is_integer() else number
+    return value
+
+
+def _feishu_record_fields(entry: dict[str, Any], field_names: set[str], field_types: dict[str, Any]) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    for key, value in entry.items():
+        if key not in field_names:
+            continue
+        coerced = _coerce_feishu_field_value(key, value, field_types.get(key))
+        if coerced is None:
+            continue
+        fields[key] = coerced
+    return fields
+
+
 def append_lark_pool_entries_to_lark(
     entries: list[dict],
     *,
@@ -686,10 +727,11 @@ def append_lark_pool_entries_to_lark(
             if capacity <= 0:
                 continue
             field_names = set(table.get("field_names") or _WRITE_FIELD_NAMES)
+            field_types = table.get("field_types") if isinstance(table.get("field_types"), dict) else {}
             while cursor < len(pending) and capacity > 0:
                 chunk = pending[cursor : cursor + min(_APPEND_CHUNK_SIZE, capacity)]
                 records = [
-                    {"fields": {key: value for key, value in entry.items() if key in field_names}}
+                    {"fields": _feishu_record_fields(entry, field_names, field_types)}
                     for entry in chunk
                 ]
                 _log_lark_request("bilikara pool append", {"records": records})

--- a/bilikara/lark_pool_client.py
+++ b/bilikara/lark_pool_client.py
@@ -24,6 +24,8 @@ BITABLE_TABLES = (
 )
 
 _BASE_URL = "https://open.feishu.cn/open-apis"
+_CLOUDFLARE_API_URL = (os.environ.get("BILIKARA_CF_API_URL") or "https://api.kevinx96.icu").rstrip("/")
+_CLOUDFLARE_SEARCH_TIMEOUT = float(os.environ.get("BILIKARA_CF_SEARCH_TIMEOUT") or "2.0")
 _TABLE_LIMIT = 20_000
 _APPEND_CHUNK_SIZE = 400
 _SYNC_FILE = cfg.DATA_DIR / "lark_pool_sync.json"
@@ -36,8 +38,10 @@ _ACTIVE_TABLES: list[dict[str, Any]] = []
 _TABLE_PROBED: set[int] = set()
 _SYNC_LOCK = threading.RLock()
 _REQUIRED_FIELD_NAMES = {"mid", "bvid", "title", "url", "owner_name", "owner_url"}
+_OPTIONAL_FIELD_NAMES = {"tag_1", "tag_2", "tag_3", "tag_4", "tag_5", "tag_status"}
+_WRITE_FIELD_NAMES = _REQUIRED_FIELD_NAMES | _OPTIONAL_FIELD_NAMES
 _REQUIRED_SEARCH_FIELDS = {"bvid", "title", "url"}
-_DEBUG_LOGS = False
+_DEBUG_LOGS = str(os.environ.get("BILIKARA_LARK_DEBUG") or "").strip().lower() in {"1", "true", "yes", "on"}
 _INVALID_VIDEO_TITLES = {"已失效视频"}
 
 
@@ -69,6 +73,55 @@ def _get_json(url: str, *, token: str, timeout: float = 12.0) -> dict:
             return json.loads(response.read().decode("utf-8"))
     except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
         raise LarkPoolError(f"Lark request failed: {exc}") from exc
+
+
+def _cloudflare_json(method: str, path: str, payload: dict[str, Any] | None = None, *, timeout: float = 12.0) -> Any:
+    url = f"{_CLOUDFLARE_API_URL}{path}"
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": f"bilikara/{getattr(cfg, 'APP_VERSION', 'dev')} (+https://github.com/VZRXS/bilikara)",
+    }
+    data = None
+    if payload is not None:
+        headers["Content-Type"] = "application/json; charset=utf-8"
+        data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(url, data=data, headers=headers, method=method.upper())
+    _log_lark_debug(
+        "cloudflare request",
+        {"method": method.upper(), "url": url, "timeout": timeout, "payload_keys": sorted((payload or {}).keys())},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw_body = response.read().decode("utf-8")
+            parsed = json.loads(raw_body)
+            _log_lark_debug(
+                "cloudflare response",
+                {
+                    "status": getattr(response, "status", None),
+                    "url": url,
+                    "shape": type(parsed).__name__,
+                    "preview": raw_body[:500],
+                },
+            )
+            return parsed
+    except urllib.error.HTTPError as exc:
+        try:
+            error_body = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            error_body = ""
+        _log_lark_debug(
+            "cloudflare request failed",
+            {
+                "url": url,
+                "status": exc.code,
+                "error": str(exc),
+                "body": error_body[:1000],
+            },
+        )
+        raise LarkPoolError(f"Cloudflare request failed: {exc}") from exc
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        _log_lark_debug("cloudflare request failed", {"url": url, "error": str(exc)})
+        raise LarkPoolError(f"Cloudflare request failed: {exc}") from exc
 
 
 def _require_success(payload: dict, label: str) -> dict:
@@ -106,6 +159,8 @@ def _log_lark_debug(label: str, payload: dict[str, Any]) -> None:
 
 def _tenant_access_token() -> str:
     global _TOKEN_VALUE, _TOKEN_EXPIRES_AT
+    if not APP_SECRET:
+        raise LarkPoolError("BILIKARA_LARK_APP_SECRET is required for direct Feishu access")
     now = time.time()
     with _TOKEN_LOCK:
         if _TOKEN_VALUE and now < _TOKEN_EXPIRES_AT - 60:
@@ -300,7 +355,7 @@ def _bump_table_count(index: int, delta: int) -> None:
                     "app_token": app_token,
                     "table_id": table_id,
                     "count": int(delta),
-                    "field_names": sorted(_REQUIRED_FIELD_NAMES),
+                    "field_names": sorted(_WRITE_FIELD_NAMES),
                     "search_enabled": True,
                 }
             )
@@ -396,6 +451,12 @@ def search_lark_pool_table(query: str, table_index: int, *, limit: int = 30) -> 
         normalized_index = int(table_index)
     except (TypeError, ValueError):
         return []
+    if not APP_SECRET:
+        _log_lark_debug(
+            "table search skipped without feishu secret",
+            {"table": normalized_index, "query": normalized_query},
+        )
+        return []
     table = _active_table(normalized_index)
     if table is None:
         return []
@@ -403,7 +464,84 @@ def search_lark_pool_table(query: str, table_index: int, *, limit: int = 30) -> 
     return _search_lark_pool_table(normalized_query, table, token=token, limit=limit)
 
 
-def search_lark_pool(query: str, *, limit: int = 30) -> list[dict]:
+def _cloudflare_search_item(raw_item: Any) -> dict | None:
+    if not isinstance(raw_item, dict):
+        return None
+    bvid = _field_text(raw_item.get("bvid")).strip()
+    title = _field_text(raw_item.get("title")).strip()
+    url = _field_text(raw_item.get("url")).strip()
+    if not url and bvid:
+        url = f"https://www.bilibili.com/video/{bvid}"
+    if not bvid or not title or not url:
+        return None
+    return {
+        "mid": _field_text(raw_item.get("mid")).strip(),
+        "bvid": bvid,
+        "title": title,
+        "url": url,
+        "owner_name": _field_text(raw_item.get("owner_name")).strip(),
+        "owner_url": _field_text(raw_item.get("owner_url")).strip(),
+        "source": "cloudflare",
+    }
+
+
+def _cloudflare_search_items(payload: Any) -> list[Any]:
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, dict):
+        return []
+    for key in ("items", "results"):
+        items = payload.get(key)
+        if isinstance(items, list):
+            return items
+    data = payload.get("data")
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ("items", "results"):
+            items = data.get(key)
+            if isinstance(items, list):
+                return items
+    return []
+
+
+def _search_cloudflare_pool(query: str, *, limit: int = 30) -> list[dict] | None:
+    normalized_query = str(query or "").strip()
+    if not normalized_query:
+        return []
+    query_string = urllib.parse.urlencode({"keyword": normalized_query, "limit": max(1, int(limit))})
+    try:
+        payload = _cloudflare_json(
+            "GET",
+            f"/search?{query_string}",
+            timeout=_CLOUDFLARE_SEARCH_TIMEOUT,
+        )
+    except LarkPoolError:
+        return None
+    results: list[dict] = []
+    seen_bvids: set[str] = set()
+    raw_items = _cloudflare_search_items(payload)
+    for raw_item in raw_items:
+        item = _cloudflare_search_item(raw_item)
+        if not item or item["bvid"] in seen_bvids:
+            continue
+        seen_bvids.add(item["bvid"])
+        results.append(item)
+        if len(results) >= max(1, int(limit)):
+            break
+    _log_lark_debug(
+        "cloudflare search parsed",
+        {
+            "query": normalized_query,
+            "raw_count": len(raw_items),
+            "result_count": len(results),
+            "sample_bvids": [item.get("bvid") for item in results[:5]],
+        },
+    )
+    return results
+
+
+def _search_lark_pool_legacy(query: str, *, limit: int = 30) -> list[dict]:
     normalized_query = str(query or "").strip()
     if not normalized_query:
         return []
@@ -420,6 +558,22 @@ def search_lark_pool(query: str, *, limit: int = 30) -> list[dict]:
     return results
 
 
+def search_lark_pool(query: str, *, limit: int = 30) -> list[dict]:
+    normalized_query = str(query or "").strip()
+    if not normalized_query:
+        return []
+    if _CLOUDFLARE_API_URL:
+        cloudflare_results = _search_cloudflare_pool(normalized_query, limit=limit)
+        if cloudflare_results is not None:
+            _log_lark_debug(
+                "search served by cloudflare",
+                {"query": normalized_query, "count": len(cloudflare_results)},
+            )
+            return cloudflare_results
+        _log_lark_debug("search falling back to feishu tables", {"query": normalized_query})
+    return _search_lark_pool_legacy(normalized_query, limit=limit)
+
+
 def _load_synced_bvids() -> set[str]:
     try:
         payload = json.loads(_SYNC_FILE.read_text(encoding="utf-8"))
@@ -434,7 +588,14 @@ def _save_synced_bvids(bvids: set[str]) -> None:
     payload = {"schema_version": 1, "bvids": sorted(bvids), "updated_at": time.time()}
     temp_path = Path(str(_SYNC_FILE) + ".tmp")
     temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    temp_path.replace(_SYNC_FILE)
+    try:
+        temp_path.replace(_SYNC_FILE)
+    except PermissionError:
+        _SYNC_FILE.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        try:
+            temp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def normalize_pool_entry(entry: dict) -> dict | None:
@@ -449,7 +610,7 @@ def normalize_pool_entry(entry: dict) -> dict | None:
         url = f"https://www.bilibili.com/video/{bvid}"
     if not bvid or not title or not url:
         return None
-    return {
+    normalized = {
         "mid": str(entry.get("mid") or entry.get("owner_mid") or "").strip(),
         "bvid": bvid,
         "title": title,
@@ -457,9 +618,16 @@ def normalize_pool_entry(entry: dict) -> dict | None:
         "owner_name": str(entry.get("owner_name") or entry.get("author") or "").strip(),
         "owner_url": str(entry.get("owner_url") or "").strip(),
     }
+    for key in ("tag_1", "tag_2", "tag_3", "tag_4", "tag_5"):
+        value = entry.get(key)
+        if value is not None:
+            normalized[key] = str(value).strip()
+    if entry.get("tag_status") is not None:
+        normalized["tag_status"] = str(entry.get("tag_status")).strip()
+    return normalized
 
 
-def append_lark_pool_entries(entries: list[dict]) -> dict:
+def _normalize_pool_entries(entries: list[dict]) -> list[dict]:
     normalized: list[dict] = []
     seen_batch: set[str] = set()
     for entry in entries:
@@ -468,11 +636,40 @@ def append_lark_pool_entries(entries: list[dict]) -> dict:
             continue
         seen_batch.add(normalized_entry["bvid"])
         normalized.append(normalized_entry)
+    return normalized
+
+
+def append_cloudflare_pool_entries(entries: list[dict]) -> dict:
+    normalized = _normalize_pool_entries(entries)
+    if not normalized:
+        return {"attempted": 0, "added": 0}
+    try:
+        payload = _cloudflare_json("POST", "/batch-add", {"records": normalized}, timeout=20)
+    except LarkPoolError as exc:
+        return {"attempted": len(normalized), "added": 0, "error": str(exc)}
+    if not isinstance(payload, dict):
+        return {"attempted": len(normalized), "added": 0, "error": "Cloudflare returned an invalid payload"}
+    return {
+        "attempted": int(payload.get("attempted") or len(normalized)),
+        "added": int(payload.get("added") or 0),
+        "skipped_existing": int(payload.get("skipped_existing") or 0),
+        "feishu_queued": int(payload.get("feishu_queued") or 0),
+    }
+
+
+def append_lark_pool_entries_to_lark(
+    entries: list[dict],
+    *,
+    start_table_index: int = 1,
+    only_table_index: int | None = None,
+    use_sync_cache: bool = True,
+) -> dict:
+    normalized = _normalize_pool_entries(entries)
     if not normalized:
         return {"attempted": 0, "added": 0}
 
     with _SYNC_LOCK:
-        synced_bvids = _load_synced_bvids()
+        synced_bvids = _load_synced_bvids() if use_sync_cache else set()
         pending = [entry for entry in normalized if entry["bvid"] not in synced_bvids]
         if not pending:
             return {"attempted": len(normalized), "added": 0}
@@ -480,10 +677,15 @@ def append_lark_pool_entries(entries: list[dict]) -> dict:
         added = 0
         cursor = 0
         for table in _active_tables():
+            table_index = int(table.get("index") or 0)
+            if only_table_index is not None and table_index != int(only_table_index):
+                continue
+            if only_table_index is None and table_index < int(start_table_index):
+                continue
             capacity = max(0, _TABLE_LIMIT - int(table.get("count") or 0))
             if capacity <= 0:
                 continue
-            field_names = set(table.get("field_names") or _REQUIRED_FIELD_NAMES)
+            field_names = set(table.get("field_names") or _WRITE_FIELD_NAMES)
             while cursor < len(pending) and capacity > 0:
                 chunk = pending[cursor : cursor + min(_APPEND_CHUNK_SIZE, capacity)]
                 records = [
@@ -505,10 +707,15 @@ def append_lark_pool_entries(entries: list[dict]) -> dict:
                 added += len(chunk)
                 synced_bvids.update(entry["bvid"] for entry in chunk)
                 _bump_table_count(int(table["index"]), len(chunk))
-                _save_synced_bvids(synced_bvids)
+                if use_sync_cache:
+                    _save_synced_bvids(synced_bvids)
             if cursor >= len(pending):
                 break
         return {"attempted": len(normalized), "added": added}
+
+
+def append_lark_pool_entries(entries: list[dict]) -> dict:
+    return append_cloudflare_pool_entries(entries)
 
 
 def append_lark_pool_entries_in_background(entries: list[dict]) -> None:

--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -584,10 +584,14 @@ class BilikaraHandler(BaseHTTPRequestHandler):
             query = route_query.get("q", [""])[0]
             table_index = route_query.get("table", [""])[0]
             try:
+                limit = max(1, min(100, int(route_query.get("limit", ["80"])[0] or "80")))
+            except (TypeError, ValueError):
+                limit = 80
+            try:
                 if table_index:
-                    results = search_lark_pool_table(query, int(table_index))
+                    results = search_lark_pool_table(query, int(table_index), limit=limit)
                 else:
-                    results = search_lark_pool(query)
+                    results = search_lark_pool(query, limit=limit)
                 self._write_json({"ok": True, "data": {"items": results}})
             except Exception as e:
                 self._write_json({"ok": False, "error": str(e)})

--- a/static/app.js
+++ b/static/app.js
@@ -5311,7 +5311,7 @@ async function handleLarkSearchSubmit(event) {
         ? `搜索到 ${collectedItems.length} 条共享结果${partialFailure ? "，部分表搜索失败" : ""}。`
         : partialFailure
           ? "部分表搜索失败，bilikara 数据库里暂时没有匹配结果。"
-          : "bilikara 数据库里没有匹配结果。",
+          : "bilikara 数据库里没有匹配结果。快使用添加 UID 功能/拉取收藏添加你喜爱的up主/稿件吧",
       partialFailure && !collectedItems.length,
     );
   } catch (error) {

--- a/static/app.js
+++ b/static/app.js
@@ -927,7 +927,10 @@ async function searchGatchaCache(query) {
 
 async function searchLarkPool(query) {
   const normalizedQuery = String(query || "").trim();
-  const response = await fetch(`/api/lark/search?q=${encodeURIComponent(normalizedQuery)}`, {
+  const params = new URLSearchParams();
+  params.set("q", normalizedQuery);
+  params.set("limit", "80");
+  const response = await fetch(`/api/lark/search?${params.toString()}`, {
     cache: "no-store",
     headers: clientHeaders(),
   });
@@ -943,6 +946,7 @@ async function searchLarkPoolTable(query, tableIndex) {
   const params = new URLSearchParams();
   params.set("q", normalizedQuery);
   params.set("table", String(tableIndex));
+  params.set("limit", "80");
   const response = await fetch(`/api/lark/search?${params.toString()}`, {
     cache: "no-store",
     headers: clientHeaders(),

--- a/static/app.js
+++ b/static/app.js
@@ -43,6 +43,8 @@ const state = {
   bbdownLoginRenderSignature: "",
   searchCookieFaceRenderSignature: "",
   gatchaUidFaceRenderSignature: "",
+  gatchaTaskLastMessageSignature: "",
+  gatchaTaskWatchStartedAt: Date.now() / 1000,
   historyRenderSignature: "",
   playlistEmptyRenderSignature: "",
   cacheSliderRenderSignature: "",
@@ -1327,6 +1329,39 @@ function gatchaTaskBusyMessage() {
   return state.data?.gatcha?.message || "拉取任务执行中，请等待任务结束";
 }
 
+function syncGatchaTaskTerminalMessage() {
+  const task = state.data?.gatcha || {};
+  if (task.busy || state.gatchaUidSaving || state.gatchaRefreshSaving || state.gatchaFavlistSaving) {
+    return;
+  }
+  const status = String(task.last_status || "");
+  if (!["success", "partial", "failed"].includes(status)) {
+    return;
+  }
+  const updatedAt = Number(task.last_updated_at || 0);
+  if (updatedAt && updatedAt < state.gatchaTaskWatchStartedAt - 1) {
+    return;
+  }
+  const signature = JSON.stringify({
+    status,
+    message: task.last_message || "",
+    error: task.last_error || "",
+    updatedAt,
+  });
+  if (signature === state.gatchaTaskLastMessageSignature) {
+    return;
+  }
+  state.gatchaTaskLastMessageSignature = signature;
+  const fallback =
+    status === "success"
+      ? "抽卡缓存更新完成。"
+      : status === "partial"
+        ? "抽卡缓存已部分更新，但有项目拉取失败。"
+        : "抽卡缓存更新失败。";
+  const detail = task.last_error ? `${task.last_message || fallback} ${task.last_error}` : task.last_message || fallback;
+  setGatchaUidMessage(detail, status !== "success");
+}
+
 function syncSearchStageView(view) {
   const nextView = view || "search";
   const previousView = state.searchStageView || "search";
@@ -1425,6 +1460,7 @@ function renderSearchCookieFace() {
 }
 
 function renderGatchaUidFace() {
+  syncGatchaTaskTerminalMessage();
   const showUid = Boolean(state.gatchaUidVisible);
   const taskBusy = gatchaTaskBusy();
   const signature = JSON.stringify({
@@ -1434,6 +1470,8 @@ function renderGatchaUidFace() {
     favlistSaving: state.gatchaFavlistSaving,
     taskBusy,
     taskMessage: gatchaTaskBusyMessage(),
+    taskLastStatus: state.data?.gatcha?.last_status || "",
+    taskLastUpdatedAt: state.data?.gatcha?.last_updated_at || 0,
   });
   if (signature === state.gatchaUidFaceRenderSignature) {
     return;
@@ -5242,29 +5280,21 @@ async function handleLarkSearchSubmit(event) {
   }
   setLarkSearchMessage("正在搜索 bilikara 数据库...(联网搜索需要3-15s不等)");
   try {
-    for (let tableIndex = 1; tableIndex <= larkSearchTableCount; tableIndex += 1) {
-      let tableItems = [];
-      try {
-        tableItems = await searchLarkPoolTable(query, tableIndex);
-      } catch (error) {
-        partialFailure = true;
-        continue;
+    const poolItems = await searchLarkPool(query);
+    if (state.larkSearchSeq !== searchSeq) {
+      return;
+    }
+    const freshItems = poolItems.filter((item) => {
+      const bvid = String(item?.bvid || "").trim();
+      if (!bvid || seenBvids.has(bvid)) {
+        return false;
       }
-      if (state.larkSearchSeq !== searchSeq) {
-        return;
-      }
-      const freshItems = tableItems.filter((item) => {
-        const bvid = String(item?.bvid || "").trim();
-        if (!bvid || seenBvids.has(bvid)) {
-          return false;
-        }
-        seenBvids.add(bvid);
-        return true;
-      });
-      if (freshItems.length) {
-        collectedItems.push(...freshItems);
-        appendSearchResultItems(elements.larkSearchResults, freshItems);
-      }
+      seenBvids.add(bvid);
+      return true;
+    });
+    if (freshItems.length) {
+      collectedItems.push(...freshItems);
+      appendSearchResultItems(elements.larkSearchResults, freshItems);
     }
     if (state.larkSearchSeq !== searchSeq) {
       return;
@@ -6339,7 +6369,12 @@ elements.refreshGatchaCacheButton?.addEventListener("click", async () => {
   try {
     const result = await refreshGatchaCache();
     if (result?.started !== false && state.data) {
-      state.data.gatcha = { busy: true, message: gatchaTaskBusyMessage() };
+      state.data.gatcha = {
+        ...(state.data.gatcha || {}),
+        busy: true,
+        message: gatchaTaskBusyMessage(),
+        last_status: "running",
+      };
     }
     setGatchaUidMessage(result?.started === false ? "抽卡缓存已经在更新中。" : "已开始更新抽卡缓存。");
   } catch (error) {

--- a/static/remote.css
+++ b/static/remote.css
@@ -1219,6 +1219,8 @@ select:disabled {
 .search-results {
   display: grid;
   gap: 10px;
+  align-content: start;
+  grid-auto-rows: max-content;
   margin-top: 12px;
   max-height: clamp(220px, 42vh, 460px);
   overflow-y: auto;

--- a/static/remote.js
+++ b/static/remote.js
@@ -45,6 +45,8 @@ const state = {
   gatchaUidSaving: false,
   gatchaRefreshSaving: false,
   gatchaFavlistSaving: false,
+  gatchaTaskLastMessageSignature: "",
+  gatchaTaskWatchStartedAt: Date.now() / 1000,
   followBrowseVisible: false,
   larkSearchVisible: false,
   larkSearchLoading: false,
@@ -833,6 +835,39 @@ function gatchaTaskBusyMessage() {
   return state.data?.gatcha?.message || "拉取任务执行中，请等待任务结束";
 }
 
+function syncGatchaTaskTerminalMessage() {
+  const task = state.data?.gatcha || {};
+  if (task.busy || state.gatchaUidSaving || state.gatchaRefreshSaving || state.gatchaFavlistSaving) {
+    return;
+  }
+  const status = String(task.last_status || "");
+  if (!["success", "partial", "failed"].includes(status)) {
+    return;
+  }
+  const updatedAt = Number(task.last_updated_at || 0);
+  if (updatedAt && updatedAt < state.gatchaTaskWatchStartedAt - 1) {
+    return;
+  }
+  const signature = JSON.stringify({
+    status,
+    message: task.last_message || "",
+    error: task.last_error || "",
+    updatedAt,
+  });
+  if (signature === state.gatchaTaskLastMessageSignature) {
+    return;
+  }
+  state.gatchaTaskLastMessageSignature = signature;
+  const fallback =
+    status === "success"
+      ? "抽卡缓存更新完成。"
+      : status === "partial"
+        ? "抽卡缓存已部分更新，但有项目拉取失败。"
+        : "抽卡缓存更新失败。";
+  const detail = task.last_error ? `${task.last_message || fallback} ${task.last_error}` : task.last_message || fallback;
+  setGatchaUidMessage(detail, status !== "success");
+}
+
 function gatchaUidResultMessage(result, fallbackUid = "") {
   const cache = result?.cache || {};
   const addedCount = Number(cache.added_count || 0);
@@ -1211,6 +1246,7 @@ function setGatchaUidMessage(message, isError = false) {
 }
 
 function renderGatchaUidView() {
+  syncGatchaTaskTerminalMessage();
   const showUid = Boolean(state.gatchaUidVisible);
   const hasCandidate = Boolean(state.gatchaCandidate);
   const taskBusy = gatchaTaskBusy();
@@ -2565,29 +2601,21 @@ elements.larkSearchForm?.addEventListener("submit", async (event) => {
   }
   setLarkSearchMessage("正在搜索 bilikara 数据库...(联网搜索需要3-15s不等)");
   try {
-    for (let tableIndex = 1; tableIndex <= larkSearchTableCount; tableIndex += 1) {
-      let tableItems = [];
-      try {
-        tableItems = await searchLarkPoolTable(query, tableIndex);
-      } catch (error) {
-        partialFailure = true;
-        continue;
+    const poolItems = await searchLarkPool(query);
+    if (state.larkSearchSeq !== searchSeq) {
+      return;
+    }
+    const freshItems = poolItems.filter((item) => {
+      const bvid = String(item?.bvid || "").trim();
+      if (!bvid || seenBvids.has(bvid)) {
+        return false;
       }
-      if (state.larkSearchSeq !== searchSeq) {
-        return;
-      }
-      const freshItems = tableItems.filter((item) => {
-        const bvid = String(item?.bvid || "").trim();
-        if (!bvid || seenBvids.has(bvid)) {
-          return false;
-        }
-        seenBvids.add(bvid);
-        return true;
-      });
-      if (freshItems.length) {
-        collectedItems.push(...freshItems);
-        appendLarkSearchResults(freshItems);
-      }
+      seenBvids.add(bvid);
+      return true;
+    });
+    if (freshItems.length) {
+      collectedItems.push(...freshItems);
+      appendLarkSearchResults(freshItems);
     }
     if (state.larkSearchSeq !== searchSeq) {
       return;
@@ -2812,7 +2840,12 @@ elements.refreshGatchaCacheButton?.addEventListener("click", async () => {
   try {
     const result = await refreshGatchaCache();
     if (result?.started !== false && state.data) {
-      state.data.gatcha = { busy: true, message: gatchaTaskBusyMessage() };
+      state.data.gatcha = {
+        ...(state.data.gatcha || {}),
+        busy: true,
+        message: gatchaTaskBusyMessage(),
+        last_status: "running",
+      };
     }
     setGatchaUidMessage(result?.started === false ? "拉取任务执行中，请等待任务结束" : "已开始后台更新抽卡缓存。");
   } catch (error) {

--- a/static/remote.js
+++ b/static/remote.js
@@ -755,7 +755,10 @@ async function searchGatchaCache(query) {
 
 async function searchLarkPool(query) {
   const normalizedQuery = String(query || "").trim();
-  const response = await fetch(`/api/lark/search?q=${encodeURIComponent(normalizedQuery)}`, {
+  const params = new URLSearchParams();
+  params.set("q", normalizedQuery);
+  params.set("limit", "80");
+  const response = await fetch(`/api/lark/search?${params.toString()}`, {
     cache: "no-store",
     headers: clientHeaders(),
   });
@@ -771,6 +774,7 @@ async function searchLarkPoolTable(query, tableIndex) {
   const params = new URLSearchParams();
   params.set("q", normalizedQuery);
   params.set("table", String(tableIndex));
+  params.set("limit", "80");
   const response = await fetch(`/api/lark/search?${params.toString()}`, {
     cache: "no-store",
     headers: clientHeaders(),

--- a/static/styles.css
+++ b/static/styles.css
@@ -3769,6 +3769,8 @@ select:disabled {
 .search-results {
   display: grid;
   gap: 10px;
+  align-content: start;
+  grid-auto-rows: max-content;
   min-height: 0;
   max-height: 100%;
   overflow-y: auto;

--- a/tests/test_lark_pool_client.py
+++ b/tests/test_lark_pool_client.py
@@ -1,4 +1,4 @@
-import json
+﻿import json
 import uuid
 import unittest
 from pathlib import Path
@@ -95,11 +95,23 @@ class LarkPoolClientTest(unittest.TestCase):
 
         with patch.object(lark_pool, "_cloudflare_json", side_effect=fake_cloudflare):
             result = lark_pool.append_lark_pool_entries(
-                [{"bvid": "BVCFADD", "title": "new", "url": "https://www.bilibili.com/video/BVCFADD"}]
+                [{"bvid": "BV1CFADD0001", "title": "new", "url": "https://www.bilibili.com/video/BV1CFADD0001"}]
             )
 
         self.assertEqual(result["added"], 1)
-        self.assertEqual(posted_payloads[0]["records"][0]["bvid"], "BVCFADD")
+        self.assertEqual(posted_payloads[0]["records"][0]["bvid"], "BV1CFADD0001")
+
+    def test_append_lark_pool_entries_rejects_short_dummy_bvids(self):
+        with patch.object(lark_pool, "_cloudflare_json") as cloudflare:
+            result = lark_pool.append_lark_pool_entries(
+                [
+                    {"bvid": "BVFAV1", "title": "dummy", "url": "https://www.bilibili.com/video/BVFAV1"},
+                    {"bvid": "BVADDED42", "title": "dummy", "url": "https://www.bilibili.com/video/BVADDED42"},
+                ]
+            )
+
+        cloudflare.assert_not_called()
+        self.assertEqual(result, {"attempted": 0, "added": 0})
 
     def test_active_tables_skip_tables_without_search_fields(self):
         with (
@@ -235,7 +247,7 @@ class LarkPoolClientTest(unittest.TestCase):
         temp_root = Path.cwd() / ".tmp"
         temp_root.mkdir(exist_ok=True)
         sync_file = temp_root / f"lark_pool_sync_{uuid.uuid4().hex}.json"
-        sync_file.write_text(json.dumps({"bvids": ["BVOLD"]}), encoding="utf-8")
+        sync_file.write_text(json.dumps({"bvids": ["BV1OLD000001"]}), encoding="utf-8")
         posted_records = []
 
         def fake_post(url, payload, *, token=None, timeout=12.0):
@@ -256,15 +268,15 @@ class LarkPoolClientTest(unittest.TestCase):
         ):
             result = lark_pool.append_lark_pool_entries_to_lark(
                 [
-                    {"bvid": "BVOLD", "title": "old", "url": "https://www.bilibili.com/video/BVOLD"},
-                    {"bvid": "BVNEW", "title": "new", "url": "https://www.bilibili.com/video/BVNEW"},
+                    {"bvid": "BV1OLD000001", "title": "old", "url": "https://www.bilibili.com/video/BV1OLD000001"},
+                    {"bvid": "BV1NEW000001", "title": "new", "url": "https://www.bilibili.com/video/BV1NEW000001"},
                 ]
             )
 
         self.assertEqual(result["added"], 1)
-        self.assertEqual(posted_records[0]["fields"]["bvid"], "BVNEW")
+        self.assertEqual(posted_records[0]["fields"]["bvid"], "BV1NEW000001")
         payload = json.loads(sync_file.read_text(encoding="utf-8"))
-        self.assertIn("BVNEW", payload["bvids"])
+        self.assertIn("BV1NEW000001", payload["bvids"])
 
     def test_append_lark_pool_entries_skips_invalid_video_titles(self):
         temp_root = Path.cwd() / ".tmp"
@@ -290,19 +302,19 @@ class LarkPoolClientTest(unittest.TestCase):
             result = lark_pool.append_lark_pool_entries_to_lark(
                 [
                     {
-                        "bvid": "BVDEAD",
+                        "bvid": "BV1DEAD0001",
                         "title": next(iter(lark_pool._INVALID_VIDEO_TITLES)),
-                        "url": "https://www.bilibili.com/video/BVDEAD",
+                        "url": "https://www.bilibili.com/video/BV1DEAD0001",
                     },
-                    {"bvid": "BVALIVE", "title": "alive", "url": "https://www.bilibili.com/video/BVALIVE"},
+                    {"bvid": "BV1ALIVE0000", "title": "alive", "url": "https://www.bilibili.com/video/BV1ALIVE0000"},
                 ]
             )
 
         self.assertEqual(result["attempted"], 1)
         self.assertEqual(result["added"], 1)
-        self.assertEqual([record["fields"]["bvid"] for record in posted_records], ["BVALIVE"])
+        self.assertEqual([record["fields"]["bvid"] for record in posted_records], ["BV1ALIVE0000"])
         payload = json.loads(sync_file.read_text(encoding="utf-8"))
-        self.assertNotIn("BVDEAD", payload["bvids"])
+        self.assertNotIn("BV1DEAD0001", payload["bvids"])
 
     def test_append_lark_pool_entries_to_lark_preserves_tags_and_can_target_table(self):
         temp_root = Path.cwd() / ".tmp"
@@ -340,9 +352,9 @@ class LarkPoolClientTest(unittest.TestCase):
             result = lark_pool.append_lark_pool_entries_to_lark(
                 [
                     {
-                        "bvid": "BVTAGGED",
+                        "bvid": "BV1TAGGED000",
                         "title": "tagged",
-                        "url": "https://www.bilibili.com/video/BVTAGGED",
+                        "url": "https://www.bilibili.com/video/BV1TAGGED000",
                         "tag_1": "work",
                         "tag_4": "music",
                         "tag_status": "1",
@@ -362,3 +374,4 @@ class LarkPoolClientTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/test_lark_pool_client.py
+++ b/tests/test_lark_pool_client.py
@@ -331,6 +331,7 @@ class LarkPoolClientTest(unittest.TestCase):
                         "table_id": "table2",
                         "count": 0,
                         "field_names": sorted(lark_pool._WRITE_FIELD_NAMES),
+                        "field_types": {"tag_status": 2, "mid": 2},
                     },
                 ],
             ),
@@ -344,6 +345,7 @@ class LarkPoolClientTest(unittest.TestCase):
                         "url": "https://www.bilibili.com/video/BVTAGGED",
                         "tag_1": "work",
                         "tag_4": "music",
+                        "tag_status": "1",
                     }
                 ],
                 only_table_index=2,
@@ -354,6 +356,8 @@ class LarkPoolClientTest(unittest.TestCase):
         self.assertIn("table2", posted_urls[0])
         self.assertEqual(posted_records[0]["fields"]["tag_1"], "work")
         self.assertEqual(posted_records[0]["fields"]["tag_4"], "music")
+        self.assertEqual(posted_records[0]["fields"]["tag_status"], 1)
+        self.assertNotIn("mid", posted_records[0]["fields"])
 
 
 if __name__ == "__main__":

--- a/tests/test_lark_pool_client.py
+++ b/tests/test_lark_pool_client.py
@@ -1,7 +1,7 @@
 import json
+import uuid
 import unittest
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import bilikara.lark_pool_client as lark_pool
@@ -15,6 +15,7 @@ class LarkPoolClientTest(unittest.TestCase):
                 "_post_json",
                 return_value={"code": 0, "tenant_access_token": "tenant-token", "expire": 3600},
             ),
+            patch.object(lark_pool, "APP_SECRET", "secret"),
             patch.object(lark_pool, "_TOKEN_VALUE", ""),
             patch.object(lark_pool, "_TOKEN_EXPIRES_AT", 0.0),
         ):
@@ -46,6 +47,7 @@ class LarkPoolClientTest(unittest.TestCase):
             }
 
         with (
+            patch.object(lark_pool, "_search_cloudflare_pool", return_value=None),
             patch.object(lark_pool, "_tenant_access_token", return_value="token"),
             patch.object(lark_pool, "_active_tables", return_value=[{"app_token": "app", "table_id": "table"}]),
             patch.object(lark_pool, "_post_json", side_effect=fake_post),
@@ -55,6 +57,49 @@ class LarkPoolClientTest(unittest.TestCase):
         self.assertEqual(results[0]["bvid"], "BVPOOL1")
         self.assertEqual(results[0]["title"], "karaoke title")
         self.assertEqual(results[0]["source"], "bilikara")
+
+    def test_search_lark_pool_uses_cloudflare_first(self):
+        def fake_cloudflare(method, path, payload=None, *, timeout=12.0):
+            self.assertEqual(method, "GET")
+            self.assertIn("/search?", path)
+            self.assertLessEqual(timeout, 2.0)
+            return [
+                {
+                    "mid": "42",
+                    "bvid": "BVCF1",
+                    "title": "cloudflare karaoke",
+                    "url": "https://www.bilibili.com/video/BVCF1",
+                    "owner_name": "owner",
+                    "owner_url": "https://space.bilibili.com/42",
+                }
+            ]
+
+        with (
+            patch.object(lark_pool, "_cloudflare_json", side_effect=fake_cloudflare),
+            patch.object(lark_pool, "_search_lark_pool_legacy") as legacy,
+        ):
+            results = lark_pool.search_lark_pool("karaoke")
+
+        legacy.assert_not_called()
+        self.assertEqual(results[0]["bvid"], "BVCF1")
+        self.assertEqual(results[0]["source"], "cloudflare")
+
+    def test_append_lark_pool_entries_posts_to_cloudflare(self):
+        posted_payloads = []
+
+        def fake_cloudflare(method, path, payload=None, *, timeout=12.0):
+            posted_payloads.append(payload)
+            self.assertEqual(method, "POST")
+            self.assertEqual(path, "/batch-add")
+            return {"attempted": 1, "added": 1, "skipped_existing": 0, "feishu_queued": 1}
+
+        with patch.object(lark_pool, "_cloudflare_json", side_effect=fake_cloudflare):
+            result = lark_pool.append_lark_pool_entries(
+                [{"bvid": "BVCFADD", "title": "new", "url": "https://www.bilibili.com/video/BVCFADD"}]
+            )
+
+        self.assertEqual(result["added"], 1)
+        self.assertEqual(posted_payloads[0]["records"][0]["bvid"], "BVCFADD")
 
     def test_active_tables_skip_tables_without_search_fields(self):
         with (
@@ -102,6 +147,7 @@ class LarkPoolClientTest(unittest.TestCase):
             return {"code": 0, "data": {"items": []}}
 
         with (
+            patch.object(lark_pool, "_search_cloudflare_pool", return_value=None),
             patch.object(lark_pool, "_tenant_access_token", return_value="token"),
             patch.object(
                 lark_pool,
@@ -144,6 +190,8 @@ class LarkPoolClientTest(unittest.TestCase):
             patch.object(lark_pool, "_ACTIVE_TABLES", []),
             patch.object(lark_pool, "_TABLE_PROBED", set()),
             patch.object(lark_pool, "BITABLE_TABLES", (("app1", "table1"), ("app2", "table2"))),
+            patch.object(lark_pool, "_CLOUDFLARE_API_URL", ""),
+            patch.object(lark_pool, "APP_SECRET", "secret"),
             patch.object(lark_pool, "_tenant_access_token", return_value="token"),
             patch.object(lark_pool, "_table_field_names", return_value={"bvid", "title", "url"}) as fields,
             patch.object(lark_pool, "_table_record_count", return_value=1) as count,
@@ -170,6 +218,8 @@ class LarkPoolClientTest(unittest.TestCase):
             patch.object(lark_pool, "_ACTIVE_TABLES", []),
             patch.object(lark_pool, "_TABLE_PROBED", set()),
             patch.object(lark_pool, "BITABLE_TABLES", (("app1", "table1"), ("app2", "table2"))),
+            patch.object(lark_pool, "_CLOUDFLARE_API_URL", ""),
+            patch.object(lark_pool, "APP_SECRET", "secret"),
             patch.object(lark_pool, "_tenant_access_token", return_value="token"),
             patch.object(lark_pool, "_table_field_names", return_value={"bvid", "title", "url"}),
             patch.object(lark_pool, "_table_record_count", return_value=0),
@@ -182,71 +232,128 @@ class LarkPoolClientTest(unittest.TestCase):
             self.assertEqual(post_count, 1)
 
     def test_append_lark_pool_entries_skips_locally_synced_bvids(self):
-        with TemporaryDirectory() as temp_dir:
-            sync_file = Path(temp_dir) / "lark_pool_sync.json"
-            sync_file.write_text(json.dumps({"bvids": ["BVOLD"]}), encoding="utf-8")
-            posted_records = []
+        temp_root = Path.cwd() / ".tmp"
+        temp_root.mkdir(exist_ok=True)
+        sync_file = temp_root / f"lark_pool_sync_{uuid.uuid4().hex}.json"
+        sync_file.write_text(json.dumps({"bvids": ["BVOLD"]}), encoding="utf-8")
+        posted_records = []
 
-            def fake_post(url, payload, *, token=None, timeout=12.0):
-                self.assertIn("/batch_create", url)
-                posted_records.extend(payload["records"])
-                return {"code": 0, "data": {}}
+        def fake_post(url, payload, *, token=None, timeout=12.0):
+            self.assertIn("/batch_create", url)
+            posted_records.extend(payload["records"])
+            return {"code": 0, "data": {}}
 
-            with (
-                patch.object(lark_pool, "_SYNC_FILE", sync_file),
-                patch.object(lark_pool.cfg, "DATA_DIR", Path(temp_dir)),
-                patch.object(lark_pool, "_tenant_access_token", return_value="token"),
-                patch.object(
-                    lark_pool,
-                    "_active_tables",
-                    return_value=[{"index": 1, "app_token": "app", "table_id": "table", "count": 1}],
-                ),
-                patch.object(lark_pool, "_post_json", side_effect=fake_post),
-            ):
-                result = lark_pool.append_lark_pool_entries(
-                    [
-                        {"bvid": "BVOLD", "title": "old", "url": "https://www.bilibili.com/video/BVOLD"},
-                        {"bvid": "BVNEW", "title": "new", "url": "https://www.bilibili.com/video/BVNEW"},
-                    ]
-                )
+        with (
+            patch.object(lark_pool, "_SYNC_FILE", sync_file),
+            patch.object(lark_pool.cfg, "DATA_DIR", temp_root),
+            patch.object(lark_pool, "_tenant_access_token", return_value="token"),
+            patch.object(
+                lark_pool,
+                "_active_tables",
+                return_value=[{"index": 1, "app_token": "app", "table_id": "table", "count": 1}],
+            ),
+            patch.object(lark_pool, "_post_json", side_effect=fake_post),
+        ):
+            result = lark_pool.append_lark_pool_entries_to_lark(
+                [
+                    {"bvid": "BVOLD", "title": "old", "url": "https://www.bilibili.com/video/BVOLD"},
+                    {"bvid": "BVNEW", "title": "new", "url": "https://www.bilibili.com/video/BVNEW"},
+                ]
+            )
 
-            self.assertEqual(result["added"], 1)
-            self.assertEqual(posted_records[0]["fields"]["bvid"], "BVNEW")
-            payload = json.loads(sync_file.read_text(encoding="utf-8"))
-            self.assertIn("BVNEW", payload["bvids"])
+        self.assertEqual(result["added"], 1)
+        self.assertEqual(posted_records[0]["fields"]["bvid"], "BVNEW")
+        payload = json.loads(sync_file.read_text(encoding="utf-8"))
+        self.assertIn("BVNEW", payload["bvids"])
 
     def test_append_lark_pool_entries_skips_invalid_video_titles(self):
-        with TemporaryDirectory() as temp_dir:
-            sync_file = Path(temp_dir) / "lark_pool_sync.json"
-            posted_records = []
+        temp_root = Path.cwd() / ".tmp"
+        temp_root.mkdir(exist_ok=True)
+        sync_file = temp_root / f"lark_pool_sync_invalid_{uuid.uuid4().hex}.json"
+        posted_records = []
 
-            def fake_post(url, payload, *, token=None, timeout=12.0):
-                posted_records.extend(payload["records"])
-                return {"code": 0, "data": {}}
+        def fake_post(url, payload, *, token=None, timeout=12.0):
+            posted_records.extend(payload["records"])
+            return {"code": 0, "data": {}}
 
-            with (
-                patch.object(lark_pool, "_SYNC_FILE", sync_file),
-                patch.object(lark_pool.cfg, "DATA_DIR", Path(temp_dir)),
-                patch.object(lark_pool, "_tenant_access_token", return_value="token"),
-                patch.object(
-                    lark_pool,
-                    "_active_tables",
-                    return_value=[{"index": 1, "app_token": "app", "table_id": "table", "count": 1}],
-                ),
-                patch.object(lark_pool, "_post_json", side_effect=fake_post),
-            ):
-                result = lark_pool.append_lark_pool_entries(
-                    [
-                        {"bvid": "BVDEAD", "title": "已失效视频", "url": "https://www.bilibili.com/video/BVDEAD"},
-                        {"bvid": "BVALIVE", "title": "alive", "url": "https://www.bilibili.com/video/BVALIVE"},
-                    ]
-                )
+        with (
+            patch.object(lark_pool, "_SYNC_FILE", sync_file),
+            patch.object(lark_pool.cfg, "DATA_DIR", temp_root),
+            patch.object(lark_pool, "_tenant_access_token", return_value="token"),
+            patch.object(
+                lark_pool,
+                "_active_tables",
+                return_value=[{"index": 1, "app_token": "app", "table_id": "table", "count": 1}],
+            ),
+            patch.object(lark_pool, "_post_json", side_effect=fake_post),
+        ):
+            result = lark_pool.append_lark_pool_entries_to_lark(
+                [
+                    {
+                        "bvid": "BVDEAD",
+                        "title": next(iter(lark_pool._INVALID_VIDEO_TITLES)),
+                        "url": "https://www.bilibili.com/video/BVDEAD",
+                    },
+                    {"bvid": "BVALIVE", "title": "alive", "url": "https://www.bilibili.com/video/BVALIVE"},
+                ]
+            )
 
-            self.assertEqual(result["attempted"], 1)
-            self.assertEqual(result["added"], 1)
-            self.assertEqual([record["fields"]["bvid"] for record in posted_records], ["BVALIVE"])
-            payload = json.loads(sync_file.read_text(encoding="utf-8"))
-            self.assertNotIn("BVDEAD", payload["bvids"])
+        self.assertEqual(result["attempted"], 1)
+        self.assertEqual(result["added"], 1)
+        self.assertEqual([record["fields"]["bvid"] for record in posted_records], ["BVALIVE"])
+        payload = json.loads(sync_file.read_text(encoding="utf-8"))
+        self.assertNotIn("BVDEAD", payload["bvids"])
+
+    def test_append_lark_pool_entries_to_lark_preserves_tags_and_can_target_table(self):
+        temp_root = Path.cwd() / ".tmp"
+        temp_root.mkdir(exist_ok=True)
+        sync_file = temp_root / f"lark_pool_sync_tags_{uuid.uuid4().hex}.json"
+        posted_urls = []
+        posted_records = []
+
+        def fake_post(url, payload, *, token=None, timeout=12.0):
+            posted_urls.append(url)
+            posted_records.extend(payload["records"])
+            return {"code": 0, "data": {}}
+
+        with (
+            patch.object(lark_pool, "_SYNC_FILE", sync_file),
+            patch.object(lark_pool.cfg, "DATA_DIR", temp_root),
+            patch.object(lark_pool, "_tenant_access_token", return_value="token"),
+            patch.object(
+                lark_pool,
+                "_active_tables",
+                return_value=[
+                    {"index": 1, "app_token": "app", "table_id": "table1", "count": 0},
+                    {
+                        "index": 2,
+                        "app_token": "app",
+                        "table_id": "table2",
+                        "count": 0,
+                        "field_names": sorted(lark_pool._WRITE_FIELD_NAMES),
+                    },
+                ],
+            ),
+            patch.object(lark_pool, "_post_json", side_effect=fake_post),
+        ):
+            result = lark_pool.append_lark_pool_entries_to_lark(
+                [
+                    {
+                        "bvid": "BVTAGGED",
+                        "title": "tagged",
+                        "url": "https://www.bilibili.com/video/BVTAGGED",
+                        "tag_1": "work",
+                        "tag_4": "music",
+                    }
+                ],
+                only_table_index=2,
+                use_sync_cache=False,
+            )
+
+        self.assertEqual(result["added"], 1)
+        self.assertIn("table2", posted_urls[0])
+        self.assertEqual(posted_records[0]["fields"]["tag_1"], "work")
+        self.assertEqual(posted_records[0]["fields"]["tag_4"], "music")
 
 
 if __name__ == "__main__":

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -1481,6 +1481,58 @@ class BilibiliParserTest(unittest.TestCase):
         finally:
             refresh_lock.release()
 
+    def test_background_gatcha_refresh_records_failure_status(self):
+        class FakeThread:
+            def __init__(self, *, target, daemon=None, name=None):
+                self.target = target
+
+            def start(self):
+                self.target()
+
+        task_status = {
+            "status": "idle",
+            "message": "",
+            "error": "",
+            "updated_at": 0.0,
+            "result": None,
+        }
+        with (
+            patch.object(bilibili_module, "_GATCHA_REFRESH_LOCK", threading.Lock()),
+            patch.object(bilibili_module, "_GATCHA_TASK_STATUS_LOCK", threading.Lock()),
+            patch.object(bilibili_module, "_GATCHA_TASK_STATUS", task_status),
+            patch.object(bilibili_module, "refresh_gatcha_cache", side_effect=RuntimeError("boom")),
+            patch.object(bilibili_module.threading, "Thread", FakeThread),
+        ):
+            self.assertTrue(bilibili_module.refresh_gatcha_cache_in_background())
+            snapshot = bilibili_module.gatcha_task_snapshot()
+
+        self.assertFalse(snapshot["busy"])
+        self.assertEqual(snapshot["last_status"], "failed")
+        self.assertEqual(snapshot["last_error"], "boom")
+
+    def test_refresh_gatcha_cache_reports_partial_uid_failures(self):
+        cache_payload = {"uids": {}, "profiles": {}}
+
+        def fake_refresh_uid(payload, mid):
+            if mid == "1":
+                raise RuntimeError("uid failed")
+            payload["uids"][mid] = [{"bvid": "BVUSER", "title": "user"}]
+            return {"uid": mid, "mode": "full", "added_count": 1, "total_count": 1}
+
+        with (
+            patch.object(bilibili_module, "effective_bilibili_cookie", return_value="cookie"),
+            patch.object(bilibili_module, "_load_gatcha_uid_payload", return_value={"uids": ["1", "2"], "profiles": {}}),
+            patch.object(bilibili_module, "_load_gatcha_cache", return_value=cache_payload),
+            patch.object(bilibili_module, "_resolve_gatcha_uid_profile", return_value=None),
+            patch.object(bilibili_module, "_refresh_gatcha_uid_cache", side_effect=fake_refresh_uid),
+            patch.object(bilibili_module, "_refresh_existing_gatcha_favlist_cache", return_value=None),
+        ):
+            result = bilibili_module.refresh_gatcha_cache()
+
+        summary = result["refresh_summary"]
+        self.assertEqual([item["uid"] for item in summary["uids"]], ["2"])
+        self.assertEqual(summary["errors"], [{"uid": "1", "error": "uid failed"}])
+
     def test_startup_gatcha_refresh_skips_uncached_default_uids_for_lark_upload(self):
         class FakeThread:
             def __init__(self, *, target, daemon=None, name=None):


### PR DESCRIPTION
## 中文版

## 概要

本 PR 将 bilikara 的搜索和新增稿件流程迁移为 Cloudflare/D1 优先，同时保留原有飞书表格作为搜索 fallback。用户通过 UID / 收藏夹 / 抽卡更新产生的新稿件会先提交到 Cloudflare Worker，由 Worker 写入 D1、过滤重复 BV，并在需要时同步新增数据到飞书。

同时补齐了 D1 -> 飞书同步、AI 自动打标签、搜索字段、调试日志控制和后台拉取状态反馈。

## 主要改动

- 搜索链路改为 Cloudflare 优先：
  - bilikara 搜索默认请求 Cloudflare `/search`
  - 超过 2 秒或 Cloudflare 请求失败时 fallback 到原飞书表格搜索
  - 飞书 `table` 参数只保留给旧飞书流程，不再混入 Cloudflare

- Cloudflare Worker 能力增强：
  - `/search` 支持 `bvid`、`mid` 精确搜索
  - `/search` 支持 `title`、`owner_name`、`tag_1` 到 `tag_5` 模糊搜索
  - `/search` 默认 limit 改为 80，最大 100
  - `/batch-add` 写入 D1，过滤已有 BV，并把新增项同步到飞书
  - `/export` 保留 admin secret，用于全量导出给 `sync_to_lark.py`

- D1 schema 和数据字段完善：
  - 增加 `owner_url`
  - 增加 `tag_status`
  - 修复 BV 大小写问题，不再把 bvid 强制转大写
  - 避免失效视频占位符污染数据

- 飞书同步流程完善：
  - `sync_to_lark.py` 支持直接脚本运行
  - 支持指定从某张表开始同步或只同步到某张表
  - 支持忽略本地同步缓存，方便测试表2
  - 同步时保留 `tag_1` 到 `tag_5` 和 `tag_status`
  - 飞书数字字段会自动转 number，空值会跳过，避免 `NumberFieldConvFail`

- 自动打标签脚本增强：
  - Gemini 输出支持清洗和容错：
    - Markdown code fence
    - 前后废话
    - 单行 JSON
    - trailing comma
    - 简单少闭合括号
  - 回填前按当前 batch 的 BV 白名单过滤，避免 Gemini 编造 BV
  - 自动补齐 `tag_1` 到 `tag_5`
  - `null` / `none` / `无` / `-` 等统一为空值

- gatcha / UID 后台拉取状态修复：
  - 后台任务不再只有“启动成功”
  - 增加 `running` / `success` / `partial` / `failed` 状态
  - 单个 UID 拉取失败会被记录为部分失败，不会静默伪成功
  - 主屏和 remote 都会显示后台任务最终状态

- 前端调整：
  - bilikara 搜索不再循环飞书 5 张表
  - 主屏和 remote 都走 Cloudflare 优先搜索
  - 搜索请求显式传 `limit=80`
  - 修复单条搜索结果时 tab / grid 过大的布局问题

- 调试和仓库清理：
  - 移除 `/api/lark/search` 的临时 JSON debug 输出
  - `BILIKARA_LARK_DEBUG` 默认关闭，只有显式设为 `1` 才输出详细日志
  - `.gitignore` 增加 `.tmp/`
  - `.gitignore` 增加 `bilikara-api/`

## 验证

- 通过 Python AST 语法检查
- 通过 `tests.test_lark_pool_client`
- 通过 gatcha 后台失败和部分失败的定向测试
- 本地验证 `auto_tagger.py` 的 Gemini JSON 清洗逻辑


## English Version

## Summary

This PR migrates bilikara search and new-video ingestion to a Cloudflare/D1-first workflow while keeping the original Feishu table search as a fallback. New videos collected from UID, favorite-list, and gatcha refresh flows are submitted to the Cloudflare Worker first. The Worker inserts only missing BV IDs into D1 and then syncs newly added rows to Feishu when enabled.

It also improves D1-to-Feishu syncing, AI auto-tagging, search coverage, debug logging, and background refresh status reporting.

## Key Changes

- Cloudflare-first search pipeline:
  - bilikara search now queries Cloudflare `/search` first
  - falls back to legacy Feishu table search if Cloudflare fails or times out after 2 seconds
  - Feishu `table` remains a legacy Feishu-only concept and is no longer mixed into Cloudflare logic

- Enhanced Cloudflare Worker:
  - `/search` supports exact search on `bvid` and `mid`
  - `/search` supports fuzzy search on `title`, `owner_name`, and `tag_1` through `tag_5`
  - `/search` default limit is now 80, max 100
  - `/batch-add` inserts into D1, deduplicates existing BV IDs, and syncs new rows to Feishu
  - `/export` remains admin-secret protected for full D1 export via `sync_to_lark.py`

- D1 schema and data cleanup:
  - added `owner_url`
  - added `tag_status`
  - fixed BV casing by preserving original bvid case
  - prevented invalid placeholder video titles from polluting the dataset

- Feishu sync improvements:
  - `sync_to_lark.py` now works when run directly as a script
  - supports starting sync from a selected table or targeting only one table
  - supports ignoring the local sync cache for test syncs
  - preserves `tag_1` through `tag_5` and `tag_status`
  - coerces Feishu number fields to numeric values and skips empty values to avoid `NumberFieldConvFail`

- Auto tagger hardening:
  - robust Gemini output cleanup for:
    - Markdown code fences
    - leading/trailing prose
    - one-line JSON
    - trailing commas
    - simple missing closing brackets
  - validates updates against the current batch BV whitelist
  - fills all `tag_1` through `tag_5` fields
  - normalizes `null`, `none`, `无`, `-`, etc. into empty values

- Gatcha / UID background refresh status:
  - background refresh no longer only reports “started”
  - added `running`, `success`, `partial`, and `failed` terminal states
  - per-UID failures are recorded as partial failures instead of being silently hidden
  - host and remote UI now display final background task status

- Frontend updates:
  - bilikara search no longer loops over the five Feishu tables
  - host and remote search both use the Cloudflare-first path
  - search requests explicitly pass `limit=80`
  - fixed oversized single-result tab/grid layout

- Debug and repo cleanup:
  - removed temporary `/api/lark/search` JSON debug logs
  - `BILIKARA_LARK_DEBUG` now defaults to off and only logs when explicitly set to `1`
  - added `.tmp/` to `.gitignore`
  - added `bilikara-api/` to `.gitignore`

## Testing

- Python AST syntax checks passed
- `tests.test_lark_pool_client` passed
- targeted gatcha background failure / partial failure tests passed
- locally verified `auto_tagger.py` Gemini JSON cleanup behavior
