### PR TITLE
ci: mark preview tags as prereleases

### DIFF
--- a/.github/workflows/ci-bundle.yml
+++ b/.github/workflows/ci-bundle.yml
@@ -214,10 +214,11 @@ jobs:
 
       - name: Upload bundle to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ steps.bundle-name.outputs.archive_name }}
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-preview.') }}
 
   mirror-release-r2:
     name: Mirror Release To R2


### PR DESCRIPTION
## Summary

- Upgrade `softprops/action-gh-release` from v2 to v3.
- Mark tags containing `-preview.` as GitHub prereleases.
- Preserve normal stable-release behavior for tags such as `v0.7.0`.

## Scope

This changes future release metadata only.

It does not move or recreate `v0.7.0-preview.1`, and it does not re-upload the existing release assets.
