### PR TITLE
若干小修复和无用代码清理

### DIFF
--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -1190,7 +1190,7 @@ def refresh_gatcha_cache_in_background(
     on_start: callable | None = None,
     on_done: callable | None = None,
     use_global_lock: bool = True,
-    upload_default_uids_to_lark: bool = True,
+    upload_default_uids_to_lark: bool = False,
 ) -> bool:
     if use_global_lock:
         if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
@@ -1200,19 +1200,6 @@ def refresh_gatcha_cache_in_background(
             on_start()
     else:
         _set_gatcha_task_status("running", message=GATCHA_TASK_BUSY_MESSAGE)
-
-    cached_default_uids_before_refresh: set[str] = set()
-    if not upload_default_uids_to_lark:
-        default_uids = set(_default_gatcha_uids())
-        with _GATCHA_CACHE_LOCK:
-            previous_cache_payload = _load_gatcha_cache(reset_legacy=False)
-        previous_uid_entries = previous_cache_payload.get("uids") if isinstance(previous_cache_payload, dict) else {}
-        if isinstance(previous_uid_entries, dict):
-            cached_default_uids_before_refresh = {
-                uid
-                for uid in default_uids
-                if isinstance(previous_uid_entries.get(uid), list) and previous_uid_entries.get(uid)
-            }
 
     def _worker() -> None:
         cache_payload: dict | None = None
@@ -1241,10 +1228,10 @@ def refresh_gatcha_cache_in_background(
                 if on_done is not None:
                     on_done()
         if cache_payload is not None and task_status != "failed":
-            excluded_uids = set()
-            if not upload_default_uids_to_lark:
-                excluded_uids = set(_default_gatcha_uids()) - cached_default_uids_before_refresh
-            _append_lark_pool_entries_async(_gatcha_cache_payload_entries(cache_payload, exclude_uids=excluded_uids))
+            excluded_uids = set(_default_gatcha_uids()) if not upload_default_uids_to_lark else set()
+            entries = _gatcha_cache_payload_entries(cache_payload, exclude_uids=excluded_uids)
+            if entries:
+                _append_lark_pool_entries_async(entries)
 
     threading.Thread(target=_worker, daemon=True, name="gatcha-cache-refresh").start()
     return True
@@ -1301,7 +1288,8 @@ def add_gatcha_uid(raw_mid: object, *, on_start: callable | None = None, on_done
             {
                 "uids": {mid: fresh_cache_payload.get("uids", {}).get(mid, [])},
                 "profiles": {mid: fresh_cache_payload.get("profiles", {}).get(mid, {})},
-            }
+            },
+            exclude_uids=set(_default_gatcha_uids()),
         )
     finally:
         _GATCHA_REFRESH_LOCK.release()

--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -1190,7 +1190,7 @@ def refresh_gatcha_cache_in_background(
     on_start: callable | None = None,
     on_done: callable | None = None,
     use_global_lock: bool = True,
-    upload_default_uids_to_lark: bool = False,
+    upload_default_uids_to_lark: bool = True,
 ) -> bool:
     if use_global_lock:
         if not _GATCHA_REFRESH_LOCK.acquire(blocking=False):
@@ -1228,8 +1228,7 @@ def refresh_gatcha_cache_in_background(
                 if on_done is not None:
                     on_done()
         if cache_payload is not None and task_status != "failed":
-            excluded_uids = set(_default_gatcha_uids()) if not upload_default_uids_to_lark else set()
-            entries = _gatcha_cache_payload_entries(cache_payload, exclude_uids=excluded_uids)
+            entries = _gatcha_cache_payload_entries(cache_payload)
             if entries:
                 _append_lark_pool_entries_async(entries)
 
@@ -1288,8 +1287,7 @@ def add_gatcha_uid(raw_mid: object, *, on_start: callable | None = None, on_done
             {
                 "uids": {mid: fresh_cache_payload.get("uids", {}).get(mid, [])},
                 "profiles": {mid: fresh_cache_payload.get("profiles", {}).get(mid, {})},
-            },
-            exclude_uids=set(_default_gatcha_uids()),
+            }
         )
     finally:
         _GATCHA_REFRESH_LOCK.release()

--- a/bilikara/lark_pool_client.py
+++ b/bilikara/lark_pool_client.py
@@ -27,9 +27,6 @@ BITABLE_TABLES = (
 _BASE_URL = "https://open.feishu.cn/open-apis"
 _CLOUDFLARE_API_URL = (os.environ.get("BILIKARA_CF_API_URL") or "https://api.kevinx96.icu").rstrip("/")
 _CLOUDFLARE_SEARCH_TIMEOUT = float(os.environ.get("BILIKARA_CF_SEARCH_TIMEOUT") or "2.0")
-_TABLE_LIMIT = 20_000
-_APPEND_CHUNK_SIZE = 400
-_SYNC_FILE = cfg.DATA_DIR / "lark_pool_sync.json"
 _TOKEN_LOCK = threading.RLock()
 _TOKEN_VALUE = ""
 _TOKEN_EXPIRES_AT = 0.0
@@ -38,7 +35,6 @@ _TABLES_READY = False
 _ACTIVE_TABLES: list[dict[str, Any]] = []
 _TABLE_PROBED: set[int] = set()
 _FIELD_TYPES_BY_TABLE: dict[tuple[str, str], dict[str, Any]] = {}
-_SYNC_LOCK = threading.RLock()
 _REQUIRED_FIELD_NAMES = {"mid", "bvid", "title", "url", "owner_name", "owner_url"}
 _OPTIONAL_FIELD_NAMES = {"tag_1", "tag_2", "tag_3", "tag_4", "tag_5", "tag_status"}
 _WRITE_FIELD_NAMES = _REQUIRED_FIELD_NAMES | _OPTIONAL_FIELD_NAMES
@@ -586,29 +582,6 @@ def search_lark_pool(query: str, *, limit: int = 80) -> list[dict]:
     return _search_lark_pool_legacy(normalized_query, limit=limit)
 
 
-def _load_synced_bvids() -> set[str]:
-    try:
-        payload = json.loads(_SYNC_FILE.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return set()
-    bvids = payload.get("bvids") if isinstance(payload, dict) else []
-    return {str(bvid).strip() for bvid in bvids if str(bvid).strip()}
-
-
-def _save_synced_bvids(bvids: set[str]) -> None:
-    cfg.DATA_DIR.mkdir(parents=True, exist_ok=True)
-    payload = {"schema_version": 1, "bvids": sorted(bvids), "updated_at": time.time()}
-    temp_path = Path(str(_SYNC_FILE) + ".tmp")
-    temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-    try:
-        temp_path.replace(_SYNC_FILE)
-    except PermissionError:
-        _SYNC_FILE.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
-        try:
-            temp_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-
 
 def normalize_pool_entry(entry: dict) -> dict | None:
     if not isinstance(entry, dict):
@@ -670,94 +643,6 @@ def append_cloudflare_pool_entries(entries: list[dict]) -> dict:
         "feishu_queued": int(payload.get("feishu_queued") or 0),
     }
 
-
-def _is_number_field_type(field_type: Any) -> bool:
-    return str(field_type).strip().lower() in {"2", "number"}
-
-
-def _coerce_feishu_field_value(field_name: str, value: Any, field_type: Any = None) -> Any:
-    if value is None:
-        return None
-    text = str(value).strip() if not isinstance(value, (int, float)) else value
-    if text == "":
-        return None
-    if _is_number_field_type(field_type):
-        try:
-            number = float(text)
-        except (TypeError, ValueError):
-            return None
-        return int(number) if number.is_integer() else number
-    return value
-
-
-def _feishu_record_fields(entry: dict[str, Any], field_names: set[str], field_types: dict[str, Any]) -> dict[str, Any]:
-    fields: dict[str, Any] = {}
-    for key, value in entry.items():
-        if key not in field_names:
-            continue
-        coerced = _coerce_feishu_field_value(key, value, field_types.get(key))
-        if coerced is None:
-            continue
-        fields[key] = coerced
-    return fields
-
-
-def append_lark_pool_entries_to_lark(
-    entries: list[dict],
-    *,
-    start_table_index: int = 1,
-    only_table_index: int | None = None,
-    use_sync_cache: bool = True,
-) -> dict:
-    normalized = _normalize_pool_entries(entries)
-    if not normalized:
-        return {"attempted": 0, "added": 0}
-
-    with _SYNC_LOCK:
-        synced_bvids = _load_synced_bvids() if use_sync_cache else set()
-        pending = [entry for entry in normalized if entry["bvid"] not in synced_bvids]
-        if not pending:
-            return {"attempted": len(normalized), "added": 0}
-        token = _tenant_access_token()
-        added = 0
-        cursor = 0
-        for table in _active_tables():
-            table_index = int(table.get("index") or 0)
-            if only_table_index is not None and table_index != int(only_table_index):
-                continue
-            if only_table_index is None and table_index < int(start_table_index):
-                continue
-            capacity = max(0, _TABLE_LIMIT - int(table.get("count") or 0))
-            if capacity <= 0:
-                continue
-            field_names = set(table.get("field_names") or _WRITE_FIELD_NAMES)
-            field_types = table.get("field_types") if isinstance(table.get("field_types"), dict) else {}
-            while cursor < len(pending) and capacity > 0:
-                chunk = pending[cursor : cursor + min(_APPEND_CHUNK_SIZE, capacity)]
-                records = [
-                    {"fields": _feishu_record_fields(entry, field_names, field_types)}
-                    for entry in chunk
-                ]
-                _log_lark_request("bilikara pool append", {"records": records})
-                _require_success(
-                    _post_json(
-                        _records_url(table["app_token"], table["table_id"], "/batch_create"),
-                        {"records": records},
-                        token=token,
-                        timeout=20,
-                    ),
-                    "bilikara pool append failed",
-                )
-                cursor += len(chunk)
-                capacity -= len(chunk)
-                added += len(chunk)
-                synced_bvids.update(entry["bvid"] for entry in chunk)
-                _bump_table_count(int(table["index"]), len(chunk))
-                if use_sync_cache:
-                    _save_synced_bvids(synced_bvids)
-            if cursor >= len(pending):
-                break
-        return {"attempted": len(normalized), "added": added}
 
 
 def append_lark_pool_entries(entries: list[dict]) -> dict:

--- a/static/app.js
+++ b/static/app.js
@@ -1218,6 +1218,20 @@ function renderFollowBrowse() {
         count.className = "follow-up-count";
         count.textContent = `${Number(owner.count || 0)} 首`;
 
+        button.addEventListener("click", async (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const uid = String(button.dataset.uid || "").trim();
+          if (!uid) {
+            return;
+          }
+          state.followBrowseSelectedUid = uid;
+          if (elements.followSearchQuery) {
+            elements.followSearchQuery.value = "";
+          }
+          await loadFollowBrowse({ uid, query: "" });
+        });
+
         button.append(name, count);
         elements.followUpGrid.appendChild(button);
       });
@@ -6675,6 +6689,7 @@ elements.followUpGrid?.addEventListener("click", async (event) => {
   if (!uid) {
     return;
   }
+  event.preventDefault();
   state.followBrowseSelectedUid = uid;
   if (elements.followSearchQuery) {
     elements.followSearchQuery.value = "";

--- a/static/app.js
+++ b/static/app.js
@@ -1218,20 +1218,6 @@ function renderFollowBrowse() {
         count.className = "follow-up-count";
         count.textContent = `${Number(owner.count || 0)} 首`;
 
-        button.addEventListener("click", async (event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          const uid = String(button.dataset.uid || "").trim();
-          if (!uid) {
-            return;
-          }
-          state.followBrowseSelectedUid = uid;
-          if (elements.followSearchQuery) {
-            elements.followSearchQuery.value = "";
-          }
-          await loadFollowBrowse({ uid, query: "" });
-        });
-
         button.append(name, count);
         elements.followUpGrid.appendChild(button);
       });
@@ -1406,6 +1392,7 @@ function syncSearchStageView(view) {
   if (state.searchFlipFrame) {
     window.cancelAnimationFrame(state.searchFlipFrame);
     state.searchFlipFrame = null;
+    elements.searchStage?.classList.remove("is-preparing-flip");
   }
 
   if (isInitialRender) {
@@ -1426,22 +1413,28 @@ function syncSearchStageView(view) {
     setClassToggle(elements.searchStage, "is-lark-view", activeView === "lark");
   };
   const clearFlip = () => {
-    elements.searchStage?.classList.remove("is-flipping");
+    elements.searchStage?.classList.remove("is-flipping", "is-preparing-flip");
     state.searchFlipTimer = null;
   };
   const searchViewOrder = ["search", "browse", "lark"];
   const previousIndex = searchViewOrder.indexOf(previousView);
   const nextIndex = searchViewOrder.indexOf(nextView);
   const forwardSteps = (nextIndex - previousIndex + searchViewOrder.length) % searchViewOrder.length;
+  const startAngle = state.searchStageAngle;
   if (forwardSteps === 1) {
     state.searchStageAngle -= 120;
   } else if (forwardSteps === 2) {
     state.searchStageAngle += 120;
   }
 
-  elements.searchStage?.classList.add("is-flipping");
+  elements.searchStage?.classList.add("is-preparing-flip", "is-flipping");
+  if (elements.searchStageInner) {
+    elements.searchStageInner.style.transform = `rotateY(${startAngle}deg)`;
+    elements.searchStageInner.getBoundingClientRect();
+  }
   state.searchFlipFrame = window.requestAnimationFrame(() => {
     state.searchFlipFrame = null;
+    elements.searchStage?.classList.remove("is-preparing-flip");
     if (elements.searchStageInner) {
       elements.searchStageInner.style.transform = `rotateY(${state.searchStageAngle}deg)`;
     }
@@ -6689,7 +6682,6 @@ elements.followUpGrid?.addEventListener("click", async (event) => {
   if (!uid) {
     return;
   }
-  event.preventDefault();
   state.followBrowseSelectedUid = uid;
   if (elements.followSearchQuery) {
     elements.followSearchQuery.value = "";

--- a/static/remote.js
+++ b/static/remote.js
@@ -1172,20 +1172,6 @@ function renderFollowBrowse() {
         count.className = "follow-up-count";
         count.textContent = `${Number(owner.count || 0)} 首`;
 
-        button.addEventListener("click", async (event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          const uid = String(button.dataset.uid || "").trim();
-          if (!uid) {
-            return;
-          }
-          state.followBrowseSelectedUid = uid;
-          if (elements.followSearchQuery) {
-            elements.followSearchQuery.value = "";
-          }
-          await loadFollowBrowse({ uid, query: "" });
-        });
-
         button.append(name, count);
         elements.followUpGrid.appendChild(button);
       });
@@ -2702,7 +2688,6 @@ elements.followUpGrid?.addEventListener("click", async (event) => {
   if (!uid) {
     return;
   }
-  event.preventDefault();
   state.followBrowseSelectedUid = uid;
   if (elements.followSearchQuery) {
     elements.followSearchQuery.value = "";

--- a/static/remote.js
+++ b/static/remote.js
@@ -1172,6 +1172,20 @@ function renderFollowBrowse() {
         count.className = "follow-up-count";
         count.textContent = `${Number(owner.count || 0)} 首`;
 
+        button.addEventListener("click", async (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          const uid = String(button.dataset.uid || "").trim();
+          if (!uid) {
+            return;
+          }
+          state.followBrowseSelectedUid = uid;
+          if (elements.followSearchQuery) {
+            elements.followSearchQuery.value = "";
+          }
+          await loadFollowBrowse({ uid, query: "" });
+        });
+
         button.append(name, count);
         elements.followUpGrid.appendChild(button);
       });
@@ -2688,6 +2702,7 @@ elements.followUpGrid?.addEventListener("click", async (event) => {
   if (!uid) {
     return;
   }
+  event.preventDefault();
   state.followBrowseSelectedUid = uid;
   if (elements.followSearchQuery) {
     elements.followSearchQuery.value = "";

--- a/static/styles.css
+++ b/static/styles.css
@@ -3620,12 +3620,22 @@ select:disabled {
   transition: transform 420ms ease;
 }
 
+.search-stage:not(.is-flipping) .search-stage-inner,
+.search-stage.is-preparing-flip .search-stage-inner {
+  transition: none;
+}
+
 .search-stage.is-cookie-view .search-stage-inner {
   transform: rotateY(-120deg);
 }
 
 .search-stage.is-lark-view .search-stage-inner {
   transform: rotateY(120deg);
+}
+
+.search-stage.is-cookie-view:not(.is-flipping) .search-stage-inner,
+.search-stage.is-lark-view:not(.is-flipping) .search-stage-inner {
+  transform: none !important;
 }
 
 .search-face {
@@ -3654,6 +3664,11 @@ select:disabled {
   pointer-events: none;
   grid-template-rows: auto auto minmax(0, 1fr);
   transform: rotateY(240deg);
+}
+
+.search-stage.is-cookie-view:not(.is-flipping) .search-face-back,
+.search-stage.is-lark-view:not(.is-flipping) .search-face-lark {
+  transform: none;
 }
 
 .search-stage.is-cookie-view .search-face-front {

--- a/tests/test_lark_pool_client.py
+++ b/tests/test_lark_pool_client.py
@@ -1,7 +1,4 @@
-﻿import json
-import uuid
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 import bilikara.lark_pool_client as lark_pool
@@ -243,133 +240,31 @@ class LarkPoolClientTest(unittest.TestCase):
             self.assertEqual(lark_pool.search_lark_pool_table("karaoke", 2), [])
             self.assertEqual(post_count, 1)
 
-    def test_append_lark_pool_entries_skips_locally_synced_bvids(self):
-        temp_root = Path.cwd() / ".tmp"
-        temp_root.mkdir(exist_ok=True)
-        sync_file = temp_root / f"lark_pool_sync_{uuid.uuid4().hex}.json"
-        sync_file.write_text(json.dumps({"bvids": ["BV1OLD000001"]}), encoding="utf-8")
-        posted_records = []
+    def test_append_lark_pool_entries_posts_to_cloudflare_only(self):
+        requests = []
 
-        def fake_post(url, payload, *, token=None, timeout=12.0):
-            self.assertIn("/batch_create", url)
-            posted_records.extend(payload["records"])
-            return {"code": 0, "data": {}}
+        def fake_cloudflare(method, path, payload=None, *, timeout=12.0):
+            requests.append((method, path, payload, timeout))
+            return {"attempted": 1, "added": 1, "skipped_existing": 0, "feishu_queued": 1}
 
-        with (
-            patch.object(lark_pool, "_SYNC_FILE", sync_file),
-            patch.object(lark_pool.cfg, "DATA_DIR", temp_root),
-            patch.object(lark_pool, "_tenant_access_token", return_value="token"),
-            patch.object(
-                lark_pool,
-                "_active_tables",
-                return_value=[{"index": 1, "app_token": "app", "table_id": "table", "count": 1}],
-            ),
-            patch.object(lark_pool, "_post_json", side_effect=fake_post),
-        ):
-            result = lark_pool.append_lark_pool_entries_to_lark(
-                [
-                    {"bvid": "BV1OLD000001", "title": "old", "url": "https://www.bilibili.com/video/BV1OLD000001"},
-                    {"bvid": "BV1NEW000001", "title": "new", "url": "https://www.bilibili.com/video/BV1NEW000001"},
-                ]
-            )
-
-        self.assertEqual(result["added"], 1)
-        self.assertEqual(posted_records[0]["fields"]["bvid"], "BV1NEW000001")
-        payload = json.loads(sync_file.read_text(encoding="utf-8"))
-        self.assertIn("BV1NEW000001", payload["bvids"])
-
-    def test_append_lark_pool_entries_skips_invalid_video_titles(self):
-        temp_root = Path.cwd() / ".tmp"
-        temp_root.mkdir(exist_ok=True)
-        sync_file = temp_root / f"lark_pool_sync_invalid_{uuid.uuid4().hex}.json"
-        posted_records = []
-
-        def fake_post(url, payload, *, token=None, timeout=12.0):
-            posted_records.extend(payload["records"])
-            return {"code": 0, "data": {}}
-
-        with (
-            patch.object(lark_pool, "_SYNC_FILE", sync_file),
-            patch.object(lark_pool.cfg, "DATA_DIR", temp_root),
-            patch.object(lark_pool, "_tenant_access_token", return_value="token"),
-            patch.object(
-                lark_pool,
-                "_active_tables",
-                return_value=[{"index": 1, "app_token": "app", "table_id": "table", "count": 1}],
-            ),
-            patch.object(lark_pool, "_post_json", side_effect=fake_post),
-        ):
-            result = lark_pool.append_lark_pool_entries_to_lark(
+        with patch.object(lark_pool, "_cloudflare_json", side_effect=fake_cloudflare):
+            result = lark_pool.append_lark_pool_entries(
                 [
                     {
-                        "bvid": "BV1DEAD0001",
-                        "title": next(iter(lark_pool._INVALID_VIDEO_TITLES)),
-                        "url": "https://www.bilibili.com/video/BV1DEAD0001",
-                    },
-                    {"bvid": "BV1ALIVE0000", "title": "alive", "url": "https://www.bilibili.com/video/BV1ALIVE0000"},
-                ]
-            )
-
-        self.assertEqual(result["attempted"], 1)
-        self.assertEqual(result["added"], 1)
-        self.assertEqual([record["fields"]["bvid"] for record in posted_records], ["BV1ALIVE0000"])
-        payload = json.loads(sync_file.read_text(encoding="utf-8"))
-        self.assertNotIn("BV1DEAD0001", payload["bvids"])
-
-    def test_append_lark_pool_entries_to_lark_preserves_tags_and_can_target_table(self):
-        temp_root = Path.cwd() / ".tmp"
-        temp_root.mkdir(exist_ok=True)
-        sync_file = temp_root / f"lark_pool_sync_tags_{uuid.uuid4().hex}.json"
-        posted_urls = []
-        posted_records = []
-
-        def fake_post(url, payload, *, token=None, timeout=12.0):
-            posted_urls.append(url)
-            posted_records.extend(payload["records"])
-            return {"code": 0, "data": {}}
-
-        with (
-            patch.object(lark_pool, "_SYNC_FILE", sync_file),
-            patch.object(lark_pool.cfg, "DATA_DIR", temp_root),
-            patch.object(lark_pool, "_tenant_access_token", return_value="token"),
-            patch.object(
-                lark_pool,
-                "_active_tables",
-                return_value=[
-                    {"index": 1, "app_token": "app", "table_id": "table1", "count": 0},
-                    {
-                        "index": 2,
-                        "app_token": "app",
-                        "table_id": "table2",
-                        "count": 0,
-                        "field_names": sorted(lark_pool._WRITE_FIELD_NAMES),
-                        "field_types": {"tag_status": 2, "mid": 2},
-                    },
-                ],
-            ),
-            patch.object(lark_pool, "_post_json", side_effect=fake_post),
-        ):
-            result = lark_pool.append_lark_pool_entries_to_lark(
-                [
-                    {
-                        "bvid": "BV1TAGGED000",
-                        "title": "tagged",
-                        "url": "https://www.bilibili.com/video/BV1TAGGED000",
-                        "tag_1": "work",
-                        "tag_4": "music",
-                        "tag_status": "1",
+                        "bvid": "BV1NEW000001",
+                        "title": "new",
+                        "url": "https://www.bilibili.com/video/BV1NEW000001",
                     }
-                ],
-                only_table_index=2,
-                use_sync_cache=False,
+                ]
             )
 
         self.assertEqual(result["added"], 1)
-        self.assertIn("table2", posted_urls[0])
-        self.assertEqual(posted_records[0]["fields"]["tag_1"], "work")
-        self.assertEqual(posted_records[0]["fields"]["tag_4"], "music")
-        self.assertEqual(posted_records[0]["fields"]["tag_status"], 1)
-        self.assertNotIn("mid", posted_records[0]["fields"])
+        self.assertEqual(len(requests), 1)
+        method, path, payload, timeout = requests[0]
+        self.assertEqual(method, "POST")
+        self.assertEqual(path, "/batch-add")
+        self.assertEqual(timeout, 20)
+        self.assertEqual(payload["records"][0]["bvid"], "BV1NEW000001")
 
 
 if __name__ == "__main__":

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -1533,7 +1533,7 @@ class BilibiliParserTest(unittest.TestCase):
         self.assertEqual([item["uid"] for item in summary["uids"]], ["2"])
         self.assertEqual(summary["errors"], [{"uid": "1", "error": "uid failed"}])
 
-    def test_startup_gatcha_refresh_skips_default_uids_for_lark_upload(self):
+    def test_startup_gatcha_refresh_uploads_default_uids_to_cloudflare_append_path(self):
         class FakeThread:
             def __init__(self, *, target, daemon=None, name=None):
                 self.target = target
@@ -1563,9 +1563,9 @@ class BilibiliParserTest(unittest.TestCase):
             )
 
         uploaded_entries = append_lark.call_args.args[0]
-        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVUSER"])
+        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVDEFAULT", "BVUSER"])
 
-    def test_startup_gatcha_refresh_skips_cached_default_uids_for_lark_upload(self):
+    def test_startup_gatcha_refresh_uploads_cached_default_uids_to_cloudflare_append_path(self):
         class FakeThread:
             def __init__(self, *, target, daemon=None, name=None):
                 self.target = target
@@ -1595,9 +1595,9 @@ class BilibiliParserTest(unittest.TestCase):
             )
 
         uploaded_entries = append_lark.call_args.args[0]
-        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVUSER"])
+        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVDEFAULT", "BVUSER"])
 
-    def test_manual_gatcha_refresh_skips_default_uids_for_lark_upload_by_default(self):
+    def test_manual_gatcha_refresh_uploads_default_uids_to_cloudflare_append_path_by_default(self):
         class FakeThread:
             def __init__(self, *, target, daemon=None, name=None):
                 self.target = target
@@ -1622,7 +1622,7 @@ class BilibiliParserTest(unittest.TestCase):
             self.assertTrue(bilibili_module.refresh_gatcha_cache_in_background(use_global_lock=False))
 
         uploaded_entries = append_lark.call_args.args[0]
-        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVUSER"])
+        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVDEFAULT", "BVUSER"])
 
     @patch("bilikara.bilibili.request_json")
     def test_fetch_video_item(self, mock_request_json):

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -1533,7 +1533,7 @@ class BilibiliParserTest(unittest.TestCase):
         self.assertEqual([item["uid"] for item in summary["uids"]], ["2"])
         self.assertEqual(summary["errors"], [{"uid": "1", "error": "uid failed"}])
 
-    def test_startup_gatcha_refresh_skips_uncached_default_uids_for_lark_upload(self):
+    def test_startup_gatcha_refresh_skips_default_uids_for_lark_upload(self):
         class FakeThread:
             def __init__(self, *, target, daemon=None, name=None):
                 self.target = target
@@ -1552,7 +1552,6 @@ class BilibiliParserTest(unittest.TestCase):
         with (
             patch.object(bilibili_module, "refresh_gatcha_cache", return_value=cache_payload),
             patch.object(bilibili_module, "_default_gatcha_uids", return_value=["1"]),
-            patch.object(bilibili_module, "_load_gatcha_cache", return_value={"uids": {}}),
             patch.object(bilibili_module, "_append_lark_pool_entries_async") as append_lark,
             patch.object(bilibili_module.threading, "Thread", FakeThread),
         ):
@@ -1566,7 +1565,7 @@ class BilibiliParserTest(unittest.TestCase):
         uploaded_entries = append_lark.call_args.args[0]
         self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVUSER"])
 
-    def test_startup_gatcha_refresh_uploads_cached_default_uids_to_lark(self):
+    def test_startup_gatcha_refresh_skips_cached_default_uids_for_lark_upload(self):
         class FakeThread:
             def __init__(self, *, target, daemon=None, name=None):
                 self.target = target
@@ -1585,11 +1584,6 @@ class BilibiliParserTest(unittest.TestCase):
         with (
             patch.object(bilibili_module, "refresh_gatcha_cache", return_value=cache_payload),
             patch.object(bilibili_module, "_default_gatcha_uids", return_value=["1"]),
-            patch.object(
-                bilibili_module,
-                "_load_gatcha_cache",
-                return_value={"uids": {"1": [{"bvid": "BVCACHED"}]}},
-            ),
             patch.object(bilibili_module, "_append_lark_pool_entries_async") as append_lark,
             patch.object(bilibili_module.threading, "Thread", FakeThread),
         ):
@@ -1601,7 +1595,34 @@ class BilibiliParserTest(unittest.TestCase):
             )
 
         uploaded_entries = append_lark.call_args.args[0]
-        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVDEFAULT", "BVUSER"])
+        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVUSER"])
+
+    def test_manual_gatcha_refresh_skips_default_uids_for_lark_upload_by_default(self):
+        class FakeThread:
+            def __init__(self, *, target, daemon=None, name=None):
+                self.target = target
+
+            def start(self):
+                self.target()
+
+        cache_payload = {
+            "uids": {
+                "1": [{"bvid": "BVDEFAULT", "title": "default", "url": "https://www.bilibili.com/video/BVDEFAULT"}],
+                "2": [{"bvid": "BVUSER", "title": "user", "url": "https://www.bilibili.com/video/BVUSER"}],
+            },
+            "profiles": {},
+        }
+
+        with (
+            patch.object(bilibili_module, "refresh_gatcha_cache", return_value=cache_payload),
+            patch.object(bilibili_module, "_default_gatcha_uids", return_value=["1"]),
+            patch.object(bilibili_module, "_append_lark_pool_entries_async") as append_lark,
+            patch.object(bilibili_module.threading, "Thread", FakeThread),
+        ):
+            self.assertTrue(bilibili_module.refresh_gatcha_cache_in_background(use_global_lock=False))
+
+        uploaded_entries = append_lark.call_args.args[0]
+        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVUSER"])
 
     @patch("bilikara.bilibili.request_json")
     def test_fetch_video_item(self, mock_request_json):


### PR DESCRIPTION
1.手动删除了之前codex大人非要瞒着我留下来的飞书表格上传逻辑
2.删除了codex大人用来禁止向cloudflare上传的飞书参数
3.修复了搜索因为3重翻页带来的hitbox问题，会导致up主:"VZRXS"那一列在关注列表无法点击也无法hover的问题。

现在所有新增稿件/自动更新/手动拉取都会上传cloudflare由workers决定是否添加D1
添加完D1再由workers统一打包送到飞书
鉴于飞书现在只有fallback和可视化功能，访问者仅限人在国外的开发者团队，迁移到上限极高的googlesheets或许是更好的选择