### PR TITLE
feat: migrate download candidate planning to Rust

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,8 @@ When completing a task, agents must report:
 | `src/media_page_selection.rs` | Pure matching and ranking algorithm for video pages. |
 | `src/audio_binding.rs` | Dual-audio and instrumental variant pairing policy. |
 | `src/download_candidate_planning.rs` | Pure updater download URL construction, source labeling, ordering, and deduplication policy. |
+| `src/media_download_candidate_planning.rs` | Pure DASH and preferred-audio primary/backup URL flattening, identity, and ordering policy. |
+| `src/tool_download_candidate_planning.rs` | Pure BBDown, yt-dlp, and aria2c asset fallback construction, labeling, ordering, and deduplication policy. |
 | `src/release_selection.rs` | Semantic version sorting and release filtering rules. |
 | `src/asset_selection.rs` | Update package scoring by platform and architecture. |
 | `src/ffi.rs` | FFI wrapper utilities, memory safety helpers, panic containment. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ When completing a task, agents must report:
 | `src/lib.rs` | Domain API exports (`rlib`) and FFI C-ABI entrypoints (`cdylib`). |
 | `src/media_page_selection.rs` | Pure matching and ranking algorithm for video pages. |
 | `src/audio_binding.rs` | Dual-audio and instrumental variant pairing policy. |
+| `src/download_candidate_planning.rs` | Pure updater download URL construction, source labeling, ordering, and deduplication policy. |
 | `src/release_selection.rs` | Semantic version sorting and release filtering rules. |
 | `src/asset_selection.rs` | Update package scoring by platform and architecture. |
 | `src/ffi.rs` | FFI wrapper utilities, memory safety helpers, panic containment. |

--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -48,6 +48,7 @@ from .config import (
     YTDLP_RELEASE_API,
 )
 from .bilibili import BilibiliError, effective_bilibili_cookie, fetch_dash_playurl
+from . import rust_backend
 from .store import PlaylistStore
 
 MEDIA_EXTENSIONS = {".mp4", ".mkv", ".webm", ".flv", ".m4v"}
@@ -2369,8 +2370,7 @@ class CacheManager:
                 preferred_audio = dolby_audio
 
             if preferred_audio:
-                audio_urls = [preferred_audio["url"]]
-                audio_urls.extend(preferred_audio.get("backup_urls") or [])
+                audio_urls = self._preferred_audio_urls(preferred_audio)
             else:
                 audio_urls = self._dash_stream_urls(page_dash_streams, "audio")
             if not audio_urls:
@@ -2578,7 +2578,7 @@ class CacheManager:
         return result_paths
 
     @staticmethod
-    def _dash_stream_urls(dash_streams: dict, stream_kind: str) -> list[str]:
+    def _py_dash_stream_urls(dash_streams: dict, stream_kind: str) -> list[str]:
         if stream_kind == "video":
             streams = dash_streams.get("video") or []
             urls = []
@@ -2604,6 +2604,62 @@ class CacheManager:
                         urls.append(backup_url)
             return urls
         return []
+
+    @staticmethod
+    def _dash_stream_urls(dash_streams: dict, stream_kind: str) -> list[str]:
+        if stream_kind not in {"video", "audio"}:
+            return CacheManager._py_dash_stream_urls(dash_streams, stream_kind)
+        streams = dash_streams.get(stream_kind) or []
+        request = {
+            "schema_version": 1,
+            "mode": "dash_streams",
+            "stream_kind": stream_kind,
+            "streams": [
+                {
+                    "original_index": index,
+                    "primary_url": str(stream.get("url") or ""),
+                    "backup_urls": [
+                        str(backup) for backup in (stream.get("backup_urls") or [])
+                    ],
+                }
+                for index, stream in enumerate(streams)
+            ],
+        }
+        completed, response = rust_backend.try_plan_media_download_candidates(request)
+        if completed and response is not None:
+            return [candidate["url"] for candidate in response["candidates"]]
+        return CacheManager._py_dash_stream_urls(dash_streams, stream_kind)
+
+    @staticmethod
+    def _py_preferred_audio_urls(preferred_audio: dict) -> list[str]:
+        urls = [preferred_audio["url"]]
+        urls.extend(preferred_audio.get("backup_urls") or [])
+        return urls
+
+    @staticmethod
+    def _preferred_audio_urls(preferred_audio: dict) -> list[str]:
+        primary_url = preferred_audio["url"]
+        backup_urls = list(preferred_audio.get("backup_urls") or [])
+        if not isinstance(primary_url, str) or not all(
+            isinstance(url, str) for url in backup_urls
+        ):
+            return CacheManager._py_preferred_audio_urls(preferred_audio)
+        request = {
+            "schema_version": 1,
+            "mode": "preferred_audio",
+            "stream_kind": "audio",
+            "streams": [
+                {
+                    "original_index": 0,
+                    "primary_url": primary_url,
+                    "backup_urls": backup_urls,
+                }
+            ],
+        }
+        completed, response = rust_backend.try_plan_media_download_candidates(request)
+        if completed and response is not None:
+            return [candidate["url"] for candidate in response["candidates"]]
+        return CacheManager._py_preferred_audio_urls(preferred_audio)
 
     @staticmethod
     def _safe_url_summary(url: object) -> str:
@@ -4450,7 +4506,7 @@ class CacheManager:
 
             try:
                 # 1. Download to temporary archive
-                self._download_tool_asset(asset, tmp_archive)
+                self._download_tool_asset(asset, tmp_archive, tool="bbdown")
 
                 # 2. Validate downloaded archive
                 archive_name = asset["name"]
@@ -4635,17 +4691,17 @@ class CacheManager:
         YTDLP_DIR.mkdir(parents=True, exist_ok=True)
         name = str(asset.get("name") or target_path.name)
         download_url = str(asset.get("browser_download_url") or "")
-        if not download_url and not self._tool_fallback_url(name):
+        if not download_url and not self._tool_fallback_url(name, tool="ytdlp"):
             raise RuntimeError("yt-dlp release asset missing download URL")
         if name.lower().endswith((".zip", ".tar.gz", ".tgz")):
             archive_path = YTDLP_DIR / name
-            self._download_tool_asset(asset, archive_path)
+            self._download_tool_asset(asset, archive_path, tool="ytdlp")
             try:
                 self._extract_tool_binary_from_archive(archive_path, YTDLP_DIR, target_path.name)
             finally:
                 archive_path.unlink(missing_ok=True)
         else:
-            self._download_tool_asset(asset, target_path)
+            self._download_tool_asset(asset, target_path, tool="ytdlp")
 
     def _install_aria2c(self, target_path: Path) -> None:
         system, arch = self._current_platform_tokens()
@@ -4663,10 +4719,10 @@ class CacheManager:
         ARIA2C_DIR.mkdir(parents=True, exist_ok=True)
         name = str(asset.get("name") or "aria2c.zip")
         download_url = str(asset.get("browser_download_url") or "")
-        if not download_url and not self._tool_fallback_url(name):
+        if not download_url and not self._tool_fallback_url(name, tool="aria2c"):
             raise RuntimeError("aria2 release asset missing download URL")
         archive_path = ARIA2C_DIR / name
-        self._download_tool_asset(asset, archive_path)
+        self._download_tool_asset(asset, archive_path, tool="aria2c")
         try:
             self._extract_tool_binary_from_archive(archive_path, ARIA2C_DIR, target_path.name)
         finally:
@@ -4862,28 +4918,98 @@ class CacheManager:
             return json.loads(response.read().decode("utf-8"))
 
     @staticmethod
-    def _fallback_tool_asset(name: str) -> dict[str, str]:
-        if not TOOL_ASSET_BASE_URL:
+    def _py_tool_fallback_url(name: str, base_url: str) -> str:
+        if not base_url or not name:
+            return ""
+        return f"{base_url}/{urllib.parse.quote(name)}"
+
+    @staticmethod
+    def _py_fallback_tool_asset(name: str, base_url: str) -> dict[str, str]:
+        if not base_url:
             raise RuntimeError("tool asset fallback base URL is not configured")
         return {
             "name": name,
-            "browser_download_url": f"{TOOL_ASSET_BASE_URL}/{urllib.parse.quote(name)}",
+            "browser_download_url": CacheManager._py_tool_fallback_url(
+                name, base_url
+            ),
         }
 
     @staticmethod
-    def _tool_fallback_url(name: str) -> str:
-        if not TOOL_ASSET_BASE_URL or not name:
-            return ""
-        return f"{TOOL_ASSET_BASE_URL}/{urllib.parse.quote(name)}"
-
-    def _download_tool_asset(self, asset: dict, target_path: Path) -> None:
-        name = str(asset.get("name") or target_path.name)
+    def _py_tool_download_candidates(
+        asset: dict,
+        target_name: str,
+        fallback_base_urls: list[str],
+    ) -> list[str]:
+        name = str(asset.get("name") or target_name)
         primary_url = str(asset.get("browser_download_url") or "")
-        fallback_url = self._tool_fallback_url(name)
+        fallback_urls = [
+            CacheManager._py_tool_fallback_url(name, base_url)
+            for base_url in fallback_base_urls
+        ]
         urls: list[str] = []
-        for url in (primary_url, fallback_url):
+        for url in [primary_url, *fallback_urls]:
             if url and url not in urls:
                 urls.append(url)
+        return urls
+
+    @staticmethod
+    def _plan_tool_download_candidates(
+        tool: str,
+        asset: dict,
+        target_name: str,
+        fallback_base_urls: list[str],
+    ) -> list[str]:
+        name = str(asset.get("name") or target_name)
+        primary_url = str(asset.get("browser_download_url") or "")
+        request = {
+            "schema_version": 1,
+            "tool": tool,
+            "asset": {
+                "mode": "supplied",
+                "name": name,
+                "primary_url": primary_url,
+            },
+            "fallback_bases": [
+                {"original_index": index, "base_url": base_url}
+                for index, base_url in enumerate(fallback_base_urls)
+            ],
+        }
+        completed, response = rust_backend.try_plan_tool_download_candidates(request)
+        if completed and response is not None:
+            return [candidate["url"] for candidate in response["candidates"]]
+        return CacheManager._py_tool_download_candidates(
+            asset, target_name, fallback_base_urls
+        )
+
+    @staticmethod
+    def _tool_fallback_url(name: str, *, tool: str = "bbdown") -> str:
+        urls = CacheManager._plan_tool_download_candidates(
+            tool,
+            {"name": name, "browser_download_url": ""},
+            name,
+            [TOOL_ASSET_BASE_URL],
+        )
+        return urls[0] if urls else ""
+
+    @staticmethod
+    def _fallback_tool_asset(name: str) -> dict[str, str]:
+        urls = CacheManager._plan_tool_download_candidates(
+            "bbdown",
+            {"name": name, "browser_download_url": ""},
+            name,
+            [TOOL_ASSET_BASE_URL],
+        )
+        if not urls:
+            return CacheManager._py_fallback_tool_asset(name, TOOL_ASSET_BASE_URL)
+        return {"name": name, "browser_download_url": urls[0]}
+
+    def _download_tool_asset(
+        self, asset: dict, target_path: Path, *, tool: str = "bbdown"
+    ) -> None:
+        name = str(asset.get("name") or target_path.name)
+        urls = self._plan_tool_download_candidates(
+            tool, asset, target_path.name, [TOOL_ASSET_BASE_URL]
+        )
         if not urls:
             raise RuntimeError(f"tool asset {name} missing download URL")
 
@@ -4924,6 +5050,15 @@ class CacheManager:
 
     def _bbdown_fallback_asset(self) -> dict[str, str]:
         system, arch = self._current_platform_tokens()
+        return self._default_tool_fallback_asset("bbdown", system, arch)
+
+    @staticmethod
+    def _py_default_tool_fallback_asset(
+        tool: str,
+        system: str,
+        arch: str,
+        fallback_base_url: str,
+    ) -> dict[str, str]:
         asset_names = {
             ("windows", "x64"): "BBDown_1.6.3_20240814_win-x64.zip",
             ("windows", "x86"): "BBDown_1.6.3_20240814_win-x64.zip",
@@ -4933,27 +5068,73 @@ class CacheManager:
             ("linux", "x64"): "BBDown_1.6.3_20240814_linux-x64.zip",
             ("linux", "arm64"): "BBDown_1.6.3_20240814_linux-arm64.zip",
         }
-        name = asset_names.get((system, arch))
-        if not name:
-            raise RuntimeError(f"no BBDown tool fallback asset for {system}/{arch}")
-        return self._fallback_tool_asset(name)
+        if tool == "bbdown":
+            name = asset_names.get((system, arch))
+            if not name:
+                raise RuntimeError(f"no BBDown tool fallback asset for {system}/{arch}")
+            if not fallback_base_url:
+                raise RuntimeError("tool asset fallback base URL is not configured")
+            url = CacheManager._py_tool_fallback_url(name, fallback_base_url)
+        elif tool == "ytdlp":
+            if system == "windows":
+                if arch == "arm64":
+                    name = "yt-dlp_arm64.exe"
+                elif arch == "x86":
+                    name = "yt-dlp_x86.exe"
+                else:
+                    name = "yt-dlp.exe"
+            elif system == "darwin":
+                name = "yt-dlp_macos"
+            elif system == "linux":
+                name = "yt-dlp_linux"
+            else:
+                name = "yt-dlp"
+            if not fallback_base_url:
+                raise RuntimeError("tool asset fallback base URL is not configured")
+            url = CacheManager._py_tool_fallback_url(name, fallback_base_url)
+        elif tool == "aria2c":
+            if system != "windows":
+                raise RuntimeError(f"no aria2c fallback asset for {system}/{arch}")
+            name = CacheManager._aria2_windows_fallback_asset_name(arch)
+            url = (
+                "https://github.com/aria2/aria2/releases/download/release-1.37.0/"
+                f"{urllib.parse.quote(name)}"
+            )
+        else:
+            raise RuntimeError(f"unknown tool candidate planner: {tool}")
+        return {"name": name, "browser_download_url": url}
+
+    @staticmethod
+    def _default_tool_fallback_asset(
+        tool: str,
+        system: str,
+        arch: str,
+    ) -> dict[str, str]:
+        request = {
+            "schema_version": 1,
+            "tool": tool,
+            "asset": {
+                "mode": "default_for_target",
+                "platform": system,
+                "arch": arch,
+            },
+            "fallback_bases": [
+                {"original_index": 0, "base_url": TOOL_ASSET_BASE_URL}
+            ],
+        }
+        completed, response = rust_backend.try_plan_tool_download_candidates(request)
+        if completed and response is not None and response["candidates"]:
+            return {
+                "name": response["asset_name"],
+                "browser_download_url": response["candidates"][0]["url"],
+            }
+        return CacheManager._py_default_tool_fallback_asset(
+            tool, system, arch, TOOL_ASSET_BASE_URL
+        )
 
     def _ytdlp_fallback_asset(self) -> dict[str, str]:
         system, arch = self._current_platform_tokens()
-        if system == "windows":
-            if arch == "arm64":
-                name = "yt-dlp_arm64.exe"
-            elif arch == "x86":
-                name = "yt-dlp_x86.exe"
-            else:
-                name = "yt-dlp.exe"
-        elif system == "darwin":
-            name = "yt-dlp_macos"
-        elif system == "linux":
-            name = "yt-dlp_linux"
-        else:
-            name = "yt-dlp"
-        return self._fallback_tool_asset(name)
+        return self._default_tool_fallback_asset("ytdlp", system, arch)
 
     @staticmethod
     def _aria2_windows_fallback_asset_name(arch: str) -> str:
@@ -4973,13 +5154,7 @@ class CacheManager:
 
     def _aria2_fallback_asset(self) -> dict[str, str]:
         system, arch = self._current_platform_tokens()
-        if system != "windows":
-            raise RuntimeError(f"no aria2c fallback asset for {system}/{arch}")
-        name = self._aria2_windows_fallback_asset_name(arch)
-        return {
-            "name": name,
-            "browser_download_url": f"https://github.com/aria2/aria2/releases/download/release-1.37.0/{urllib.parse.quote(name)}",
-        }
+        return self._default_tool_fallback_asset("aria2c", system, arch)
 
     def _select_ytdlp_asset(self, release: dict) -> dict:
         system, arch = self._current_platform_tokens()

--- a/bilikara/rust_backend.py
+++ b/bilikara/rust_backend.py
@@ -35,9 +35,14 @@ PHASE2_CAPABILITIES = (
     "select_media_pages",
     "decide_audio_binding",
     "plan_update_download_candidates",
+    "plan_media_download_candidates",
+    "plan_tool_download_candidates",
 )
 
 MAX_UPDATE_DOWNLOAD_CANDIDATE_INPUTS = 4096
+MAX_MEDIA_DOWNLOAD_STREAM_INPUTS = 4096
+MAX_MEDIA_DOWNLOAD_CANDIDATES = 16384
+MAX_TOOL_FALLBACK_BASES = 256
 
 
 def _rust_library_name() -> str:
@@ -158,6 +163,16 @@ _SYMBOLS = {
     ),
     "plan_update_download_candidates": (
         "rust_plan_update_download_candidates",
+        [ctypes.c_char_p],
+        ctypes.c_void_p,
+    ),
+    "plan_media_download_candidates": (
+        "rust_plan_media_download_candidates",
+        [ctypes.c_char_p],
+        ctypes.c_void_p,
+    ),
+    "plan_tool_download_candidates": (
+        "rust_plan_tool_download_candidates",
         [ctypes.c_char_p],
         ctypes.c_void_p,
     ),
@@ -1148,6 +1163,456 @@ def try_plan_update_download_candidates(
             return False, None
         response = json.loads(response_json)
         if not _valid_update_download_plan_response(response, candidates, proxy):
+            return False, None
+        return True, response
+    except Exception:
+        return False, None
+
+
+def _media_download_plan_request(
+    request: object,
+) -> tuple[str, str, list[dict[str, object]]] | None:
+    if not isinstance(request, dict) or set(request) != {
+        "schema_version",
+        "mode",
+        "stream_kind",
+        "streams",
+    }:
+        return None
+    schema_version = request.get("schema_version")
+    mode = request.get("mode")
+    stream_kind = request.get("stream_kind")
+    streams = request.get("streams")
+    if (
+        isinstance(schema_version, bool)
+        or schema_version != 1
+        or not isinstance(mode, str)
+        or mode not in {"dash_streams", "preferred_audio"}
+        or not isinstance(stream_kind, str)
+        or stream_kind not in {"video", "audio"}
+        or not isinstance(streams, list)
+        or len(streams) > MAX_MEDIA_DOWNLOAD_STREAM_INPUTS
+        or (mode == "preferred_audio" and (stream_kind != "audio" or len(streams) > 1))
+    ):
+        return None
+
+    validated: list[dict[str, object]] = []
+    previous_index: int | None = None
+    candidate_count = 0
+    max_index = 2 ** (ctypes.sizeof(ctypes.c_size_t) * 8) - 1
+    for stream in streams:
+        if not isinstance(stream, dict) or set(stream) != {
+            "original_index",
+            "primary_url",
+            "backup_urls",
+        }:
+            return None
+        original_index = stream.get("original_index")
+        primary_url = stream.get("primary_url")
+        backup_urls = stream.get("backup_urls")
+        if (
+            isinstance(original_index, bool)
+            or not isinstance(original_index, int)
+            or original_index < 0
+            or original_index > max_index
+            or (previous_index is not None and original_index <= previous_index)
+            or not isinstance(primary_url, str)
+            or not isinstance(backup_urls, list)
+            or not all(isinstance(url, str) for url in backup_urls)
+        ):
+            return None
+        candidate_count += 1 + len(backup_urls)
+        if candidate_count > MAX_MEDIA_DOWNLOAD_CANDIDATES:
+            return None
+        previous_index = original_index
+        validated.append(
+            {
+                "original_index": original_index,
+                "primary_url": primary_url,
+                "backup_urls": list(backup_urls),
+            }
+        )
+    return str(mode), str(stream_kind), validated
+
+
+def _expected_media_download_candidates(
+    mode: str,
+    streams: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    expected: list[dict[str, object]] = []
+    for stream in streams:
+        values = [("primary", None, stream["primary_url"])]
+        values.extend(
+            ("backup", backup_index, url)
+            for backup_index, url in enumerate(stream["backup_urls"])
+        )
+        for source, backup_index, raw_url in values:
+            url = str(raw_url).strip() if mode == "dash_streams" else str(raw_url)
+            if mode == "dash_streams" and not url:
+                continue
+            expected.append(
+                {
+                    "stream_index": stream["original_index"],
+                    "source": source,
+                    "backup_index": backup_index,
+                    "url": url,
+                }
+            )
+    return expected
+
+
+def _valid_media_download_plan_response(
+    response: object,
+    mode: str,
+    streams: list[dict[str, object]],
+) -> bool:
+    if not isinstance(response, dict) or set(response) != {
+        "schema_version",
+        "status",
+        "candidates",
+    }:
+        return False
+    schema_version = response.get("schema_version")
+    status = response.get("status")
+    candidates = response.get("candidates")
+    if (
+        isinstance(schema_version, bool)
+        or schema_version != 1
+        or not isinstance(status, str)
+        or status not in {"planned", "empty"}
+        or not isinstance(candidates, list)
+        or len(candidates) > sum(1 + len(stream["backup_urls"]) for stream in streams)
+    ):
+        return False
+
+    request_by_index = {stream["original_index"]: stream for stream in streams}
+    parsed: list[dict[str, object]] = []
+    for candidate in candidates:
+        if not isinstance(candidate, dict) or set(candidate) != {
+            "stream_index",
+            "source",
+            "backup_index",
+            "url",
+        }:
+            return False
+        stream_index = candidate.get("stream_index")
+        source = candidate.get("source")
+        backup_index = candidate.get("backup_index")
+        url = candidate.get("url")
+        if (
+            isinstance(stream_index, bool)
+            or not isinstance(stream_index, int)
+            or stream_index not in request_by_index
+            or not isinstance(source, str)
+            or source not in {"primary", "backup"}
+            or not isinstance(url, str)
+            or (mode == "dash_streams" and (not url or url != url.strip()))
+        ):
+            return False
+        if source == "primary":
+            if backup_index is not None:
+                return False
+        elif (
+            isinstance(backup_index, bool)
+            or not isinstance(backup_index, int)
+            or backup_index < 0
+            or backup_index >= len(request_by_index[stream_index]["backup_urls"])
+        ):
+            return False
+        parsed.append(
+            {
+                "stream_index": stream_index,
+                "source": source,
+                "backup_index": backup_index,
+                "url": url,
+            }
+        )
+    expected = _expected_media_download_candidates(mode, streams)
+    return parsed == expected and (
+        (status == "empty" and not parsed) or (status == "planned" and bool(parsed))
+    )
+
+
+def try_plan_media_download_candidates(
+    request: dict[str, object],
+) -> tuple[bool, dict[str, Any] | None]:
+    """Call and strictly validate media primary/backup URL planning."""
+
+    validated = _media_download_plan_request(request)
+    if (
+        validated is None
+        or _rust_lib is None
+        or not _CAPABILITIES.get("plan_media_download_candidates", False)
+    ):
+        return False, None
+    mode, _stream_kind, streams = validated
+    try:
+        payload = json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        pointer = _rust_lib.rust_plan_media_download_candidates(payload)
+        response_json = _read_rust_string(pointer)
+        if response_json is None:
+            return False, None
+        response = json.loads(response_json)
+        if not _valid_media_download_plan_response(response, mode, streams):
+            return False, None
+        return True, response
+    except Exception:
+        return False, None
+
+
+def _tool_download_plan_request(
+    request: object,
+) -> tuple[str, dict[str, object], list[dict[str, object]]] | None:
+    if not isinstance(request, dict) or set(request) != {
+        "schema_version",
+        "tool",
+        "asset",
+        "fallback_bases",
+    }:
+        return None
+    schema_version = request.get("schema_version")
+    tool = request.get("tool")
+    asset = request.get("asset")
+    fallback_bases = request.get("fallback_bases")
+    if (
+        isinstance(schema_version, bool)
+        or schema_version != 1
+        or not isinstance(tool, str)
+        or tool not in {"bbdown", "ytdlp", "aria2c"}
+        or not isinstance(asset, dict)
+        or not isinstance(fallback_bases, list)
+        or len(fallback_bases) > MAX_TOOL_FALLBACK_BASES
+    ):
+        return None
+    mode = asset.get("mode")
+    if mode == "supplied":
+        if (
+            set(asset) != {"mode", "name", "primary_url"}
+            or not isinstance(asset.get("name"), str)
+            or not asset["name"]
+            or not isinstance(asset.get("primary_url"), str)
+        ):
+            return None
+    elif mode == "default_for_target":
+        if (
+            set(asset) != {"mode", "platform", "arch"}
+            or not isinstance(asset.get("platform"), str)
+            or not isinstance(asset.get("arch"), str)
+        ):
+            return None
+    else:
+        return None
+
+    validated_bases: list[dict[str, object]] = []
+    previous_index: int | None = None
+    max_index = 2 ** (ctypes.sizeof(ctypes.c_size_t) * 8) - 1
+    for fallback in fallback_bases:
+        if not isinstance(fallback, dict) or set(fallback) != {
+            "original_index",
+            "base_url",
+        }:
+            return None
+        original_index = fallback.get("original_index")
+        base_url = fallback.get("base_url")
+        if (
+            isinstance(original_index, bool)
+            or not isinstance(original_index, int)
+            or original_index < 0
+            or original_index > max_index
+            or (previous_index is not None and original_index <= previous_index)
+            or not isinstance(base_url, str)
+        ):
+            return None
+        previous_index = original_index
+        validated_bases.append(
+            {"original_index": original_index, "base_url": base_url}
+        )
+    return str(tool), dict(asset), validated_bases
+
+
+def _default_tool_asset_name(tool: str, platform_name: str, arch: str) -> str | None:
+    if tool == "bbdown":
+        return {
+            ("windows", "x64"): "BBDown_1.6.3_20240814_win-x64.zip",
+            ("windows", "x86"): "BBDown_1.6.3_20240814_win-x64.zip",
+            ("windows", "arm64"): "BBDown_1.6.3_20240814_win-arm64.zip",
+            ("darwin", "x64"): "BBDown_1.6.3_20240814_osx-x64.zip",
+            ("darwin", "arm64"): "BBDown_1.6.3_20240814_osx-arm64.zip",
+            ("linux", "x64"): "BBDown_1.6.3_20240814_linux-x64.zip",
+            ("linux", "arm64"): "BBDown_1.6.3_20240814_linux-arm64.zip",
+        }.get((platform_name, arch))
+    if tool == "ytdlp":
+        if platform_name == "windows":
+            if arch == "arm64":
+                return "yt-dlp_arm64.exe"
+            if arch == "x86":
+                return "yt-dlp_x86.exe"
+            return "yt-dlp.exe"
+        if platform_name == "darwin":
+            return "yt-dlp_macos"
+        if platform_name == "linux":
+            return "yt-dlp_linux"
+        return "yt-dlp"
+    if tool == "aria2c" and platform_name == "windows":
+        return (
+            "aria2-1.37.0-win-32bit-build1.zip"
+            if arch == "x86"
+            else "aria2-1.37.0-win-64bit-build1.zip"
+        )
+    return None
+
+
+def _expected_tool_download_plan(
+    tool: str,
+    asset: dict[str, object],
+    fallback_bases: list[dict[str, object]],
+) -> tuple[str, list[dict[str, object]]] | None:
+    if asset["mode"] == "supplied":
+        asset_name = str(asset["name"])
+        primary_url = str(asset["primary_url"])
+        primary_source = "supplied_primary"
+    else:
+        asset_name = _default_tool_asset_name(
+            tool, str(asset["platform"]), str(asset["arch"])
+        )
+        if asset_name is None:
+            return None
+        if tool == "aria2c":
+            primary_url = (
+                "https://github.com/aria2/aria2/releases/download/"
+                f"release-1.37.0/{urllib.parse.quote(asset_name)}"
+            )
+            primary_source = "built_in_primary"
+        else:
+            primary_url = ""
+            primary_source = "supplied_primary"
+
+    expected: list[dict[str, object]] = []
+    seen: set[str] = set()
+    if primary_url:
+        seen.add(primary_url)
+        expected.append(
+            {
+                "source": primary_source,
+                "fallback_index": None,
+                "url": primary_url,
+            }
+        )
+    quoted_name = urllib.parse.quote(asset_name)
+    for fallback in fallback_bases:
+        base_url = str(fallback["base_url"])
+        if not base_url:
+            continue
+        url = f"{base_url}/{quoted_name}"
+        if url in seen:
+            continue
+        seen.add(url)
+        expected.append(
+            {
+                "source": "configured_fallback",
+                "fallback_index": fallback["original_index"],
+                "url": url,
+            }
+        )
+    if asset["mode"] == "default_for_target" and tool in {"bbdown", "ytdlp"} and not expected:
+        return None
+    return asset_name, expected
+
+
+def _valid_tool_download_plan_response(
+    response: object,
+    tool: str,
+    expected_asset_name: str,
+    expected_candidates: list[dict[str, object]],
+) -> bool:
+    if not isinstance(response, dict) or set(response) != {
+        "schema_version",
+        "status",
+        "tool",
+        "asset_name",
+        "candidates",
+    }:
+        return False
+    schema_version = response.get("schema_version")
+    status = response.get("status")
+    candidates = response.get("candidates")
+    if (
+        isinstance(schema_version, bool)
+        or schema_version != 1
+        or not isinstance(status, str)
+        or status not in {"planned", "empty"}
+        or response.get("tool") != tool
+        or response.get("asset_name") != expected_asset_name
+        or not isinstance(candidates, list)
+        or len(candidates) > len(expected_candidates)
+    ):
+        return False
+    parsed: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not isinstance(candidate, dict) or set(candidate) != {
+            "source",
+            "fallback_index",
+            "url",
+        }:
+            return False
+        source = candidate.get("source")
+        fallback_index = candidate.get("fallback_index")
+        url = candidate.get("url")
+        if (
+            not isinstance(source, str)
+            or source
+            not in {"supplied_primary", "built_in_primary", "configured_fallback"}
+            or not isinstance(url, str)
+            or not url
+            or url in seen
+        ):
+            return False
+        if source == "configured_fallback":
+            if isinstance(fallback_index, bool) or not isinstance(fallback_index, int):
+                return False
+        elif fallback_index is not None:
+            return False
+        seen.add(url)
+        parsed.append(
+            {"source": source, "fallback_index": fallback_index, "url": url}
+        )
+    return parsed == expected_candidates and (
+        (status == "empty" and not parsed) or (status == "planned" and bool(parsed))
+    )
+
+
+def try_plan_tool_download_candidates(
+    request: dict[str, object],
+) -> tuple[bool, dict[str, Any] | None]:
+    """Call and strictly validate tool asset candidate planning."""
+
+    validated = _tool_download_plan_request(request)
+    if validated is None:
+        return False, None
+    tool, asset, fallback_bases = validated
+    expected = _expected_tool_download_plan(tool, asset, fallback_bases)
+    if (
+        expected is None
+        or _rust_lib is None
+        or not _CAPABILITIES.get("plan_tool_download_candidates", False)
+    ):
+        return False, None
+    expected_asset_name, expected_candidates = expected
+    try:
+        payload = json.dumps(request, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        pointer = _rust_lib.rust_plan_tool_download_candidates(payload)
+        response_json = _read_rust_string(pointer)
+        if response_json is None:
+            return False, None
+        response = json.loads(response_json)
+        if not _valid_tool_download_plan_response(
+            response, tool, expected_asset_name, expected_candidates
+        ):
             return False, None
         return True, response
     except Exception:

--- a/bilikara/rust_backend.py
+++ b/bilikara/rust_backend.py
@@ -4,6 +4,7 @@ import ctypes
 import json
 import platform
 import sys
+import urllib.parse
 from pathlib import Path
 from typing import Any
 
@@ -33,7 +34,10 @@ PHASE2_CAPABILITIES = (
     "select_release",
     "select_media_pages",
     "decide_audio_binding",
+    "plan_update_download_candidates",
 )
+
+MAX_UPDATE_DOWNLOAD_CANDIDATE_INPUTS = 4096
 
 
 def _rust_library_name() -> str:
@@ -149,6 +153,11 @@ _SYMBOLS = {
     ),
     "decide_audio_binding": (
         "rust_decide_audio_binding",
+        [ctypes.c_char_p],
+        ctypes.c_void_p,
+    ),
+    "plan_update_download_candidates": (
+        "rust_plan_update_download_candidates",
         [ctypes.c_char_p],
         ctypes.c_void_p,
     ),
@@ -915,6 +924,230 @@ def try_decide_audio_binding(
             return False, None
         response = json.loads(response_json)
         if not _valid_audio_binding_response(response, request_indices):
+            return False, None
+        return True, response
+    except Exception:
+        return False, None
+
+
+def _update_download_plan_request(
+    request: object,
+) -> tuple[list[dict[str, object]], dict[str, object] | None] | None:
+    if not isinstance(request, dict) or set(request) != {
+        "schema_version",
+        "candidates",
+        "proxy",
+    }:
+        return None
+    schema_version = request.get("schema_version")
+    if isinstance(schema_version, bool) or schema_version != 1:
+        return None
+
+    raw_candidates = request.get("candidates")
+    if (
+        not isinstance(raw_candidates, list)
+        or len(raw_candidates) > MAX_UPDATE_DOWNLOAD_CANDIDATE_INPUTS
+    ):
+        return None
+
+    candidates: list[dict[str, object]] = []
+    previous_index: int | None = None
+    max_index = 2 ** (ctypes.sizeof(ctypes.c_size_t) * 8) - 1
+    for candidate in raw_candidates:
+        if not isinstance(candidate, dict) or set(candidate) != {
+            "original_index",
+            "url",
+            "source",
+        }:
+            return None
+        original_index = candidate.get("original_index")
+        url = candidate.get("url")
+        source = candidate.get("source")
+        if (
+            isinstance(original_index, bool)
+            or not isinstance(original_index, int)
+            or original_index < 0
+            or original_index > max_index
+            or (previous_index is not None and original_index <= previous_index)
+            or not isinstance(url, str)
+            or source not in {"primary", "mirror", "derived_mirror"}
+        ):
+            return None
+        previous_index = original_index
+        candidates.append(
+            {
+                "original_index": original_index,
+                "url": url,
+                "source": source,
+            }
+        )
+
+    raw_proxy = request.get("proxy")
+    proxy: dict[str, object] | None
+    if raw_proxy is None:
+        proxy = None
+    elif (
+        isinstance(raw_proxy, dict)
+        and set(raw_proxy) == {"template", "proxy_first"}
+        and isinstance(raw_proxy.get("template"), str)
+        and isinstance(raw_proxy.get("proxy_first"), bool)
+    ):
+        proxy = {
+            "template": raw_proxy["template"],
+            "proxy_first": raw_proxy["proxy_first"],
+        }
+    else:
+        return None
+    return candidates, proxy
+
+
+def _py_format_proxy_for_validation(proxy: str, url: str) -> str:
+    proxy = proxy.strip()
+    url = url.strip()
+    if not proxy or not url:
+        return ""
+    encoded_url = urllib.parse.quote(url, safe="")
+    if "{url_encoded}" in proxy:
+        return proxy.replace("{url_encoded}", encoded_url)
+    if "{url}" in proxy:
+        return proxy.replace("{url}", url)
+    separator = "" if proxy.endswith(("/", "=", "?", "&")) else "/"
+    return f"{proxy}{separator}{url}"
+
+
+def _expected_update_download_candidates(
+    candidates: list[dict[str, object]],
+    proxy: dict[str, object] | None,
+) -> list[dict[str, object]]:
+    expected: list[dict[str, object]] = []
+    seen_urls: set[str] = set()
+    for candidate in candidates:
+        direct_url = str(candidate["url"]).strip()
+        if not direct_url:
+            continue
+        proxy_url = (
+            _py_format_proxy_for_validation(str(proxy["template"]), direct_url)
+            if proxy is not None
+            else ""
+        )
+        if proxy_url.strip() == direct_url:
+            proxy_url = ""
+        routes = (
+            (("proxy", proxy_url), ("direct", direct_url))
+            if proxy is not None and proxy["proxy_first"] is True
+            else (("direct", direct_url), ("proxy", proxy_url))
+        )
+        for route, raw_url in routes:
+            url = raw_url.strip()
+            if not url or url in seen_urls:
+                continue
+            seen_urls.add(url)
+            expected.append(
+                {
+                    "input_index": candidate["original_index"],
+                    "source": candidate["source"],
+                    "route": route,
+                    "url": url,
+                }
+            )
+    return expected
+
+
+def _valid_update_download_plan_response(
+    response: object,
+    candidates: list[dict[str, object]],
+    proxy: dict[str, object] | None,
+) -> bool:
+    if not isinstance(response, dict) or set(response) != {
+        "schema_version",
+        "status",
+        "candidates",
+    }:
+        return False
+    schema_version = response.get("schema_version")
+    status = response.get("status")
+    planned = response.get("candidates")
+    if (
+        isinstance(schema_version, bool)
+        or schema_version != 1
+        or status not in {"planned", "empty"}
+        or not isinstance(planned, list)
+        or len(planned) > len(candidates) * 2
+    ):
+        return False
+
+    parsed: list[dict[str, object]] = []
+    seen_urls: set[str] = set()
+    request_by_index = {
+        candidate["original_index"]: candidate for candidate in candidates
+    }
+    for candidate in planned:
+        if not isinstance(candidate, dict) or set(candidate) != {
+            "input_index",
+            "source",
+            "route",
+            "url",
+        }:
+            return False
+        input_index = candidate.get("input_index")
+        source = candidate.get("source")
+        route = candidate.get("route")
+        url = candidate.get("url")
+        if (
+            isinstance(input_index, bool)
+            or not isinstance(input_index, int)
+            or input_index not in request_by_index
+            or source not in {"primary", "mirror", "derived_mirror"}
+            or source != request_by_index[input_index]["source"]
+            or route not in {"direct", "proxy"}
+            or not isinstance(url, str)
+            or not url
+            or url != url.strip()
+            or url in seen_urls
+            or (route == "proxy" and proxy is None)
+        ):
+            return False
+        seen_urls.add(url)
+        parsed.append(
+            {
+                "input_index": input_index,
+                "source": source,
+                "route": route,
+                "url": url,
+            }
+        )
+
+    expected = _expected_update_download_candidates(candidates, proxy)
+    if parsed != expected:
+        return False
+    return (status == "empty" and not parsed) or (status == "planned" and bool(parsed))
+
+
+def try_plan_update_download_candidates(
+    request: dict[str, object],
+) -> tuple[bool, dict[str, Any] | None]:
+    """Call and strictly validate updater-only candidate planning."""
+
+    validated_request = _update_download_plan_request(request)
+    if (
+        validated_request is None
+        or _rust_lib is None
+        or not _CAPABILITIES.get("plan_update_download_candidates", False)
+    ):
+        return False, None
+    candidates, proxy = validated_request
+    try:
+        request_json = json.dumps(
+            request,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        pointer = _rust_lib.rust_plan_update_download_candidates(request_json)
+        response_json = _read_rust_string(pointer)
+        if response_json is None:
+            return False, None
+        response = json.loads(response_json)
+        if not _valid_update_download_plan_response(response, candidates, proxy):
             return False, None
         return True, response
     except Exception:

--- a/bilikara/updater.py
+++ b/bilikara/updater.py
@@ -48,7 +48,7 @@ class AppUpdateError(RuntimeError):
     pass
 
 
-def _dedupe_urls(urls: list[str]) -> list[str]:
+def _py_dedupe_urls(urls: list[str]) -> list[str]:
     result: list[str] = []
     seen: set[str] = set()
     for url in urls:
@@ -58,6 +58,103 @@ def _dedupe_urls(urls: list[str]) -> list[str]:
         seen.add(normalized)
         result.append(normalized)
     return result
+
+
+def _update_candidate_inputs(
+    urls: list[object],
+    sources: list[str] | None = None,
+) -> list[dict[str, object]]:
+    return [
+        {
+            "original_index": index,
+            "url": str(url or ""),
+            "source": sources[index] if sources is not None else "primary",
+        }
+        for index, url in enumerate(urls)
+    ]
+
+
+def _update_download_plan_request(
+    candidates: list[dict[str, object]],
+    *,
+    proxy: str | None = None,
+    proxy_first: bool = False,
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "candidates": candidates,
+        "proxy": (
+            {"template": str(proxy), "proxy_first": bool(proxy_first)}
+            if proxy is not None
+            else None
+        ),
+    }
+
+
+def _py_plan_update_download_candidates(
+    candidates: list[dict[str, object]],
+    *,
+    proxy: str | None = None,
+    proxy_first: bool = False,
+) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        direct_url = str(candidate.get("url") or "").strip()
+        if not direct_url:
+            continue
+        proxy_url = (
+            _py_format_download_proxy_url(str(proxy), direct_url)
+            if proxy is not None
+            else ""
+        )
+        if proxy_url.strip() == direct_url:
+            proxy_url = ""
+        ordered = (
+            (("proxy", proxy_url), ("direct", direct_url))
+            if proxy_first
+            else (("direct", direct_url), ("proxy", proxy_url))
+        )
+        for route, raw_url in ordered:
+            url = str(raw_url or "").strip()
+            if not url or url in seen:
+                continue
+            seen.add(url)
+            result.append(
+                {
+                    "input_index": candidate["original_index"],
+                    "source": candidate["source"],
+                    "route": route,
+                    "url": url,
+                }
+            )
+    return result
+
+
+def _try_native_update_download_plan(
+    candidates: list[dict[str, object]],
+    *,
+    proxy: str | None = None,
+    proxy_first: bool = False,
+) -> tuple[bool, list[dict[str, object]]]:
+    completed, response = rust_backend.try_plan_update_download_candidates(
+        _update_download_plan_request(
+            candidates,
+            proxy=proxy,
+            proxy_first=proxy_first,
+        )
+    )
+    if not completed or response is None:
+        return False, []
+    return True, list(response["candidates"])
+
+
+def _dedupe_urls(urls: list[str]) -> list[str]:
+    candidates = _update_candidate_inputs(list(urls))
+    completed, plan = _try_native_update_download_plan(candidates)
+    if completed:
+        return [str(candidate["url"]) for candidate in plan]
+    return _py_dedupe_urls(urls)
 
 
 def _py_release_list_api_from_latest(api_url: str) -> str:
@@ -75,8 +172,34 @@ def _release_list_api_from_latest(api_url: str) -> str:
     return _py_release_list_api_from_latest(api_url)
 
 
+def _py_latest_release_api_urls(
+    primary_url: object,
+    fallback_urls: tuple[str, ...] | list[str],
+) -> list[str]:
+    return _py_dedupe_urls([str(primary_url or ""), *fallback_urls])
+
+
 def _latest_release_api_urls() -> list[str]:
-    return _dedupe_urls([APP_RELEASE_API, *APP_RELEASE_API_FALLBACKS])
+    urls = [APP_RELEASE_API, *APP_RELEASE_API_FALLBACKS]
+    sources = ["primary", *("mirror" for _ in APP_RELEASE_API_FALLBACKS)]
+    candidates = _update_candidate_inputs(urls, sources)
+    completed, plan = _try_native_update_download_plan(candidates)
+    if completed:
+        return [str(candidate["url"]) for candidate in plan]
+    return _py_latest_release_api_urls(APP_RELEASE_API, APP_RELEASE_API_FALLBACKS)
+
+
+def _py_release_list_api_urls(
+    primary_url: object,
+    fallback_urls: tuple[str, ...] | list[str],
+    latest_fallback_urls: tuple[str, ...] | list[str],
+) -> list[str]:
+    derived_fallbacks = [
+        _py_release_list_api_from_latest(url) for url in latest_fallback_urls
+    ]
+    return _py_dedupe_urls(
+        [str(primary_url or ""), *fallback_urls, *derived_fallbacks]
+    )
 
 
 def _release_list_api_urls() -> list[str]:
@@ -84,7 +207,21 @@ def _release_list_api_urls() -> list[str]:
         _release_list_api_from_latest(url)
         for url in APP_RELEASE_API_FALLBACKS
     ]
-    return _dedupe_urls([APP_RELEASES_API, *APP_RELEASES_API_FALLBACKS, *derived_fallbacks])
+    urls = [APP_RELEASES_API, *APP_RELEASES_API_FALLBACKS, *derived_fallbacks]
+    sources = [
+        "primary",
+        *("mirror" for _ in APP_RELEASES_API_FALLBACKS),
+        *("derived_mirror" for _ in derived_fallbacks),
+    ]
+    candidates = _update_candidate_inputs(urls, sources)
+    completed, plan = _try_native_update_download_plan(candidates)
+    if completed:
+        return [str(candidate["url"]) for candidate in plan]
+    return _py_release_list_api_urls(
+        APP_RELEASES_API,
+        APP_RELEASES_API_FALLBACKS,
+        APP_RELEASE_API_FALLBACKS,
+    )
 
 
 def _py_format_download_proxy_url(proxy: str, url: str) -> str:
@@ -110,15 +247,39 @@ def _format_download_proxy_url(proxy: str, url: str) -> str:
     return _py_format_download_proxy_url(proxy, url)
 
 
-def _download_url_candidates(url: str) -> list[str]:
-    url = str(url or "").strip()
-    if not url:
+def _py_download_url_candidates(
+    url: object,
+    proxy: object,
+    proxy_first: bool,
+) -> list[str]:
+    normalized_url = str(url or "").strip()
+    if not normalized_url:
         return []
-    proxy_url = _format_download_proxy_url(APP_UPDATE_DOWNLOAD_PROXY, url)
-    if not proxy_url or proxy_url == url:
-        return [url]
-    candidates = [proxy_url, url] if APP_UPDATE_DOWNLOAD_PROXY_FIRST else [url, proxy_url]
-    return _dedupe_urls(candidates)
+    proxy_url = _py_format_download_proxy_url(str(proxy or ""), normalized_url)
+    if not proxy_url or proxy_url == normalized_url:
+        return [normalized_url]
+    candidates = (
+        [proxy_url, normalized_url]
+        if proxy_first
+        else [normalized_url, proxy_url]
+    )
+    return _py_dedupe_urls(candidates)
+
+
+def _download_url_candidates(url: str) -> list[str]:
+    candidates = _update_candidate_inputs([url], ["primary"])
+    completed, plan = _try_native_update_download_plan(
+        candidates,
+        proxy=APP_UPDATE_DOWNLOAD_PROXY,
+        proxy_first=APP_UPDATE_DOWNLOAD_PROXY_FIRST,
+    )
+    if completed:
+        return [str(candidate["url"]) for candidate in plan]
+    return _py_download_url_candidates(
+        url,
+        APP_UPDATE_DOWNLOAD_PROXY,
+        APP_UPDATE_DOWNLOAD_PROXY_FIRST,
+    )
 
 
 def _py_normalize_version_tag(version: object) -> str:

--- a/docs/rust-business-rule-migration-plan.md
+++ b/docs/rust-business-rule-migration-plan.md
@@ -256,9 +256,8 @@ Remaining risks:
 
 ### 5. Quality and stream ranking
 
-Status: next candidate, not started. No quality/stream selection, download
-planning, BBDown, aria2, cache, or FFmpeg work was begun as part of the audio
-binding migration.
+Status: deferred, not started. No quality/stream selection, BBDown, aria2,
+cache, or FFmpeg work was begun as part of download-candidate planning.
 
 Current Python ownership:
 
@@ -312,48 +311,99 @@ Recommended order: only after page and binding domains.
 
 ### 6. Download candidate planning
 
-Current Python ownership:
+Status: **partially implemented for updater candidates only**. Phase 2 remains
+**4/8 complete**; recommended-sequence item 5 does not count as complete until
+the cache/media-tool semantics have a proven cohesive model or are migrated as
+a separately justified domain.
 
-- `bilikara/updater.py`: `_dedupe_urls`, `_download_url_candidates`;
-- `bilikara/cache.py`: `_dash_stream_urls`, `_tool_fallback_url`, fallback asset
-  helpers, and selected pure portions of URL/source planning;
-- `_download_tool_asset`, `_download_url`, downloader commands, and retry loops
-  are explicitly excluded.
+Migrated Python ownership:
 
-Input/output model: primary URLs, mirrors, proxy configuration, proxy-first
-flag, source kind, and explicit platform/architecture facts; output an ordered,
-deduplicated candidate list with reason/source labels.
+- `bilikara/updater.py`: `_dedupe_urls`, `_latest_release_api_urls`,
+  `_release_list_api_urls`, and `_download_url_candidates` now adapt explicit
+  immutable inputs and invoke one updater-only plan operation.
+- Complete independently executable references remain as `_py_dedupe_urls`,
+  `_py_latest_release_api_urls`, `_py_release_list_api_urls`,
+  `_py_download_url_candidates`, and
+  `_py_plan_update_download_candidates`.
+- `bilikara/rust_backend.py` owns the independently detected
+  `plan_update_download_candidates` capability and validates the complete
+  native response before `updater.py` uses it.
 
-Dependencies: Phase-1 proxy URL formatting and explicit configuration values.
-No function may read environment variables or global config inside Rust.
+Typed domain model:
 
-User-visible policy: proxy-first ordering, direct fallback, mirror priority,
-duplicate removal, and possibly tool-source preference. Separate APIs may be
-needed if updater and media-tool semantics are not actually identical.
+- Input: `UpdateDownloadPlanRequest { candidates:
+  Vec<UpdateCandidateInput>, proxy: Option<UpdateDownloadProxy> }`.
+- Each input carries `original_index`, URL, and an explicit `Primary`, `Mirror`,
+  or `DerivedMirror` source.
+- Output: `UpdateDownloadPlan { candidates: Vec<PlannedUpdateCandidate> }`;
+  each planned candidate carries the originating input index/source, a
+  `Direct` or `Proxy` route, and the normalized URL.
+- Duplicate typed input indices are invalid. Empty or whitespace-only inputs
+  produce a valid empty plan.
+- The typed domain has no serde derives, raw pointers, Python, Tauri, I/O,
+  configuration, or mutable state dependencies. It reuses the Phase-1
+  `url_utils::format_download_proxy_url` transformation.
 
-Proposed Rust structures:
+JSON FFI schema:
 
-```text
-Candidate { url, source, priority }
-DownloadPlanRequest { primary, mirrors, proxy, proxy_first }
-DownloadPlan { candidates }
-```
+- Additive ABI-v1 export:
+  `rust_plan_update_download_candidates(request_json) -> owned response JSON or
+  null`.
+- Request fields are exactly `schema_version`, `candidates`, and nullable
+  `proxy`. Candidate indices must be strictly increasing on the wire; sources
+  are `primary`, `mirror`, or `derived_mirror`.
+- Response fields are exactly `schema_version`, `status`, and `candidates`.
+  Status is `planned` or `empty`; route is `direct` or `proxy`.
+- Malformed pointers, UTF-8, JSON, schemas, enums, fields, or indices return
+  null. A valid empty plan is a concrete `empty` response.
 
-Proposed FFI:
+Preserved updater policy and validation:
 
-```text
-rust_plan_download_candidates(request_json) -> owned response JSON or null
-```
+- URLs are trimmed; empty values are removed; the first occurrence wins; and
+  relative primary/mirror/derived-mirror order remains stable.
+- Proxy formatting preserves `{url_encoded}`, `{url}`, and suffix-separator
+  behavior. An empty proxy or proxy output equal to the direct URL adds no
+  candidate. Explicit `proxy_first` controls direct/proxy order.
+- Python recomputes the only permissible plan from the request and rejects an
+  unknown status/source/route, unknown fields, Boolean or out-of-range indices,
+  source/index mismatches, empty or untrimmed URLs, duplicates, invented URLs,
+  impossible proxy relationships, count violations, or ordering changes.
+- Missing library/symbol, ABI incompatibility, null response, panic, malformed
+  JSON, or any validation failure executes the complete Python reference.
+- Python still performs every HTTP request, retry, timeout, download,
+  installation, error translation, and state update.
 
-Python fallback: retain ordered candidate construction; Python performs every
-request, retry, timeout, and error translation.
+Cohesion decision and deferred code:
 
-Golden tests: empty URLs, duplicate direct/proxy URLs, placeholder proxies,
-proxy-first both ways, mirror stability, Unicode URLs, and current retry-order
-fixtures. Tests must assert planning only and mock all network entry points.
+- Updater and cache/media-tool planning were **not unified**. `_dash_stream_urls`
+  flattens every stream's direct and backup URLs and currently preserves
+  duplicates; preferred-audio construction has a separate raw direct/backup
+  path. `_tool_fallback_url` synthesizes a name-based bucket URL, while
+  `_download_tool_asset` uses fixed primary-first ordering and different
+  trimming semantics. None has updater proxy transformation or `proxy_first`.
+- Therefore `_dash_stream_urls`, preferred-audio URL construction,
+  `_tool_fallback_url`, `_fallback_tool_asset`, `_download_tool_asset`, and all
+  cache/media downloader call sites remain unchanged in Python. A generic
+  `rust_plan_download_candidates` export would misleadingly imply semantics
+  that the audit did not establish.
 
-Risk: medium-to-high. Although pure, ordering controls which external source is
-tried first and therefore affects reliability and privacy expectations.
+Test coverage:
+
+- Typed Rust, wire, and FFI tests cover empty input, trimming, stable
+  deduplication, source/index identity, both proxy orders and placeholders,
+  suffix separators, equal/repeated proxy results, mirror order, cross-source
+  duplicates, Unicode/encoded URLs, invalid requests, determinism, null/UTF-8,
+  malformed JSON/schema/enums/indices, allocation/free repetition, and panic
+  containment.
+- Python golden-policy tests exercise only `_py_*` references. Backend tests
+  cover capability isolation and every fallback/validation class. Strict-native
+  fixed and generated fixtures compare the real release Rust library with the
+  Python policy without permitting fallback.
+
+Remaining risk: ordering controls which external source is contacted first.
+The strict reconstruction validator and complete fallback bound this risk for
+the migrated updater path. Cache/media-tool semantics remain deliberately
+deferred rather than silently changed.
 
 Recommended order: after update selection and only after updater/tool planners
 are shown to share a stable schema.

--- a/docs/rust-business-rule-migration-plan.md
+++ b/docs/rust-business-rule-migration-plan.md
@@ -311,10 +311,9 @@ Recommended order: only after page and binding domains.
 
 ### 6. Download candidate planning
 
-Status: **partially implemented for updater candidates only**. Phase 2 remains
-**4/8 complete**; recommended-sequence item 5 does not count as complete until
-the cache/media-tool semantics have a proven cohesive model or are migrated as
-a separately justified domain.
+Status: **completed**. Phase 2 is **5/8 complete**. Item 5 uses three precise
+typed domains because updater, media, and tool planners have materially
+different normalization, duplication, source, and ordering semantics.
 
 Migrated Python ownership:
 
@@ -328,6 +327,13 @@ Migrated Python ownership:
 - `bilikara/rust_backend.py` owns the independently detected
   `plan_update_download_candidates` capability and validates the complete
   native response before `updater.py` uses it.
+- `bilikara/cache.py`: `_dash_stream_urls`, preferred-audio URL flattening,
+  `_tool_fallback_url`, tool fallback-asset construction, and
+  `_download_tool_asset` now adapt explicit immutable values into one media or
+  tool plan call. Complete `_py_*` references remain independently executable.
+- Runtime platform/architecture and `TOOL_ASSET_BASE_URL` remain Python-owned
+  facts and are passed explicitly. Tool release asset selection remains in the
+  existing selection policy and is not part of candidate planning.
 
 Typed domain model:
 
@@ -343,6 +349,25 @@ Typed domain model:
 - The typed domain has no serde derives, raw pointers, Python, Tauri, I/O,
   configuration, or mutable state dependencies. It reuses the Phase-1
   `url_utils::format_download_proxy_url` transformation.
+- Media input is `MediaDownloadPlanRequest { mode, stream_kind, streams }`.
+  Each `MediaStreamUrlInput` carries an original stream index, primary URL,
+  and ordered backups. Output candidates carry stream index, `Primary` or
+  `Backup` source, optional backup index, and URL.
+- Media `DashStreams` mode trims and removes empty URLs while preserving every
+  duplicate. `PreferredAudio` mode accepts at most one audio descriptor and
+  preserves the raw strings, empties, duplicates, and order used by the
+  existing special path. Choosing that descriptor remains Python Item 6
+  policy and was not migrated.
+- Tool input is `ToolDownloadPlanRequest { tool, asset, fallback_bases }`.
+  `ToolAssetInput` is either a supplied asset name/primary URL or a
+  `DefaultForTarget` with explicit platform/architecture. Output includes the
+  resolved asset name and candidates labeled `SuppliedPrimary`,
+  `BuiltInPrimary`, or `ConfiguredFallback`, with the originating fallback
+  index where applicable.
+- Tool planning preserves primary-first order, constructs name-based fallback
+  URLs using the existing `urllib.parse.quote`-equivalent rules (including
+  slash preservation), skips empty configured bases, and performs exact-string
+  stable first-occurrence deduplication without trimming.
 
 JSON FFI schema:
 
@@ -356,6 +381,18 @@ JSON FFI schema:
   Status is `planned` or `empty`; route is `direct` or `proxy`.
 - Malformed pointers, UTF-8, JSON, schemas, enums, fields, or indices return
   null. A valid empty plan is a concrete `empty` response.
+- Additive ABI-v1 media export:
+  `rust_plan_media_download_candidates(request_json)`. Request fields are
+  exactly `schema_version`, `mode`, `stream_kind`, and `streams`; response
+  fields are exactly `schema_version`, `status`, and `candidates`.
+- Additive ABI-v1 tool export:
+  `rust_plan_tool_download_candidates(request_json)`. Request fields are
+  exactly `schema_version`, `tool`, tagged `asset`, and `fallback_bases`;
+  response fields are exactly `schema_version`, `status`, `tool`,
+  `asset_name`, and `candidates`.
+- Both exports return Rust-owned JSON freed by `rust_free_string`, contain
+  panics, reject null/invalid UTF-8/malformed JSON/unsupported schema or enums,
+  and return concrete `empty` responses for valid empty plans.
 
 Preserved updater policy and validation:
 
@@ -373,19 +410,23 @@ Preserved updater policy and validation:
 - Python still performs every HTTP request, retry, timeout, download,
   installation, error translation, and state update.
 
-Cohesion decision and deferred code:
+Cohesion decision and completed boundary:
 
-- Updater and cache/media-tool planning were **not unified**. `_dash_stream_urls`
-  flattens every stream's direct and backup URLs and currently preserves
-  duplicates; preferred-audio construction has a separate raw direct/backup
-  path. `_tool_fallback_url` synthesizes a name-based bucket URL, while
-  `_download_tool_asset` uses fixed primary-first ordering and different
-  trimming semantics. None has updater proxy transformation or `proxy_first`.
-- Therefore `_dash_stream_urls`, preferred-audio URL construction,
-  `_tool_fallback_url`, `_fallback_tool_asset`, `_download_tool_asset`, and all
-  cache/media downloader call sites remain unchanged in Python. A generic
-  `rust_plan_download_candidates` export would misleadingly imply semantics
-  that the audit did not establish.
+- Updater, media, and tool planning were intentionally **not unified into one
+  schema**. The updater domain trims/deduplicates globally and supports proxy
+  transformation; media preserves duplicates and has two normalization modes;
+  tools use name-derived fallbacks and exact-string deduplication.
+- The remaining pure candidate construction is covered by the three domains.
+  Bilibili response parsing still constructs typed stream descriptors while
+  handling an HTTP response; it is response adaptation rather than candidate
+  ordering. FFmpeg/ffprobe have no download-URL candidate helper: their source
+  discovery is filesystem/runtime I/O.
+- HTTP, retries, timeout/error handling, redirect behavior, aria2/BBDown/
+  yt-dlp/FFmpeg/ffprobe command construction and execution, extraction,
+  filesystem publication, cache workers/mutation, cancellation, and download
+  loops remain Python.
+- Tool release asset scoring/selection and preferred-audio/video stream
+  selection remain deferred ranking policy. No Item 6 work was started.
 
 Test coverage:
 
@@ -399,14 +440,21 @@ Test coverage:
   cover capability isolation and every fallback/validation class. Strict-native
   fixed and generated fixtures compare the real release Rust library with the
   Python policy without permitting fallback.
+- Media coverage includes primary/backup flattening, raw preferred audio,
+  duplicate preservation, empty/whitespace strings, Unicode/encoded URLs,
+  stream/backup identity, modes, invalid indices, ordering, and determinism.
+- Tool coverage includes supplied and built-in primaries, multiple configured
+  bases, platform/architecture mappings, unsupported targets, name encoding,
+  empty bases, exact duplicate removal, tool/source/index identity, strict
+  native validation, allocation/free repetition, and fallback behavior.
 
 Remaining risk: ordering controls which external source is contacted first.
-The strict reconstruction validator and complete fallback bound this risk for
-the migrated updater path. Cache/media-tool semantics remain deliberately
-deferred rather than silently changed.
+The strict reconstruction validators and complete independent references bound
+this risk for all three domains. Cross-platform release-gate confirmation and
+production variation in externally supplied URL strings remain the residual
+risks; neither can move I/O or mutable state into Rust.
 
-Recommended order: after update selection and only after updater/tool planners
-are shown to share a stable schema.
+Recommended order: complete; proceed to Item 6 only as a separate migration.
 
 ### 7. Playlist ordering and deduplication
 
@@ -515,7 +563,7 @@ Recommended order: late, after pure planning has been extracted from mutation.
 2. Release filtering and stable/preview selection.
 3. Media-page matching and ranking.
 4. Audio variant pairing and binding decisions.
-5. Download candidate planning, if updater/tool schemas can be unified safely.
+5. Download candidate planning using separate cohesive schemas where required.
 6. Quality and stream ranking.
 7. Cache planning calculations after mutation-free extraction.
 8. Playlist ordering and deduplication after mutation-free extraction.

--- a/docs/rust-native-utility-inventory.md
+++ b/docs/rust-native-utility-inventory.md
@@ -279,6 +279,7 @@ Missing optional symbols disable only their matching capabilities.
 | --- | --- | --- |
 | `media_page_selection` | `rust_select_media_pages` / `select_media_pages` | Implemented and locally stabilized. Cross-platform confirmation remains for the PR to `dev`. Python retains Bilibili adaptation, object mapping, and fallback. |
 | `audio_binding` | `rust_decide_audio_binding` / `decide_audio_binding` | Implemented only after the strict media-page gate passed. Python retains model construction, errors, manual selection, URLs, and fallback. |
+| `download_candidate_planning` (updater-only) | `rust_plan_update_download_candidates` / `plan_update_download_candidates` | Partially implements Phase 2 recommended-sequence item 5 for updater helpers only. Python retains complete `_py_*` references and all I/O. Cache/media-tool URL planning remains Python because its duplicate, source, fallback, and ordering semantics do not match updater proxy planning. Phase 2 remains 4/8 complete. |
 
 Audio binding transports only original index, page number, duration, and part
 label. It does not transport CID or arbitrary Bilibili metadata. The Rust
@@ -286,9 +287,10 @@ domain preserves the existing broad keyword substring policy and returns
 `single`, `automatic`, `manual_required`, or domain-level `no_match`.
 
 Variant-ID construction remains entirely in Python and was not consolidated.
-Quality/stream ranking is the next candidate, but no ranking, download
-planning, BBDown, aria2, cache, playlist, mobile plugin, or FFmpeg migration
-was started here.
+Updater-only download candidate planning is now implemented without advancing
+Phase 2 beyond 4/8 because the cache/media-tool half is intentionally deferred.
+No quality/stream ranking, cache planning, playlist ordering, BBDown, aria2,
+mobile plugin, or FFmpeg migration was started.
 
 ### Criteria for future migration
 
@@ -300,7 +302,9 @@ I/O and mutable policy in Python unless that later phase explicitly changes
 the boundary.
 
 The intentionally deferred helpers in the audit remain deferred. In
-particular, release and asset scoring/selection, URL candidate order, Bilibili
-short-link resolution, cache quality/source defaults, track/download planning,
-path traversal checks, persistent schema adapters, rendering utilities, and
-all filesystem/network/subprocess/thread behavior are not part of Phase 1.
+particular, release and asset scoring/selection, cache/media-tool URL candidate
+order, Bilibili short-link resolution, cache quality/source defaults,
+track/download planning, path traversal checks, persistent schema adapters,
+rendering utilities, and all filesystem/network/subprocess/thread behavior are
+not part of Phase 1. Updater-only candidate planning is the later partial
+Phase-2 domain documented above.

--- a/docs/rust-native-utility-inventory.md
+++ b/docs/rust-native-utility-inventory.md
@@ -62,7 +62,7 @@ No other helper is approved for Phase 1. The tables below document why.
 | `_page_url`, `_build_media_url` | URL composition | yes | Defer: each is a trivial operation in downloader/local-serving code, not a reusable URL parsing domain. |
 | `_normalize_output_line`, `_extract_progress`, `_compact_probe_error`, `_format_stage_bytes` | subprocess output cleanup/parsing | core yes | Excluded from this phase because their primary purpose is subprocess/progress handling. |
 | `_dash_max_quality_id`, `_video_quality_priority`, format selectors and stream selectors | quality lookup/ranking | yes | Excluded: download policy, scoring, ranking, and selection. |
-| `_dash_stream_urls`, `_current_platform_tokens`, release asset-name helpers | response adapters/platform selection | mostly | Excluded: source/download planning or heterogeneous dictionaries. |
+| `_dash_stream_urls`, `_current_platform_tokens`, release asset-name helpers | response adapters/platform selection | mostly | Excluded from Phase 1. The pure URL flattening and fallback asset construction were later migrated as Phase 2 Item 5; runtime detection and dictionary adaptation remain Python. |
 | All command, downloader, archive extraction, file lookup, path-size, process, worker, retry, cache-window, and filesystem helpers | I/O, subprocess, state, scheduling, policy | no/mixed | Outside Phase 1 by definition. |
 
 ### `bilikara/config.py`
@@ -137,8 +137,8 @@ No other helper is approved for Phase 1. The tables below document why.
 | Helpers reviewed | Category / dependencies | Pure | Decision and reason |
 | --- | --- | --- | --- |
 | `_release_list_api_from_latest`, `_format_download_proxy_url` | URL syntax/composition | yes | **Migrate now** as `url_utils.rs`. |
-| `_dedupe_urls`, `_latest_release_api_urls`, `_release_list_api_urls` | ordered fallback construction | yes | Defer/exclude: ordered fallback and source preference policy. The pure URL transform used inside is migrated separately. |
-| `_download_url_candidates` | ordered proxy/direct candidates | yes | Explicitly excluded: ordered download fallback policy. |
+| `_dedupe_urls`, `_latest_release_api_urls`, `_release_list_api_urls` | ordered fallback construction | yes | Excluded from Phase 1; later migrated as the updater portion of Phase 2 Item 5. |
+| `_download_url_candidates` | ordered proxy/direct candidates | yes | Excluded from Phase 1; later migrated as the updater portion of Phase 2 Item 5. |
 | Version, architecture, asset-token, safe-filename helpers | normalization/parsing | yes | Already migrated; Python fallbacks retained. |
 | `is_release_version`, `is_preview_version`, `is_stable_version`, `is_newer_version` | classification/comparison | yes | Intentionally remain Python composition over migrated parse results; migration would duplicate trivial policy. |
 | `_asset_text` | release asset dictionary → text | yes | Defer: Python dictionary adapter; no useful native work. |
@@ -279,7 +279,9 @@ Missing optional symbols disable only their matching capabilities.
 | --- | --- | --- |
 | `media_page_selection` | `rust_select_media_pages` / `select_media_pages` | Implemented and locally stabilized. Cross-platform confirmation remains for the PR to `dev`. Python retains Bilibili adaptation, object mapping, and fallback. |
 | `audio_binding` | `rust_decide_audio_binding` / `decide_audio_binding` | Implemented only after the strict media-page gate passed. Python retains model construction, errors, manual selection, URLs, and fallback. |
-| `download_candidate_planning` (updater-only) | `rust_plan_update_download_candidates` / `plan_update_download_candidates` | Partially implements Phase 2 recommended-sequence item 5 for updater helpers only. Python retains complete `_py_*` references and all I/O. Cache/media-tool URL planning remains Python because its duplicate, source, fallback, and ordering semantics do not match updater proxy planning. Phase 2 remains 4/8 complete. |
+| `download_candidate_planning` (updater) | `rust_plan_update_download_candidates` / `plan_update_download_candidates` | Implements updater API/direct/proxy construction with trimming, stable deduplication, explicit sources/routes, and complete Python fallback. |
+| `media_download_candidate_planning` | `rust_plan_media_download_candidates` / `plan_media_download_candidates` | Implements DASH primary/backup flattening and preferred-audio URL flattening. DASH trims/drops empties and preserves duplicates; preferred audio preserves raw strings and duplicates. Python retains descriptor selection, all I/O, and complete `_py_*` references. |
+| `tool_download_candidate_planning` | `rust_plan_tool_download_candidates` / `plan_tool_download_candidates` | Implements supplied/built-in primary plus configured fallback ordering, tool/target fallback asset identity, name quoting, and exact stable deduplication for BBDown, yt-dlp, and aria2c. Python retains runtime detection, asset scoring, downloads, installation, and complete `_py_*` references. |
 
 Audio binding transports only original index, page number, duration, and part
 label. It does not transport CID or arbitrary Bilibili metadata. The Rust
@@ -287,10 +289,11 @@ domain preserves the existing broad keyword substring policy and returns
 `single`, `automatic`, `manual_required`, or domain-level `no_match`.
 
 Variant-ID construction remains entirely in Python and was not consolidated.
-Updater-only download candidate planning is now implemented without advancing
-Phase 2 beyond 4/8 because the cache/media-tool half is intentionally deferred.
-No quality/stream ranking, cache planning, playlist ordering, BBDown, aria2,
-mobile plugin, or FFmpeg migration was started.
+Phase 2 Item 5 is complete and Phase 2 is 5/8. The three candidate domains are
+separate because their normalization, duplicate, source, and ordering policies
+are intentionally different. No quality/stream ranking, cache planning,
+playlist ordering, downloader execution, mobile plugin, or FFmpeg migration
+was started.
 
 ### Criteria for future migration
 
@@ -302,9 +305,9 @@ I/O and mutable policy in Python unless that later phase explicitly changes
 the boundary.
 
 The intentionally deferred helpers in the audit remain deferred. In
-particular, release and asset scoring/selection, cache/media-tool URL candidate
-order, Bilibili short-link resolution, cache quality/source defaults,
-track/download planning, path traversal checks, persistent schema adapters,
+particular, release and asset scoring/selection, Bilibili short-link
+resolution, cache quality/source defaults, stream ranking, cache-window and
+playlist planning, path traversal checks, persistent schema adapters,
 rendering utilities, and all filesystem/network/subprocess/thread behavior are
-not part of Phase 1. Updater-only candidate planning is the later partial
-Phase-2 domain documented above.
+not part of Phase 1. Updater, media, and tool candidate planning are the later
+completed Phase-2 Item 5 domains documented above.

--- a/rust/src/download_candidate_planning.rs
+++ b/rust/src/download_candidate_planning.rs
@@ -1,0 +1,589 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::url_utils::format_download_proxy_url;
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateCandidateSource {
+    Primary,
+    Mirror,
+    DerivedMirror,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateCandidateInput {
+    pub original_index: usize,
+    pub url: String,
+    pub source: UpdateCandidateSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateDownloadProxy {
+    pub template: String,
+    pub proxy_first: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateDownloadPlanRequest {
+    pub candidates: Vec<UpdateCandidateInput>,
+    pub proxy: Option<UpdateDownloadProxy>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateCandidateRoute {
+    Direct,
+    Proxy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedUpdateCandidate {
+    pub input_index: usize,
+    pub source: UpdateCandidateSource,
+    pub route: UpdateCandidateRoute,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateDownloadPlan {
+    pub candidates: Vec<PlannedUpdateCandidate>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateDownloadPlanError {
+    InvalidRequest,
+}
+
+pub fn plan_update_download_candidates(
+    request: &UpdateDownloadPlanRequest,
+) -> Result<UpdateDownloadPlan, UpdateDownloadPlanError> {
+    let mut input_indices = HashSet::with_capacity(request.candidates.len());
+    if request
+        .candidates
+        .iter()
+        .any(|candidate| !input_indices.insert(candidate.original_index))
+    {
+        return Err(UpdateDownloadPlanError::InvalidRequest);
+    }
+
+    let mut planned = Vec::with_capacity(request.candidates.len().saturating_mul(2));
+    let mut seen_urls = HashSet::with_capacity(request.candidates.len().saturating_mul(2));
+
+    for candidate in &request.candidates {
+        let direct_url = candidate.url.trim();
+        if direct_url.is_empty() {
+            continue;
+        }
+
+        let mut proxy_url = request
+            .proxy
+            .as_ref()
+            .map(|proxy| format_download_proxy_url(&proxy.template, direct_url))
+            .unwrap_or_default();
+        if proxy_url.trim() == direct_url {
+            proxy_url.clear();
+        }
+        let proxy_first = request
+            .proxy
+            .as_ref()
+            .is_some_and(|proxy| proxy.proxy_first);
+
+        let routes = if proxy_first {
+            [
+                (UpdateCandidateRoute::Proxy, proxy_url.as_str()),
+                (UpdateCandidateRoute::Direct, direct_url),
+            ]
+        } else {
+            [
+                (UpdateCandidateRoute::Direct, direct_url),
+                (UpdateCandidateRoute::Proxy, proxy_url.as_str()),
+            ]
+        };
+
+        for (route, url) in routes {
+            let normalized_url = url.trim();
+            if normalized_url.is_empty() || !seen_urls.insert(normalized_url.to_string()) {
+                continue;
+            }
+            planned.push(PlannedUpdateCandidate {
+                input_index: candidate.original_index,
+                source: candidate.source,
+                route,
+                url: normalized_url.to_string(),
+            });
+        }
+    }
+
+    Ok(UpdateDownloadPlan {
+        candidates: planned,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UpdateDownloadPlanWireRequest {
+    schema_version: u32,
+    candidates: Vec<UpdateCandidateWireInput>,
+    proxy: Option<UpdateDownloadProxyWire>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UpdateCandidateWireInput {
+    original_index: usize,
+    url: String,
+    source: UpdateCandidateSourceWire,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum UpdateCandidateSourceWire {
+    Primary,
+    Mirror,
+    DerivedMirror,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct UpdateDownloadProxyWire {
+    template: String,
+    proxy_first: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum UpdateDownloadPlanWireStatus {
+    Planned,
+    Empty,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum UpdateCandidateRouteWire {
+    Direct,
+    Proxy,
+}
+
+#[derive(Debug, Serialize)]
+struct PlannedUpdateCandidateWire {
+    input_index: usize,
+    source: UpdateCandidateSourceWire,
+    route: UpdateCandidateRouteWire,
+    url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateDownloadPlanWireResponse {
+    schema_version: u32,
+    status: UpdateDownloadPlanWireStatus,
+    candidates: Vec<PlannedUpdateCandidateWire>,
+}
+
+impl From<UpdateCandidateSourceWire> for UpdateCandidateSource {
+    fn from(source: UpdateCandidateSourceWire) -> Self {
+        match source {
+            UpdateCandidateSourceWire::Primary => Self::Primary,
+            UpdateCandidateSourceWire::Mirror => Self::Mirror,
+            UpdateCandidateSourceWire::DerivedMirror => Self::DerivedMirror,
+        }
+    }
+}
+
+impl From<UpdateCandidateSource> for UpdateCandidateSourceWire {
+    fn from(source: UpdateCandidateSource) -> Self {
+        match source {
+            UpdateCandidateSource::Primary => Self::Primary,
+            UpdateCandidateSource::Mirror => Self::Mirror,
+            UpdateCandidateSource::DerivedMirror => Self::DerivedMirror,
+        }
+    }
+}
+
+pub(crate) fn plan_update_download_candidates_json(request_json: &str) -> Option<String> {
+    let wire_request: UpdateDownloadPlanWireRequest = serde_json::from_str(request_json).ok()?;
+    if wire_request.schema_version != SCHEMA_VERSION {
+        return None;
+    }
+
+    let mut previous_index = None;
+    for candidate in &wire_request.candidates {
+        if previous_index.is_some_and(|previous| candidate.original_index <= previous) {
+            return None;
+        }
+        previous_index = Some(candidate.original_index);
+    }
+
+    let request = UpdateDownloadPlanRequest {
+        candidates: wire_request
+            .candidates
+            .into_iter()
+            .map(|candidate| UpdateCandidateInput {
+                original_index: candidate.original_index,
+                url: candidate.url,
+                source: candidate.source.into(),
+            })
+            .collect(),
+        proxy: wire_request.proxy.map(|proxy| UpdateDownloadProxy {
+            template: proxy.template,
+            proxy_first: proxy.proxy_first,
+        }),
+    };
+    let plan = plan_update_download_candidates(&request).ok()?;
+    let status = if plan.candidates.is_empty() {
+        UpdateDownloadPlanWireStatus::Empty
+    } else {
+        UpdateDownloadPlanWireStatus::Planned
+    };
+    let response = UpdateDownloadPlanWireResponse {
+        schema_version: SCHEMA_VERSION,
+        status,
+        candidates: plan
+            .candidates
+            .into_iter()
+            .map(|candidate| PlannedUpdateCandidateWire {
+                input_index: candidate.input_index,
+                source: candidate.source.into(),
+                route: match candidate.route {
+                    UpdateCandidateRoute::Direct => UpdateCandidateRouteWire::Direct,
+                    UpdateCandidateRoute::Proxy => UpdateCandidateRouteWire::Proxy,
+                },
+                url: candidate.url,
+            })
+            .collect(),
+    };
+    serde_json::to_string(&response).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{Value, json};
+
+    fn candidate(index: usize, url: &str, source: UpdateCandidateSource) -> UpdateCandidateInput {
+        UpdateCandidateInput {
+            original_index: index,
+            url: url.to_string(),
+            source,
+        }
+    }
+
+    fn request(
+        candidates: Vec<UpdateCandidateInput>,
+        proxy: Option<(&str, bool)>,
+    ) -> UpdateDownloadPlanRequest {
+        UpdateDownloadPlanRequest {
+            candidates,
+            proxy: proxy.map(|(template, proxy_first)| UpdateDownloadProxy {
+                template: template.to_string(),
+                proxy_first,
+            }),
+        }
+    }
+
+    fn urls(plan: &UpdateDownloadPlan) -> Vec<&str> {
+        plan.candidates
+            .iter()
+            .map(|candidate| candidate.url.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn empty_input_is_a_valid_empty_plan() {
+        let plan = plan_update_download_candidates(&request(vec![], None)).unwrap();
+        assert!(plan.candidates.is_empty());
+    }
+
+    #[test]
+    fn one_direct_url_preserves_identity() {
+        let plan = plan_update_download_candidates(&request(
+            vec![candidate(
+                7,
+                "https://example/app.zip",
+                UpdateCandidateSource::Primary,
+            )],
+            None,
+        ))
+        .unwrap();
+        assert_eq!(urls(&plan), ["https://example/app.zip"]);
+        assert_eq!(plan.candidates[0].input_index, 7);
+        assert_eq!(plan.candidates[0].source, UpdateCandidateSource::Primary);
+        assert_eq!(plan.candidates[0].route, UpdateCandidateRoute::Direct);
+    }
+
+    #[test]
+    fn trims_urls_and_removes_empty_entries() {
+        let plan = plan_update_download_candidates(&request(
+            vec![
+                candidate(0, "  https://example/a  ", UpdateCandidateSource::Primary),
+                candidate(1, " \t\n ", UpdateCandidateSource::Mirror),
+            ],
+            None,
+        ))
+        .unwrap();
+        assert_eq!(urls(&plan), ["https://example/a"]);
+    }
+
+    #[test]
+    fn stable_first_occurrence_deduplication_preserves_source() {
+        let plan = plan_update_download_candidates(&request(
+            vec![
+                candidate(0, "https://example/a", UpdateCandidateSource::Primary),
+                candidate(1, " https://example/a ", UpdateCandidateSource::Mirror),
+                candidate(2, "https://example/b", UpdateCandidateSource::DerivedMirror),
+            ],
+            None,
+        ))
+        .unwrap();
+        assert_eq!(urls(&plan), ["https://example/a", "https://example/b"]);
+        assert_eq!(plan.candidates[0].input_index, 0);
+        assert_eq!(plan.candidates[1].input_index, 2);
+    }
+
+    #[test]
+    fn direct_first_and_proxy_first_are_explicit() {
+        let direct_first = plan_update_download_candidates(&request(
+            vec![candidate(
+                0,
+                "https://example/a",
+                UpdateCandidateSource::Primary,
+            )],
+            Some(("https://proxy/{url}", false)),
+        ))
+        .unwrap();
+        assert_eq!(
+            urls(&direct_first),
+            ["https://example/a", "https://proxy/https://example/a"]
+        );
+
+        let proxy_first = plan_update_download_candidates(&request(
+            vec![candidate(
+                0,
+                "https://example/a",
+                UpdateCandidateSource::Primary,
+            )],
+            Some(("https://proxy/{url}", true)),
+        ))
+        .unwrap();
+        assert_eq!(
+            urls(&proxy_first),
+            ["https://proxy/https://example/a", "https://example/a"]
+        );
+    }
+
+    #[test]
+    fn supports_encoded_placeholder_and_suffix_separators() {
+        let encoded = plan_update_download_candidates(&request(
+            vec![candidate(
+                0,
+                "https://example/歌曲 a",
+                UpdateCandidateSource::Primary,
+            )],
+            Some(("https://proxy/{url_encoded}", true)),
+        ))
+        .unwrap();
+        assert_eq!(
+            urls(&encoded)[0],
+            "https://proxy/https%3A%2F%2Fexample%2F%E6%AD%8C%E6%9B%B2%20a"
+        );
+
+        for template in [
+            "https://proxy/",
+            "https://proxy=",
+            "https://proxy?",
+            "https://proxy&",
+        ] {
+            let plan = plan_update_download_candidates(&request(
+                vec![candidate(
+                    0,
+                    "https://example/a",
+                    UpdateCandidateSource::Primary,
+                )],
+                Some((template, true)),
+            ))
+            .unwrap();
+            assert_eq!(urls(&plan)[0], format!("{template}https://example/a"));
+        }
+    }
+
+    #[test]
+    fn empty_or_equal_proxy_does_not_add_a_candidate() {
+        for proxy in ["", "   ", "{url}"] {
+            let plan = plan_update_download_candidates(&request(
+                vec![candidate(
+                    0,
+                    "https://example/a",
+                    UpdateCandidateSource::Primary,
+                )],
+                Some((proxy, true)),
+            ))
+            .unwrap();
+            assert_eq!(urls(&plan), ["https://example/a"]);
+            assert_eq!(plan.candidates[0].route, UpdateCandidateRoute::Direct);
+        }
+    }
+
+    #[test]
+    fn proxy_results_repeated_by_later_direct_inputs_are_deduplicated_stably() {
+        let plan = plan_update_download_candidates(&request(
+            vec![
+                candidate(0, "https://example/a", UpdateCandidateSource::Primary),
+                candidate(
+                    1,
+                    "https://proxy/https://example/a",
+                    UpdateCandidateSource::Mirror,
+                ),
+            ],
+            Some(("https://proxy/{url}", false)),
+        ))
+        .unwrap();
+        assert_eq!(
+            urls(&plan),
+            [
+                "https://example/a",
+                "https://proxy/https://example/a",
+                "https://proxy/https://proxy/https://example/a",
+            ]
+        );
+        assert_eq!(plan.candidates[1].input_index, 0);
+    }
+
+    #[test]
+    fn ordered_mirrors_and_cross_source_duplicates_are_stable() {
+        let plan = plan_update_download_candidates(&request(
+            vec![
+                candidate(0, "https://primary", UpdateCandidateSource::Primary),
+                candidate(1, "https://mirror-b", UpdateCandidateSource::Mirror),
+                candidate(2, "https://mirror-a", UpdateCandidateSource::Mirror),
+                candidate(3, "https://primary", UpdateCandidateSource::DerivedMirror),
+            ],
+            None,
+        ))
+        .unwrap();
+        assert_eq!(
+            urls(&plan),
+            ["https://primary", "https://mirror-b", "https://mirror-a"]
+        );
+    }
+
+    #[test]
+    fn unicode_and_percent_encoded_urls_are_preserved() {
+        let plan = plan_update_download_candidates(&request(
+            vec![
+                candidate(
+                    0,
+                    "https://例子.test/歌曲.zip",
+                    UpdateCandidateSource::Primary,
+                ),
+                candidate(
+                    1,
+                    "https://example/%E6%AD%8C.zip",
+                    UpdateCandidateSource::Mirror,
+                ),
+            ],
+            None,
+        ))
+        .unwrap();
+        assert_eq!(
+            urls(&plan),
+            [
+                "https://例子.test/歌曲.zip",
+                "https://example/%E6%AD%8C.zip"
+            ]
+        );
+    }
+
+    #[test]
+    fn duplicate_typed_indices_are_invalid() {
+        let error = plan_update_download_candidates(&request(
+            vec![
+                candidate(3, "https://example/a", UpdateCandidateSource::Primary),
+                candidate(3, "https://example/b", UpdateCandidateSource::Mirror),
+            ],
+            None,
+        ));
+        assert_eq!(error, Err(UpdateDownloadPlanError::InvalidRequest));
+    }
+
+    #[test]
+    fn planning_is_deterministic() {
+        let request = request(
+            vec![
+                candidate(0, "https://example/a", UpdateCandidateSource::Primary),
+                candidate(1, "https://example/b", UpdateCandidateSource::Mirror),
+            ],
+            Some(("https://proxy/{url_encoded}", true)),
+        );
+        let first = plan_update_download_candidates(&request).unwrap();
+        for _ in 0..20 {
+            assert_eq!(plan_update_download_candidates(&request).unwrap(), first);
+        }
+    }
+
+    fn wire_request(candidates: Value, proxy: Value) -> String {
+        json!({
+            "schema_version": 1,
+            "candidates": candidates,
+            "proxy": proxy,
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn wire_returns_valid_empty_and_planned_responses() {
+        let empty: Value = serde_json::from_str(
+            &plan_update_download_candidates_json(&wire_request(json!([]), Value::Null)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(empty["status"], "empty");
+        assert_eq!(empty["candidates"], json!([]));
+
+        let planned: Value = serde_json::from_str(
+            &plan_update_download_candidates_json(&wire_request(
+                json!([{"original_index": 0, "url": " https://example/a ", "source": "primary"}]),
+                json!({"template": "https://proxy/{url}", "proxy_first": false}),
+            ))
+            .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(planned["status"], "planned");
+        assert_eq!(planned["candidates"][0]["route"], "direct");
+        assert_eq!(planned["candidates"][1]["route"], "proxy");
+    }
+
+    #[test]
+    fn wire_rejects_bad_schema_json_sources_indices_and_unknown_fields() {
+        assert!(plan_update_download_candidates_json("not json").is_none());
+        assert!(
+            plan_update_download_candidates_json(
+                &json!({"schema_version": 2, "candidates": [], "proxy": null}).to_string()
+            )
+            .is_none()
+        );
+        assert!(
+            plan_update_download_candidates_json(&wire_request(
+                json!([{"original_index": 0, "url": "x", "source": "unknown"}]),
+                Value::Null,
+            ))
+            .is_none()
+        );
+        assert!(
+            plan_update_download_candidates_json(&wire_request(
+                json!([
+                    {"original_index": 1, "url": "a", "source": "primary"},
+                    {"original_index": 1, "url": "b", "source": "mirror"}
+                ]),
+                Value::Null,
+            ))
+            .is_none()
+        );
+        assert!(
+            plan_update_download_candidates_json(
+                &json!({"schema_version": 1, "candidates": [], "proxy": null, "extra": true})
+                    .to_string()
+            )
+            .is_none()
+        );
+    }
+}

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -314,6 +314,27 @@ pub unsafe extern "C" fn rust_decide_audio_binding(request_json: *const c_char) 
     })
 }
 
+/// Plans ordered updater download candidates from a schema-v1 JSON request.
+///
+/// Returns an owned JSON string that must be freed with [`rust_free_string`].
+/// A valid request whose inputs normalize to no URLs returns a concrete `empty`
+/// response. Invalid pointers, UTF-8, JSON, schemas, source kinds, or indices
+/// return null.
+///
+/// # Safety
+///
+/// `request_json` must point to a valid null-terminated UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_plan_update_download_candidates(
+    request_json: *const c_char,
+) -> *mut c_char {
+    ffi_string_result(|| {
+        // SAFETY: Required by this export's C ABI contract.
+        let request_json = unsafe { input(request_json)? };
+        crate::download_candidate_planning::plan_update_download_candidates_json(request_json)
+    })
+}
+
 /// # Safety
 ///
 /// This function is unsafe because it dereferences a raw pointer. The caller must ensure
@@ -574,6 +595,67 @@ mod tests {
     fn audio_binding_export_uses_shared_panic_containment() {
         let result = ffi_string_result(|| -> Option<String> {
             panic!("simulated audio binding panic");
+        });
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn update_download_planning_export_rejects_invalid_ffi_and_wire_inputs() {
+        let invalid_utf8 = [0xff_u8 as c_char, 0];
+        let invalid_json = CString::new("not json").unwrap();
+        let unsupported_schema =
+            CString::new(r#"{"schema_version":2,"candidates":[],"proxy":null}"#).unwrap();
+        let invalid_source = CString::new(
+            r#"{"schema_version":1,"candidates":[{"original_index":0,"url":"x","source":"unknown"}],"proxy":null}"#,
+        )
+        .unwrap();
+        let invalid_indices = CString::new(
+            r#"{"schema_version":1,"candidates":[{"original_index":1,"url":"a","source":"primary"},{"original_index":1,"url":"b","source":"mirror"}],"proxy":null}"#,
+        )
+        .unwrap();
+
+        unsafe {
+            assert!(rust_plan_update_download_candidates(std::ptr::null()).is_null());
+            assert!(rust_plan_update_download_candidates(invalid_utf8.as_ptr()).is_null());
+            assert!(rust_plan_update_download_candidates(invalid_json.as_ptr()).is_null());
+            assert!(rust_plan_update_download_candidates(unsupported_schema.as_ptr()).is_null());
+            assert!(rust_plan_update_download_candidates(invalid_source.as_ptr()).is_null());
+            assert!(rust_plan_update_download_candidates(invalid_indices.as_ptr()).is_null());
+        }
+    }
+
+    #[test]
+    fn update_download_planning_export_returns_owned_empty_and_planned_json() {
+        let empty = CString::new(r#"{"schema_version":1,"candidates":[],"proxy":null}"#).unwrap();
+        let planned = CString::new(
+            r#"{"schema_version":1,"candidates":[{"original_index":0,"url":"https://example/app.zip","source":"primary"}],"proxy":{"template":"https://proxy/{url}","proxy_first":true}}"#,
+        )
+        .unwrap();
+
+        unsafe {
+            for _ in 0..20 {
+                let result = rust_plan_update_download_candidates(empty.as_ptr());
+                assert!(!result.is_null());
+                let response = CStr::from_ptr(result).to_str().unwrap();
+                assert!(response.contains(r#""status":"empty""#));
+                assert!(response.contains(r#""candidates":[]"#));
+                rust_free_string(result);
+            }
+
+            let result = rust_plan_update_download_candidates(planned.as_ptr());
+            assert!(!result.is_null());
+            let response = CStr::from_ptr(result).to_str().unwrap();
+            assert!(response.contains(r#""status":"planned""#));
+            assert!(response.contains(r#""route":"proxy""#));
+            assert!(response.contains(r#""route":"direct""#));
+            rust_free_string(result);
+        }
+    }
+
+    #[test]
+    fn update_download_planning_export_uses_shared_panic_containment() {
+        let result = ffi_string_result(|| -> Option<String> {
+            panic!("simulated update download planning panic");
         });
         assert!(result.is_null());
     }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -335,6 +335,46 @@ pub unsafe extern "C" fn rust_plan_update_download_candidates(
     })
 }
 
+/// Plans ordered media primary/backup URL candidates from schema-v1 JSON.
+///
+/// Returns an owned JSON string that must be freed with [`rust_free_string`].
+/// Valid inputs that produce no candidates return an `empty` response; invalid
+/// pointers, UTF-8, JSON, schemas, modes, stream kinds, or indices return null.
+///
+/// # Safety
+///
+/// `request_json` must point to a valid null-terminated UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_plan_media_download_candidates(
+    request_json: *const c_char,
+) -> *mut c_char {
+    ffi_string_result(|| {
+        // SAFETY: Required by this export's C ABI contract.
+        let request_json = unsafe { input(request_json)? };
+        crate::media_download_candidate_planning::plan_media_download_candidates_json(request_json)
+    })
+}
+
+/// Plans ordered tool primary/fallback URL candidates from schema-v1 JSON.
+///
+/// Returns an owned JSON string that must be freed with [`rust_free_string`].
+/// Valid supplied assets with no usable URL return an `empty` response; invalid
+/// or unsupported requests return null and therefore use the Python reference.
+///
+/// # Safety
+///
+/// `request_json` must point to a valid null-terminated UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_plan_tool_download_candidates(
+    request_json: *const c_char,
+) -> *mut c_char {
+    ffi_string_result(|| {
+        // SAFETY: Required by this export's C ABI contract.
+        let request_json = unsafe { input(request_json)? };
+        crate::tool_download_candidate_planning::plan_tool_download_candidates_json(request_json)
+    })
+}
+
 /// # Safety
 ///
 /// This function is unsafe because it dereferences a raw pointer. The caller must ensure
@@ -656,6 +696,76 @@ mod tests {
     fn update_download_planning_export_uses_shared_panic_containment() {
         let result = ffi_string_result(|| -> Option<String> {
             panic!("simulated update download planning panic");
+        });
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn media_download_planning_export_rejects_invalid_inputs_and_returns_owned_json() {
+        let invalid_utf8 = [0xff_u8 as c_char, 0];
+        let invalid_json = CString::new("not json").unwrap();
+        let unsupported_schema = CString::new(
+            r#"{"schema_version":2,"mode":"dash_streams","stream_kind":"video","streams":[]}"#,
+        )
+        .unwrap();
+        let empty = CString::new(
+            r#"{"schema_version":1,"mode":"dash_streams","stream_kind":"video","streams":[]}"#,
+        )
+        .unwrap();
+        let planned = CString::new(
+            r#"{"schema_version":1,"mode":"dash_streams","stream_kind":"audio","streams":[{"original_index":0,"primary_url":" a ","backup_urls":["b"]}]}"#,
+        )
+        .unwrap();
+        unsafe {
+            assert!(rust_plan_media_download_candidates(std::ptr::null()).is_null());
+            assert!(rust_plan_media_download_candidates(invalid_utf8.as_ptr()).is_null());
+            assert!(rust_plan_media_download_candidates(invalid_json.as_ptr()).is_null());
+            assert!(rust_plan_media_download_candidates(unsupported_schema.as_ptr()).is_null());
+            for request in [&empty, &planned] {
+                for _ in 0..10 {
+                    let result = rust_plan_media_download_candidates(request.as_ptr());
+                    assert!(!result.is_null());
+                    rust_free_string(result);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn tool_download_planning_export_rejects_invalid_inputs_and_returns_owned_json() {
+        let invalid_utf8 = [0xff_u8 as c_char, 0];
+        let invalid_json = CString::new("not json").unwrap();
+        let invalid_enum = CString::new(
+            r#"{"schema_version":1,"tool":"unknown","asset":{"mode":"supplied","name":"a","primary_url":""},"fallback_bases":[]}"#,
+        )
+        .unwrap();
+        let empty = CString::new(
+            r#"{"schema_version":1,"tool":"bbdown","asset":{"mode":"supplied","name":"a","primary_url":""},"fallback_bases":[]}"#,
+        )
+        .unwrap();
+        let planned = CString::new(
+            r#"{"schema_version":1,"tool":"ytdlp","asset":{"mode":"supplied","name":"yt-dlp","primary_url":"https://primary"},"fallback_bases":[{"original_index":0,"base_url":"https://mirror"}]}"#,
+        )
+        .unwrap();
+        unsafe {
+            assert!(rust_plan_tool_download_candidates(std::ptr::null()).is_null());
+            assert!(rust_plan_tool_download_candidates(invalid_utf8.as_ptr()).is_null());
+            assert!(rust_plan_tool_download_candidates(invalid_json.as_ptr()).is_null());
+            assert!(rust_plan_tool_download_candidates(invalid_enum.as_ptr()).is_null());
+            for request in [&empty, &planned] {
+                for _ in 0..10 {
+                    let result = rust_plan_tool_download_candidates(request.as_ptr());
+                    assert!(!result.is_null());
+                    rust_free_string(result);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn new_download_planners_use_shared_panic_containment() {
+        let result = ffi_string_result(|| -> Option<String> {
+            panic!("simulated candidate planning panic");
         });
         assert!(result.is_null());
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,10 +5,12 @@ mod audio_binding;
 mod download_candidate_planning;
 mod ffi;
 mod filename;
+mod media_download_candidate_planning;
 mod media_page_selection;
 mod platform;
 mod release_selection;
 mod title_cleanup;
+mod tool_download_candidate_planning;
 mod url_utils;
 mod version;
 
@@ -26,9 +28,15 @@ pub use ffi::{
     rust_asset_has_windows, rust_asset_has_x64, rust_asset_tokens, rust_backend_abi_version,
     rust_clean_display_title, rust_decide_audio_binding, rust_format_download_proxy_url,
     rust_free_string, rust_is_downloadable_archive, rust_normalize_machine_arch,
-    rust_normalize_version_tag, rust_plan_update_download_candidates,
+    rust_normalize_version_tag, rust_plan_media_download_candidates,
+    rust_plan_tool_download_candidates, rust_plan_update_download_candidates,
     rust_release_list_api_from_latest, rust_safe_filename, rust_select_media_pages,
     rust_select_release, rust_select_update_asset, rust_version_sort_key, rust_version_tuple,
+};
+pub use media_download_candidate_planning::{
+    MediaCandidateSource, MediaDownloadPlan, MediaDownloadPlanError, MediaDownloadPlanMode,
+    MediaDownloadPlanRequest, MediaStreamKind, MediaStreamUrlInput, PlannedMediaCandidate,
+    plan_media_download_candidates,
 };
 pub use media_page_selection::{
     MediaPageDescriptor, MediaPageSelection, MediaPageSelectionError, MediaPageSelectionRequest,
@@ -37,4 +45,9 @@ pub use media_page_selection::{
 pub use release_selection::{
     ReleaseCandidate, ReleaseSelection, ReleaseSelectionError, ReleaseSelectionRequest,
     select_release,
+};
+pub use tool_download_candidate_planning::{
+    PlannedToolCandidate, ToolAssetInput, ToolCandidateSource, ToolDownloadPlan,
+    ToolDownloadPlanError, ToolDownloadPlanRequest, ToolFallbackBaseInput, ToolKind, ToolTarget,
+    plan_tool_download_candidates,
 };

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,6 +2,7 @@ mod archive;
 mod asset_selection;
 mod asset_tokens;
 mod audio_binding;
+mod download_candidate_planning;
 mod ffi;
 mod filename;
 mod media_page_selection;
@@ -15,14 +16,19 @@ pub use audio_binding::{
     AudioBindingDecision, AudioBindingError, AudioBindingMode, AudioBindingRequest,
     AudioBindingResult, AudioPageDescriptor, decide_audio_binding,
 };
+pub use download_candidate_planning::{
+    PlannedUpdateCandidate, UpdateCandidateInput, UpdateCandidateRoute, UpdateCandidateSource,
+    UpdateDownloadPlan, UpdateDownloadPlanError, UpdateDownloadPlanRequest, UpdateDownloadProxy,
+    plan_update_download_candidates,
+};
 pub use ffi::{
     rust_asset_has_arm64, rust_asset_has_linux, rust_asset_has_macos, rust_asset_has_universal,
     rust_asset_has_windows, rust_asset_has_x64, rust_asset_tokens, rust_backend_abi_version,
     rust_clean_display_title, rust_decide_audio_binding, rust_format_download_proxy_url,
     rust_free_string, rust_is_downloadable_archive, rust_normalize_machine_arch,
-    rust_normalize_version_tag, rust_release_list_api_from_latest, rust_safe_filename,
-    rust_select_media_pages, rust_select_release, rust_select_update_asset, rust_version_sort_key,
-    rust_version_tuple,
+    rust_normalize_version_tag, rust_plan_update_download_candidates,
+    rust_release_list_api_from_latest, rust_safe_filename, rust_select_media_pages,
+    rust_select_release, rust_select_update_asset, rust_version_sort_key, rust_version_tuple,
 };
 pub use media_page_selection::{
     MediaPageDescriptor, MediaPageSelection, MediaPageSelectionError, MediaPageSelectionRequest,

--- a/rust/src/media_download_candidate_planning.rs
+++ b/rust/src/media_download_candidate_planning.rs
@@ -1,0 +1,370 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaDownloadPlanMode {
+    DashStreams,
+    PreferredAudio,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaStreamKind {
+    Video,
+    Audio,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaStreamUrlInput {
+    pub original_index: usize,
+    pub primary_url: String,
+    pub backup_urls: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaDownloadPlanRequest {
+    pub mode: MediaDownloadPlanMode,
+    pub stream_kind: MediaStreamKind,
+    pub streams: Vec<MediaStreamUrlInput>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaCandidateSource {
+    Primary,
+    Backup,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedMediaCandidate {
+    pub stream_index: usize,
+    pub source: MediaCandidateSource,
+    pub backup_index: Option<usize>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediaDownloadPlan {
+    pub candidates: Vec<PlannedMediaCandidate>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaDownloadPlanError {
+    InvalidRequest,
+}
+
+pub fn plan_media_download_candidates(
+    request: &MediaDownloadPlanRequest,
+) -> Result<MediaDownloadPlan, MediaDownloadPlanError> {
+    if request.mode == MediaDownloadPlanMode::PreferredAudio
+        && (request.stream_kind != MediaStreamKind::Audio || request.streams.len() > 1)
+    {
+        return Err(MediaDownloadPlanError::InvalidRequest);
+    }
+
+    let mut indices = HashSet::with_capacity(request.streams.len());
+    if request
+        .streams
+        .iter()
+        .any(|stream| !indices.insert(stream.original_index))
+    {
+        return Err(MediaDownloadPlanError::InvalidRequest);
+    }
+
+    let mut candidates = Vec::new();
+    for stream in &request.streams {
+        push_candidate(
+            &mut candidates,
+            request.mode,
+            stream.original_index,
+            MediaCandidateSource::Primary,
+            None,
+            &stream.primary_url,
+        );
+        for (backup_index, backup_url) in stream.backup_urls.iter().enumerate() {
+            push_candidate(
+                &mut candidates,
+                request.mode,
+                stream.original_index,
+                MediaCandidateSource::Backup,
+                Some(backup_index),
+                backup_url,
+            );
+        }
+    }
+    Ok(MediaDownloadPlan { candidates })
+}
+
+fn push_candidate(
+    candidates: &mut Vec<PlannedMediaCandidate>,
+    mode: MediaDownloadPlanMode,
+    stream_index: usize,
+    source: MediaCandidateSource,
+    backup_index: Option<usize>,
+    raw_url: &str,
+) {
+    let url = match mode {
+        MediaDownloadPlanMode::DashStreams => raw_url.trim(),
+        MediaDownloadPlanMode::PreferredAudio => raw_url,
+    };
+    if mode == MediaDownloadPlanMode::DashStreams && url.is_empty() {
+        return;
+    }
+    candidates.push(PlannedMediaCandidate {
+        stream_index,
+        source,
+        backup_index,
+        url: url.to_string(),
+    });
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MediaDownloadPlanWireRequest {
+    schema_version: u32,
+    mode: MediaDownloadPlanModeWire,
+    stream_kind: MediaStreamKindWire,
+    streams: Vec<MediaStreamUrlWireInput>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum MediaDownloadPlanModeWire {
+    DashStreams,
+    PreferredAudio,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum MediaStreamKindWire {
+    Video,
+    Audio,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MediaStreamUrlWireInput {
+    original_index: usize,
+    primary_url: String,
+    backup_urls: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum MediaDownloadPlanWireStatus {
+    Planned,
+    Empty,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum MediaCandidateSourceWire {
+    Primary,
+    Backup,
+}
+
+#[derive(Debug, Serialize)]
+struct PlannedMediaCandidateWire {
+    stream_index: usize,
+    source: MediaCandidateSourceWire,
+    backup_index: Option<usize>,
+    url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct MediaDownloadPlanWireResponse {
+    schema_version: u32,
+    status: MediaDownloadPlanWireStatus,
+    candidates: Vec<PlannedMediaCandidateWire>,
+}
+
+pub(crate) fn plan_media_download_candidates_json(request_json: &str) -> Option<String> {
+    let wire: MediaDownloadPlanWireRequest = serde_json::from_str(request_json).ok()?;
+    if wire.schema_version != SCHEMA_VERSION {
+        return None;
+    }
+    let mut previous_index = None;
+    for stream in &wire.streams {
+        if previous_index.is_some_and(|previous| stream.original_index <= previous) {
+            return None;
+        }
+        previous_index = Some(stream.original_index);
+    }
+    let request = MediaDownloadPlanRequest {
+        mode: match wire.mode {
+            MediaDownloadPlanModeWire::DashStreams => MediaDownloadPlanMode::DashStreams,
+            MediaDownloadPlanModeWire::PreferredAudio => MediaDownloadPlanMode::PreferredAudio,
+        },
+        stream_kind: match wire.stream_kind {
+            MediaStreamKindWire::Video => MediaStreamKind::Video,
+            MediaStreamKindWire::Audio => MediaStreamKind::Audio,
+        },
+        streams: wire
+            .streams
+            .into_iter()
+            .map(|stream| MediaStreamUrlInput {
+                original_index: stream.original_index,
+                primary_url: stream.primary_url,
+                backup_urls: stream.backup_urls,
+            })
+            .collect(),
+    };
+    let plan = plan_media_download_candidates(&request).ok()?;
+    let status = if plan.candidates.is_empty() {
+        MediaDownloadPlanWireStatus::Empty
+    } else {
+        MediaDownloadPlanWireStatus::Planned
+    };
+    serde_json::to_string(&MediaDownloadPlanWireResponse {
+        schema_version: SCHEMA_VERSION,
+        status,
+        candidates: plan
+            .candidates
+            .into_iter()
+            .map(|candidate| PlannedMediaCandidateWire {
+                stream_index: candidate.stream_index,
+                source: match candidate.source {
+                    MediaCandidateSource::Primary => MediaCandidateSourceWire::Primary,
+                    MediaCandidateSource::Backup => MediaCandidateSourceWire::Backup,
+                },
+                backup_index: candidate.backup_index,
+                url: candidate.url,
+            })
+            .collect(),
+    })
+    .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stream(index: usize, primary: &str, backups: &[&str]) -> MediaStreamUrlInput {
+        MediaStreamUrlInput {
+            original_index: index,
+            primary_url: primary.to_string(),
+            backup_urls: backups.iter().map(|url| (*url).to_string()).collect(),
+        }
+    }
+
+    fn request(
+        mode: MediaDownloadPlanMode,
+        kind: MediaStreamKind,
+        streams: Vec<MediaStreamUrlInput>,
+    ) -> MediaDownloadPlanRequest {
+        MediaDownloadPlanRequest {
+            mode,
+            stream_kind: kind,
+            streams,
+        }
+    }
+
+    fn urls(plan: &MediaDownloadPlan) -> Vec<&str> {
+        plan.candidates
+            .iter()
+            .map(|item| item.url.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn dash_empty_primary_backup_order_and_duplicates_are_preserved() {
+        let plan = plan_media_download_candidates(&request(
+            MediaDownloadPlanMode::DashStreams,
+            MediaStreamKind::Video,
+            vec![
+                stream(2, " primary ", &[" backup ", "primary", " "]),
+                stream(5, "", &["backup", "backup"]),
+            ],
+        ))
+        .unwrap();
+        assert_eq!(
+            urls(&plan),
+            ["primary", "backup", "primary", "backup", "backup"]
+        );
+        assert_eq!(plan.candidates[1].stream_index, 2);
+        assert_eq!(plan.candidates[1].source, MediaCandidateSource::Backup);
+        assert_eq!(plan.candidates[1].backup_index, Some(0));
+    }
+
+    #[test]
+    fn preferred_audio_preserves_raw_strings_and_duplicates() {
+        let plan = plan_media_download_candidates(&request(
+            MediaDownloadPlanMode::PreferredAudio,
+            MediaStreamKind::Audio,
+            vec![stream(9, " primary ", &["", " primary ", "歌曲/%E6%AD%8C"])],
+        ))
+        .unwrap();
+        assert_eq!(
+            urls(&plan),
+            [" primary ", "", " primary ", "歌曲/%E6%AD%8C"]
+        );
+    }
+
+    #[test]
+    fn empty_input_is_valid_and_execution_is_deterministic() {
+        let request = request(
+            MediaDownloadPlanMode::DashStreams,
+            MediaStreamKind::Audio,
+            vec![stream(
+                0,
+                "https://例子.test/歌曲",
+                &["https://example/%E6%AD%8C"],
+            )],
+        );
+        let first = plan_media_download_candidates(&request).unwrap();
+        for _ in 0..20 {
+            assert_eq!(plan_media_download_candidates(&request).unwrap(), first);
+        }
+        let empty = plan_media_download_candidates(&MediaDownloadPlanRequest {
+            mode: MediaDownloadPlanMode::DashStreams,
+            stream_kind: MediaStreamKind::Video,
+            streams: vec![],
+        })
+        .unwrap();
+        assert!(empty.candidates.is_empty());
+    }
+
+    #[test]
+    fn invalid_typed_and_wire_invariants_are_rejected() {
+        let duplicate = request(
+            MediaDownloadPlanMode::DashStreams,
+            MediaStreamKind::Video,
+            vec![stream(1, "a", &[]), stream(1, "b", &[])],
+        );
+        assert_eq!(
+            plan_media_download_candidates(&duplicate),
+            Err(MediaDownloadPlanError::InvalidRequest)
+        );
+        let invalid_preferred = request(
+            MediaDownloadPlanMode::PreferredAudio,
+            MediaStreamKind::Video,
+            vec![stream(0, "a", &[])],
+        );
+        assert_eq!(
+            plan_media_download_candidates(&invalid_preferred),
+            Err(MediaDownloadPlanError::InvalidRequest)
+        );
+        assert!(plan_media_download_candidates_json(
+            r#"{"schema_version":1,"mode":"dash_streams","stream_kind":"video","streams":[{"original_index":2,"primary_url":"a","backup_urls":[]},{"original_index":1,"primary_url":"b","backup_urls":[]}]}"#
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn wire_rejects_schema_enums_and_unknown_fields_and_returns_empty() {
+        for invalid in [
+            r#"{"schema_version":2,"mode":"dash_streams","stream_kind":"video","streams":[]}"#,
+            r#"{"schema_version":1,"mode":"unknown","stream_kind":"video","streams":[]}"#,
+            r#"{"schema_version":1,"mode":"dash_streams","stream_kind":"unknown","streams":[]}"#,
+            r#"{"schema_version":1,"mode":"dash_streams","stream_kind":"video","streams":[],"extra":true}"#,
+        ] {
+            assert!(plan_media_download_candidates_json(invalid).is_none());
+        }
+        let response = plan_media_download_candidates_json(
+            r#"{"schema_version":1,"mode":"dash_streams","stream_kind":"video","streams":[]}"#,
+        )
+        .unwrap();
+        assert!(response.contains(r#""status":"empty""#));
+    }
+}

--- a/rust/src/tool_download_candidate_planning.rs
+++ b/rust/src/tool_download_candidate_planning.rs
@@ -1,0 +1,501 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolKind {
+    Bbdown,
+    YtDlp,
+    Aria2c,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolTarget {
+    pub platform: String,
+    pub architecture: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolAssetInput {
+    Supplied { name: String, primary_url: String },
+    DefaultForTarget(ToolTarget),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolFallbackBaseInput {
+    pub original_index: usize,
+    pub base_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolDownloadPlanRequest {
+    pub tool: ToolKind,
+    pub asset: ToolAssetInput,
+    pub fallback_bases: Vec<ToolFallbackBaseInput>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolCandidateSource {
+    SuppliedPrimary,
+    BuiltInPrimary,
+    ConfiguredFallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PlannedToolCandidate {
+    pub source: ToolCandidateSource,
+    pub fallback_index: Option<usize>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolDownloadPlan {
+    pub tool: ToolKind,
+    pub asset_name: String,
+    pub candidates: Vec<PlannedToolCandidate>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolDownloadPlanError {
+    InvalidRequest,
+    UnsupportedTarget,
+}
+
+pub fn plan_tool_download_candidates(
+    request: &ToolDownloadPlanRequest,
+) -> Result<ToolDownloadPlan, ToolDownloadPlanError> {
+    let mut indices = HashSet::with_capacity(request.fallback_bases.len());
+    if request
+        .fallback_bases
+        .iter()
+        .any(|fallback| !indices.insert(fallback.original_index))
+    {
+        return Err(ToolDownloadPlanError::InvalidRequest);
+    }
+
+    let (asset_name, primary) = match &request.asset {
+        ToolAssetInput::Supplied { name, primary_url } => {
+            if name.is_empty() {
+                return Err(ToolDownloadPlanError::InvalidRequest);
+            }
+            (
+                name.clone(),
+                (!primary_url.is_empty())
+                    .then(|| (ToolCandidateSource::SuppliedPrimary, primary_url.clone())),
+            )
+        }
+        ToolAssetInput::DefaultForTarget(target) => default_asset(request.tool, target)?,
+    };
+
+    let mut candidates = Vec::new();
+    let mut seen = HashSet::new();
+    if let Some((source, url)) = primary {
+        seen.insert(url.clone());
+        candidates.push(PlannedToolCandidate {
+            source,
+            fallback_index: None,
+            url,
+        });
+    }
+    for fallback in &request.fallback_bases {
+        if fallback.base_url.is_empty() {
+            continue;
+        }
+        let url = format!(
+            "{}/{}",
+            fallback.base_url,
+            quote_tool_asset_name(&asset_name)
+        );
+        if seen.insert(url.clone()) {
+            candidates.push(PlannedToolCandidate {
+                source: ToolCandidateSource::ConfiguredFallback,
+                fallback_index: Some(fallback.original_index),
+                url,
+            });
+        }
+    }
+    if matches!(request.asset, ToolAssetInput::DefaultForTarget(_))
+        && matches!(request.tool, ToolKind::Bbdown | ToolKind::YtDlp)
+        && candidates.is_empty()
+    {
+        return Err(ToolDownloadPlanError::InvalidRequest);
+    }
+
+    Ok(ToolDownloadPlan {
+        tool: request.tool,
+        asset_name,
+        candidates,
+    })
+}
+
+fn default_asset(
+    tool: ToolKind,
+    target: &ToolTarget,
+) -> Result<(String, Option<(ToolCandidateSource, String)>), ToolDownloadPlanError> {
+    let name = match tool {
+        ToolKind::Bbdown => match (target.platform.as_str(), target.architecture.as_str()) {
+            ("windows", "x64" | "x86") => "BBDown_1.6.3_20240814_win-x64.zip",
+            ("windows", "arm64") => "BBDown_1.6.3_20240814_win-arm64.zip",
+            ("darwin", "x64") => "BBDown_1.6.3_20240814_osx-x64.zip",
+            ("darwin", "arm64") => "BBDown_1.6.3_20240814_osx-arm64.zip",
+            ("linux", "x64") => "BBDown_1.6.3_20240814_linux-x64.zip",
+            ("linux", "arm64") => "BBDown_1.6.3_20240814_linux-arm64.zip",
+            _ => return Err(ToolDownloadPlanError::UnsupportedTarget),
+        },
+        ToolKind::YtDlp => match (target.platform.as_str(), target.architecture.as_str()) {
+            ("windows", "arm64") => "yt-dlp_arm64.exe",
+            ("windows", "x86") => "yt-dlp_x86.exe",
+            ("windows", _) => "yt-dlp.exe",
+            ("darwin", _) => "yt-dlp_macos",
+            ("linux", _) => "yt-dlp_linux",
+            _ => "yt-dlp",
+        },
+        ToolKind::Aria2c => {
+            if target.platform != "windows" {
+                return Err(ToolDownloadPlanError::UnsupportedTarget);
+            }
+            if target.architecture == "x86" {
+                "aria2-1.37.0-win-32bit-build1.zip"
+            } else {
+                "aria2-1.37.0-win-64bit-build1.zip"
+            }
+        }
+    }
+    .to_string();
+    let primary = if tool == ToolKind::Aria2c {
+        Some((
+            ToolCandidateSource::BuiltInPrimary,
+            format!(
+                "https://github.com/aria2/aria2/releases/download/release-1.37.0/{}",
+                quote_tool_asset_name(&name)
+            ),
+        ))
+    } else {
+        None
+    };
+    Ok((name, primary))
+}
+
+fn quote_tool_asset_name(value: &str) -> String {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+    let mut result = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~' | b'/') {
+            result.push(char::from(byte));
+        } else {
+            result.push('%');
+            result.push(char::from(HEX[(byte >> 4) as usize]));
+            result.push(char::from(HEX[(byte & 0x0f) as usize]));
+        }
+    }
+    result
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ToolDownloadPlanWireRequest {
+    schema_version: u32,
+    tool: ToolKindWire,
+    asset: ToolAssetWireInput,
+    fallback_bases: Vec<ToolFallbackBaseWireInput>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ToolKindWire {
+    Bbdown,
+    #[serde(rename = "ytdlp")]
+    YtDlp,
+    Aria2c,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case", deny_unknown_fields)]
+enum ToolAssetWireInput {
+    Supplied { name: String, primary_url: String },
+    DefaultForTarget { platform: String, arch: String },
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ToolFallbackBaseWireInput {
+    original_index: usize,
+    base_url: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ToolDownloadPlanWireStatus {
+    Planned,
+    Empty,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum ToolCandidateSourceWire {
+    SuppliedPrimary,
+    BuiltInPrimary,
+    ConfiguredFallback,
+}
+
+#[derive(Debug, Serialize)]
+struct PlannedToolCandidateWire {
+    source: ToolCandidateSourceWire,
+    fallback_index: Option<usize>,
+    url: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ToolDownloadPlanWireResponse {
+    schema_version: u32,
+    status: ToolDownloadPlanWireStatus,
+    tool: ToolKindWire,
+    asset_name: String,
+    candidates: Vec<PlannedToolCandidateWire>,
+}
+
+impl From<ToolKindWire> for ToolKind {
+    fn from(tool: ToolKindWire) -> Self {
+        match tool {
+            ToolKindWire::Bbdown => Self::Bbdown,
+            ToolKindWire::YtDlp => Self::YtDlp,
+            ToolKindWire::Aria2c => Self::Aria2c,
+        }
+    }
+}
+
+impl From<ToolKind> for ToolKindWire {
+    fn from(tool: ToolKind) -> Self {
+        match tool {
+            ToolKind::Bbdown => Self::Bbdown,
+            ToolKind::YtDlp => Self::YtDlp,
+            ToolKind::Aria2c => Self::Aria2c,
+        }
+    }
+}
+
+pub(crate) fn plan_tool_download_candidates_json(request_json: &str) -> Option<String> {
+    let wire: ToolDownloadPlanWireRequest = serde_json::from_str(request_json).ok()?;
+    if wire.schema_version != SCHEMA_VERSION {
+        return None;
+    }
+    let mut previous_index = None;
+    for fallback in &wire.fallback_bases {
+        if previous_index.is_some_and(|previous| fallback.original_index <= previous) {
+            return None;
+        }
+        previous_index = Some(fallback.original_index);
+    }
+    let tool: ToolKind = wire.tool.into();
+    let request = ToolDownloadPlanRequest {
+        tool,
+        asset: match wire.asset {
+            ToolAssetWireInput::Supplied { name, primary_url } => {
+                ToolAssetInput::Supplied { name, primary_url }
+            }
+            ToolAssetWireInput::DefaultForTarget { platform, arch } => {
+                ToolAssetInput::DefaultForTarget(ToolTarget {
+                    platform,
+                    architecture: arch,
+                })
+            }
+        },
+        fallback_bases: wire
+            .fallback_bases
+            .into_iter()
+            .map(|fallback| ToolFallbackBaseInput {
+                original_index: fallback.original_index,
+                base_url: fallback.base_url,
+            })
+            .collect(),
+    };
+    let plan = plan_tool_download_candidates(&request).ok()?;
+    let status = if plan.candidates.is_empty() {
+        ToolDownloadPlanWireStatus::Empty
+    } else {
+        ToolDownloadPlanWireStatus::Planned
+    };
+    serde_json::to_string(&ToolDownloadPlanWireResponse {
+        schema_version: SCHEMA_VERSION,
+        status,
+        tool: plan.tool.into(),
+        asset_name: plan.asset_name,
+        candidates: plan
+            .candidates
+            .into_iter()
+            .map(|candidate| PlannedToolCandidateWire {
+                source: match candidate.source {
+                    ToolCandidateSource::SuppliedPrimary => {
+                        ToolCandidateSourceWire::SuppliedPrimary
+                    }
+                    ToolCandidateSource::BuiltInPrimary => ToolCandidateSourceWire::BuiltInPrimary,
+                    ToolCandidateSource::ConfiguredFallback => {
+                        ToolCandidateSourceWire::ConfiguredFallback
+                    }
+                },
+                fallback_index: candidate.fallback_index,
+                url: candidate.url,
+            })
+            .collect(),
+    })
+    .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fallback(index: usize, base: &str) -> ToolFallbackBaseInput {
+        ToolFallbackBaseInput {
+            original_index: index,
+            base_url: base.to_string(),
+        }
+    }
+
+    #[test]
+    fn supplied_primary_is_first_and_exact_duplicates_are_removed() {
+        let request = ToolDownloadPlanRequest {
+            tool: ToolKind::YtDlp,
+            asset: ToolAssetInput::Supplied {
+                name: "yt dlp/歌曲".to_string(),
+                primary_url: " https://primary ".to_string(),
+            },
+            fallback_bases: vec![fallback(2, ""), fallback(5, "https://mirror")],
+        };
+        let plan = plan_tool_download_candidates(&request).unwrap();
+        assert_eq!(plan.candidates[0].url, " https://primary ");
+        assert_eq!(
+            plan.candidates[1].url,
+            "https://mirror/yt%20dlp/%E6%AD%8C%E6%9B%B2"
+        );
+        assert_eq!(plan.candidates[1].fallback_index, Some(5));
+    }
+
+    #[test]
+    fn default_assets_preserve_platform_mappings_and_mirror_order() {
+        let bbdown = ToolDownloadPlanRequest {
+            tool: ToolKind::Bbdown,
+            asset: ToolAssetInput::DefaultForTarget(ToolTarget {
+                platform: "windows".to_string(),
+                architecture: "x86".to_string(),
+            }),
+            fallback_bases: vec![fallback(0, "https://one"), fallback(1, "https://two")],
+        };
+        let plan = plan_tool_download_candidates(&bbdown).unwrap();
+        assert_eq!(plan.asset_name, "BBDown_1.6.3_20240814_win-x64.zip");
+        assert_eq!(plan.candidates.len(), 2);
+        assert!(plan.candidates[0].url.starts_with("https://one/"));
+
+        let aria = ToolDownloadPlanRequest {
+            tool: ToolKind::Aria2c,
+            asset: ToolAssetInput::DefaultForTarget(ToolTarget {
+                platform: "windows".to_string(),
+                architecture: "x86".to_string(),
+            }),
+            fallback_bases: vec![fallback(0, "https://mirror")],
+        };
+        let plan = plan_tool_download_candidates(&aria).unwrap();
+        assert_eq!(plan.asset_name, "aria2-1.37.0-win-32bit-build1.zip");
+        assert_eq!(
+            plan.candidates[0].source,
+            ToolCandidateSource::BuiltInPrimary
+        );
+        assert_eq!(
+            plan.candidates[1].source,
+            ToolCandidateSource::ConfiguredFallback
+        );
+    }
+
+    #[test]
+    fn repeated_fallback_results_are_deduplicated_stably() {
+        let request = ToolDownloadPlanRequest {
+            tool: ToolKind::YtDlp,
+            asset: ToolAssetInput::Supplied {
+                name: "yt-dlp".to_string(),
+                primary_url: "https://mirror/yt-dlp".to_string(),
+            },
+            fallback_bases: vec![fallback(0, "https://mirror"), fallback(1, "https://mirror")],
+        };
+        let plan = plan_tool_download_candidates(&request).unwrap();
+        assert_eq!(plan.candidates.len(), 1);
+        assert_eq!(
+            plan.candidates[0].source,
+            ToolCandidateSource::SuppliedPrimary
+        );
+    }
+
+    #[test]
+    fn empty_supplied_plan_is_valid_but_invalid_and_unsupported_requests_fail() {
+        let empty = ToolDownloadPlanRequest {
+            tool: ToolKind::Bbdown,
+            asset: ToolAssetInput::Supplied {
+                name: "asset.zip".to_string(),
+                primary_url: String::new(),
+            },
+            fallback_bases: vec![],
+        };
+        assert!(
+            plan_tool_download_candidates(&empty)
+                .unwrap()
+                .candidates
+                .is_empty()
+        );
+
+        let duplicate_indices = ToolDownloadPlanRequest {
+            fallback_bases: vec![fallback(1, "a"), fallback(1, "b")],
+            ..empty.clone()
+        };
+        assert_eq!(
+            plan_tool_download_candidates(&duplicate_indices),
+            Err(ToolDownloadPlanError::InvalidRequest)
+        );
+
+        let unsupported = ToolDownloadPlanRequest {
+            tool: ToolKind::Aria2c,
+            asset: ToolAssetInput::DefaultForTarget(ToolTarget {
+                platform: "linux".to_string(),
+                architecture: "x64".to_string(),
+            }),
+            fallback_bases: vec![],
+        };
+        assert_eq!(
+            plan_tool_download_candidates(&unsupported),
+            Err(ToolDownloadPlanError::UnsupportedTarget)
+        );
+    }
+
+    #[test]
+    fn unicode_percent_encoding_and_execution_are_deterministic() {
+        let request = ToolDownloadPlanRequest {
+            tool: ToolKind::YtDlp,
+            asset: ToolAssetInput::Supplied {
+                name: "歌曲%20demo".to_string(),
+                primary_url: String::new(),
+            },
+            fallback_bases: vec![fallback(0, "https://例子.test")],
+        };
+        let first = plan_tool_download_candidates(&request).unwrap();
+        assert_eq!(
+            first.candidates[0].url,
+            "https://例子.test/%E6%AD%8C%E6%9B%B2%2520demo"
+        );
+        for _ in 0..20 {
+            assert_eq!(plan_tool_download_candidates(&request).unwrap(), first);
+        }
+    }
+
+    #[test]
+    fn wire_rejects_bad_schema_enums_indices_and_unknown_fields() {
+        for invalid in [
+            r#"{"schema_version":2,"tool":"bbdown","asset":{"mode":"supplied","name":"a","primary_url":""},"fallback_bases":[]}"#,
+            r#"{"schema_version":1,"tool":"unknown","asset":{"mode":"supplied","name":"a","primary_url":""},"fallback_bases":[]}"#,
+            r#"{"schema_version":1,"tool":"bbdown","asset":{"mode":"unknown"},"fallback_bases":[]}"#,
+            r#"{"schema_version":1,"tool":"bbdown","asset":{"mode":"supplied","name":"a","primary_url":""},"fallback_bases":[{"original_index":1,"base_url":"a"},{"original_index":1,"base_url":"b"}]}"#,
+            r#"{"schema_version":1,"tool":"bbdown","asset":{"mode":"supplied","name":"a","primary_url":""},"fallback_bases":[],"extra":true}"#,
+        ] {
+            assert!(plan_tool_download_candidates_json(invalid).is_none());
+        }
+    }
+}

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1616,6 +1616,7 @@ class CacheManagerPolicyTest(unittest.TestCase):
                         "browser_download_url": "https://github.example/yt-dlp.exe",
                     },
                     target_path,
+                    tool="ytdlp",
                 )
         finally:
             manager.shutdown()
@@ -2738,7 +2739,7 @@ class CacheManagerBBDownRegressionTest(unittest.TestCase):
                     "browser_download_url": "https://github.example.com/test_tool_asset"
                 }
                 with self.assertRaisesRegex(RuntimeError, "tool asset test_tool_asset download failed") as ctx:
-                    manager._download_tool_asset(asset, target_file)
+                    manager._download_tool_asset(asset, target_file, tool="bbdown")
                 
                 err_msg = str(ctx.exception)
                 self.assertIn("test_tool_asset", err_msg)

--- a/tests/test_media_download_candidate_planning_backend.py
+++ b/tests/test_media_download_candidate_planning_backend.py
@@ -1,0 +1,112 @@
+import json
+import unittest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+from bilikara import rust_backend
+
+
+def request(mode="dash_streams", kind="video", streams=None):
+    return {
+        "schema_version": 1,
+        "mode": mode,
+        "stream_kind": kind,
+        "streams": streams or [],
+    }
+
+
+class MediaDownloadCandidatePlanningBackendTest(unittest.TestCase):
+    def _mock_response(self, response_json):
+        class Library:
+            @staticmethod
+            def rust_plan_media_download_candidates(_payload):
+                return object()
+
+        stack = ExitStack()
+        self.addCleanup(stack.close)
+        stack.enter_context(patch.object(rust_backend, "_rust_lib", Library()))
+        stack.enter_context(
+            patch.dict(rust_backend._CAPABILITIES, {"plan_media_download_candidates": True})
+        )
+        stack.enter_context(
+            patch.object(rust_backend, "_read_rust_string", return_value=response_json)
+        )
+
+    def test_valid_empty_and_duplicate_preserving_plans_are_accepted(self):
+        self._mock_response(json.dumps({"schema_version": 1, "status": "empty", "candidates": []}))
+        self.assertTrue(rust_backend.try_plan_media_download_candidates(request())[0])
+
+        req = request(
+            streams=[{"original_index": 0, "primary_url": "a", "backup_urls": ["a"]}]
+        )
+        response = {
+            "schema_version": 1,
+            "status": "planned",
+            "candidates": [
+                {"stream_index": 0, "source": "primary", "backup_index": None, "url": "a"},
+                {"stream_index": 0, "source": "backup", "backup_index": 0, "url": "a"},
+            ],
+        }
+        self._mock_response(json.dumps(response))
+        self.assertEqual(rust_backend.try_plan_media_download_candidates(req), (True, response))
+
+    def test_request_validation_rejects_malformed_modes_types_and_indices(self):
+        base = request(streams=[{"original_index": 0, "primary_url": "a", "backup_urls": []}])
+        invalid = [
+            None,
+            {**base, "schema_version": 2},
+            {**base, "mode": []},
+            {**base, "mode": "unknown"},
+            {**base, "mode": "preferred_audio", "stream_kind": "video"},
+            {**base, "extra": True},
+            {**base, "streams": [{**base["streams"][0], "original_index": True}]},
+            {**base, "streams": [base["streams"][0], base["streams"][0]]},
+            {**base, "streams": [{**base["streams"][0], "backup_urls": [None]}]},
+        ]
+        for value in invalid:
+            with self.subTest(value=value):
+                self.assertIsNone(rust_backend._media_download_plan_request(value))
+
+    def test_untrusted_response_rejects_unknown_source_bad_index_order_and_invention(self):
+        req = request(streams=[{"original_index": 3, "primary_url": " a ", "backup_urls": ["b"]}])
+        mode, _kind, streams = rust_backend._media_download_plan_request(req)
+        expected = rust_backend._expected_media_download_candidates(mode, streams)
+        base = {"schema_version": 1, "status": "planned", "candidates": expected}
+        invalid = [
+            {**base, "status": "unknown"},
+            {**base, "status": []},
+            {**base, "extra": True},
+            {**base, "candidates": [{**expected[0], "source": "unknown"}, expected[1]]},
+            {**base, "candidates": [{**expected[0], "source": []}, expected[1]]},
+            {**base, "candidates": [{**expected[0], "stream_index": True}, expected[1]]},
+            {**base, "candidates": [{**expected[0], "stream_index": 99}, expected[1]]},
+            {**base, "candidates": [{**expected[0], "backup_index": 0}, expected[1]]},
+            {**base, "candidates": [{**expected[0], "url": "invented"}, expected[1]]},
+            {**base, "candidates": list(reversed(expected))},
+        ]
+        for value in invalid:
+            with self.subTest(value=value):
+                self.assertFalse(
+                    rust_backend._valid_media_download_plan_response(value, mode, streams)
+                )
+
+    def test_missing_capability_malformed_json_and_capability_isolation_fail_closed(self):
+        with patch.object(rust_backend, "_rust_lib", None):
+            self.assertEqual(
+                rust_backend.try_plan_media_download_candidates(request()), (False, None)
+            )
+        with patch.object(rust_backend, "_rust_lib", object()), patch.dict(
+            rust_backend._CAPABILITIES, {"plan_media_download_candidates": False}
+        ):
+            self.assertEqual(
+                rust_backend.try_plan_media_download_candidates(request()), (False, None)
+            )
+        self._mock_response("not json")
+        self.assertEqual(
+            rust_backend.try_plan_media_download_candidates(request()), (False, None)
+        )
+        self.assertIn("plan_media_download_candidates", rust_backend._SYMBOLS)
+        self.assertNotEqual(
+            rust_backend._SYMBOLS["plan_media_download_candidates"],
+            rust_backend._SYMBOLS["plan_update_download_candidates"],
+        )

--- a/tests/test_media_download_candidate_planning_policy.py
+++ b/tests/test_media_download_candidate_planning_policy.py
@@ -1,0 +1,77 @@
+import itertools
+import os
+import unittest
+from unittest.mock import patch
+
+from bilikara import rust_backend
+from bilikara.cache import CacheManager
+
+
+class MediaDownloadCandidatePlanningPolicyTest(unittest.TestCase):
+    def test_python_dash_reference_trims_drops_empty_and_preserves_duplicates(self):
+        streams = {
+            "video": [
+                {
+                    "url": " primary ",
+                    "backup_urls": [" backup ", "primary", "", "backup"],
+                },
+                {"url": " ", "backup_urls": ["歌曲", "%E6%AD%8C"]},
+            ]
+        }
+        self.assertEqual(
+            CacheManager._py_dash_stream_urls(streams, "video"),
+            ["primary", "backup", "primary", "backup", "歌曲", "%E6%AD%8C"],
+        )
+        self.assertEqual(CacheManager._py_dash_stream_urls({}, "unknown"), [])
+
+    def test_python_preferred_audio_reference_preserves_raw_string_identity(self):
+        preferred = {"url": " primary ", "backup_urls": ["", " primary ", "歌曲"]}
+        self.assertEqual(
+            CacheManager._py_preferred_audio_urls(preferred),
+            [" primary ", "", " primary ", "歌曲"],
+        )
+
+    def test_public_wrappers_fall_back_completely(self):
+        dash = {"audio": [{"url": " a ", "backup_urls": ["", "a"]}]}
+        preferred = {"url": " a ", "backup_urls": ["", "a"]}
+        with patch.object(
+            rust_backend,
+            "try_plan_media_download_candidates",
+            return_value=(False, None),
+        ), patch.object(
+            CacheManager,
+            "_py_dash_stream_urls",
+            wraps=CacheManager._py_dash_stream_urls,
+        ) as dash_fallback, patch.object(
+            CacheManager,
+            "_py_preferred_audio_urls",
+            wraps=CacheManager._py_preferred_audio_urls,
+        ) as preferred_fallback:
+            self.assertEqual(CacheManager._dash_stream_urls(dash, "audio"), ["a", "a"])
+            self.assertEqual(
+                CacheManager._preferred_audio_urls(preferred), [" a ", "", "a"]
+            )
+            dash_fallback.assert_called_once()
+            preferred_fallback.assert_called_once()
+
+    def test_real_native_equivalence_across_generated_fixtures(self):
+        available = rust_backend.backend_status()["capabilities"].get(
+            "plan_media_download_candidates", False
+        )
+        if not available:
+            if os.environ.get("BILIKARA_REQUIRE_RUST_LIB") == "1":
+                self.fail("strict native suite requires media candidate planning")
+            self.skipTest("media candidate planning capability unavailable")
+
+        values = ["", " ", "https://a", " https://a ", "歌曲", "%E6%AD%8C"]
+        for primary, backup in itertools.product(values, repeat=2):
+            dash = {"video": [{"url": primary, "backup_urls": [backup, primary]}]}
+            self.assertEqual(
+                CacheManager._dash_stream_urls(dash, "video"),
+                CacheManager._py_dash_stream_urls(dash, "video"),
+            )
+        preferred = {"url": " raw ", "backup_urls": ["", " raw ", "歌曲"]}
+        self.assertEqual(
+            CacheManager._preferred_audio_urls(preferred),
+            CacheManager._py_preferred_audio_urls(preferred),
+        )

--- a/tests/test_native_utility_release_gate.py
+++ b/tests/test_native_utility_release_gate.py
@@ -33,6 +33,8 @@ EXPECTED_PHASE2_CAPABILITIES = {
     "select_media_pages",
     "decide_audio_binding",
     "plan_update_download_candidates",
+    "plan_media_download_candidates",
+    "plan_tool_download_candidates",
 }
 
 
@@ -119,6 +121,44 @@ class NativeUtilityReleaseGateTest(unittest.TestCase):
         self.assertEqual(
             [candidate["route"] for candidate in plan["candidates"]],
             ["proxy", "direct"],
+        )
+        completed, media_plan = rust_backend.try_plan_media_download_candidates(
+            {
+                "schema_version": 1,
+                "mode": "dash_streams",
+                "stream_kind": "video",
+                "streams": [
+                    {
+                        "original_index": 0,
+                        "primary_url": " primary ",
+                        "backup_urls": ["backup", "primary"],
+                    }
+                ],
+            }
+        )
+        self.assertTrue(completed)
+        self.assertEqual(
+            [candidate["url"] for candidate in media_plan["candidates"]],
+            ["primary", "backup", "primary"],
+        )
+        completed, tool_plan = rust_backend.try_plan_tool_download_candidates(
+            {
+                "schema_version": 1,
+                "tool": "ytdlp",
+                "asset": {
+                    "mode": "supplied",
+                    "name": "yt-dlp",
+                    "primary_url": "https://primary/yt-dlp",
+                },
+                "fallback_bases": [
+                    {"original_index": 0, "base_url": "https://mirror"}
+                ],
+            }
+        )
+        self.assertTrue(completed)
+        self.assertEqual(
+            [candidate["url"] for candidate in tool_plan["candidates"]],
+            ["https://primary/yt-dlp", "https://mirror/yt-dlp"],
         )
 
     def test_phase1_capability_documentation_matches_backend_symbols(self):

--- a/tests/test_native_utility_release_gate.py
+++ b/tests/test_native_utility_release_gate.py
@@ -27,6 +27,14 @@ EXPECTED_PHASE1_CAPABILITIES = {
     "is_downloadable_archive",
 }
 
+EXPECTED_PHASE2_CAPABILITIES = {
+    "select_update_asset",
+    "select_release",
+    "select_media_pages",
+    "decide_audio_binding",
+    "plan_update_download_candidates",
+}
+
 
 class FakeFunction:
     def __init__(self, result=None):
@@ -61,6 +69,7 @@ class NativeUtilityReleaseGateTest(unittest.TestCase):
             )
         )
         self.assertTrue(all(status["capabilities"].values()))
+        self.assertEqual(set(rust_backend.PHASE2_CAPABILITIES), EXPECTED_PHASE2_CAPABILITIES)
 
         # These are Rust-only backend calls. None/False completion sentinels
         # fail the gate instead of silently reaching the public Python fallback.
@@ -89,6 +98,27 @@ class NativeUtilityReleaseGateTest(unittest.TestCase):
                 "bilikara.zip",
                 "https://example/bilikara.zip",
             )
+        )
+        completed, plan = rust_backend.try_plan_update_download_candidates(
+            {
+                "schema_version": 1,
+                "candidates": [
+                    {
+                        "original_index": 0,
+                        "url": "https://example/app.zip",
+                        "source": "primary",
+                    }
+                ],
+                "proxy": {
+                    "template": "https://proxy/{url}",
+                    "proxy_first": True,
+                },
+            }
+        )
+        self.assertTrue(completed)
+        self.assertEqual(
+            [candidate["route"] for candidate in plan["candidates"]],
+            ["proxy", "direct"],
         )
 
     def test_phase1_capability_documentation_matches_backend_symbols(self):

--- a/tests/test_tool_download_candidate_planning_backend.py
+++ b/tests/test_tool_download_candidate_planning_backend.py
@@ -1,0 +1,136 @@
+import json
+import unittest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+from bilikara import rust_backend
+
+
+def request(asset=None, bases=None, tool="bbdown"):
+    return {
+        "schema_version": 1,
+        "tool": tool,
+        "asset": asset or {"mode": "supplied", "name": "tool", "primary_url": "primary"},
+        "fallback_bases": bases or [],
+    }
+
+
+class ToolDownloadCandidatePlanningBackendTest(unittest.TestCase):
+    def _mock_response(self, response_json):
+        class Library:
+            @staticmethod
+            def rust_plan_tool_download_candidates(_payload):
+                return object()
+
+        stack = ExitStack()
+        self.addCleanup(stack.close)
+        stack.enter_context(patch.object(rust_backend, "_rust_lib", Library()))
+        stack.enter_context(
+            patch.dict(rust_backend._CAPABILITIES, {"plan_tool_download_candidates": True})
+        )
+        stack.enter_context(
+            patch.object(rust_backend, "_read_rust_string", return_value=response_json)
+        )
+
+    def test_valid_empty_and_planned_results_are_accepted(self):
+        empty_req = request(
+            {"mode": "supplied", "name": "tool", "primary_url": ""}
+        )
+        empty = {
+            "schema_version": 1,
+            "status": "empty",
+            "tool": "bbdown",
+            "asset_name": "tool",
+            "candidates": [],
+        }
+        self._mock_response(json.dumps(empty))
+        self.assertEqual(rust_backend.try_plan_tool_download_candidates(empty_req), (True, empty))
+
+        planned_req = request(bases=[{"original_index": 2, "base_url": "mirror"}])
+        expected = {
+            "schema_version": 1,
+            "status": "planned",
+            "tool": "bbdown",
+            "asset_name": "tool",
+            "candidates": [
+                {"source": "supplied_primary", "fallback_index": None, "url": "primary"},
+                {"source": "configured_fallback", "fallback_index": 2, "url": "mirror/tool"},
+            ],
+        }
+        self._mock_response(json.dumps(expected))
+        self.assertEqual(
+            rust_backend.try_plan_tool_download_candidates(planned_req), (True, expected)
+        )
+
+    def test_request_validation_rejects_bad_tools_assets_targets_and_indices(self):
+        base = request()
+        invalid = [
+            None,
+            {**base, "schema_version": True},
+            {**base, "tool": []},
+            {**base, "tool": "unknown"},
+            {**base, "asset": {"mode": "supplied", "name": "", "primary_url": ""}},
+            {**base, "asset": {"mode": "unknown"}},
+            {**base, "asset": {"mode": "default_for_target", "platform": 3, "arch": "x64"}},
+            {**base, "fallback_bases": [{"original_index": True, "base_url": "x"}]},
+            {**base, "fallback_bases": [
+                {"original_index": 1, "base_url": "a"},
+                {"original_index": 1, "base_url": "b"},
+            ]},
+            {**base, "extra": True},
+        ]
+        for value in invalid:
+            with self.subTest(value=value):
+                self.assertIsNone(rust_backend._tool_download_plan_request(value))
+
+    def test_untrusted_response_rejects_unknown_identity_order_duplicates_and_invention(self):
+        req = request(bases=[{"original_index": 0, "base_url": "mirror"}])
+        tool, asset, bases = rust_backend._tool_download_plan_request(req)
+        asset_name, expected = rust_backend._expected_tool_download_plan(tool, asset, bases)
+        base = {
+            "schema_version": 1,
+            "status": "planned",
+            "tool": tool,
+            "asset_name": asset_name,
+            "candidates": expected,
+        }
+        invalid = [
+            {**base, "status": "unknown"},
+            {**base, "status": []},
+            {**base, "tool": "ytdlp"},
+            {**base, "asset_name": "invented"},
+            {**base, "extra": True},
+            {**base, "candidates": [{**expected[0], "source": "unknown"}, expected[1]]},
+            {**base, "candidates": [{**expected[0], "source": []}, expected[1]]},
+            {**base, "candidates": [{**expected[0], "fallback_index": 0}, expected[1]]},
+            {**base, "candidates": [expected[0], expected[0]]},
+            {**base, "candidates": list(reversed(expected))},
+            {**base, "candidates": [{**expected[0], "url": "invented"}, expected[1]]},
+        ]
+        for value in invalid:
+            with self.subTest(value=value):
+                self.assertFalse(
+                    rust_backend._valid_tool_download_plan_response(
+                        value, tool, asset_name, expected
+                    )
+                )
+
+    def test_missing_symbol_incompatible_semantics_and_malformed_json_fall_back(self):
+        with patch.object(rust_backend, "_rust_lib", None):
+            self.assertEqual(rust_backend.try_plan_tool_download_candidates(request()), (False, None))
+        with patch.object(rust_backend, "_rust_lib", object()), patch.dict(
+            rust_backend._CAPABILITIES, {"plan_tool_download_candidates": False}
+        ):
+            self.assertEqual(rust_backend.try_plan_tool_download_candidates(request()), (False, None))
+        unsupported = request(
+            {"mode": "default_for_target", "platform": "linux", "arch": "x64"},
+            tool="aria2c",
+        )
+        self.assertEqual(rust_backend.try_plan_tool_download_candidates(unsupported), (False, None))
+        self._mock_response("not json")
+        self.assertEqual(rust_backend.try_plan_tool_download_candidates(request()), (False, None))
+        self.assertIn("plan_tool_download_candidates", rust_backend._SYMBOLS)
+        self.assertNotEqual(
+            rust_backend._SYMBOLS["plan_tool_download_candidates"],
+            rust_backend._SYMBOLS["plan_update_download_candidates"],
+        )

--- a/tests/test_tool_download_candidate_planning_policy.py
+++ b/tests/test_tool_download_candidate_planning_policy.py
@@ -1,0 +1,104 @@
+import itertools
+import os
+import unittest
+from unittest.mock import patch
+
+from bilikara import rust_backend
+from bilikara.cache import CacheManager
+
+
+class ToolDownloadCandidatePlanningPolicyTest(unittest.TestCase):
+    def test_python_reference_is_primary_first_exact_and_stably_deduplicated(self):
+        asset = {"name": "tool name/歌曲", "browser_download_url": " primary "}
+        self.assertEqual(
+            CacheManager._py_tool_download_candidates(
+                asset, "unused", ["", "https://one", "https://one"]
+            ),
+            [" primary ", "https://one/tool%20name/%E6%AD%8C%E6%9B%B2"],
+        )
+        self.assertEqual(
+            CacheManager._py_fallback_tool_asset("tool name", "https://one"),
+            {
+                "name": "tool name",
+                "browser_download_url": "https://one/tool%20name",
+            },
+        )
+
+    def test_python_default_assets_cover_all_existing_target_rules(self):
+        fixtures = [
+            ("bbdown", "windows", "x86", "BBDown_1.6.3_20240814_win-x64.zip"),
+            ("bbdown", "darwin", "arm64", "BBDown_1.6.3_20240814_osx-arm64.zip"),
+            ("ytdlp", "windows", "arm64", "yt-dlp_arm64.exe"),
+            ("ytdlp", "other", "mips", "yt-dlp"),
+            ("aria2c", "windows", "x86", "aria2-1.37.0-win-32bit-build1.zip"),
+        ]
+        for tool, platform_name, arch, expected_name in fixtures:
+            with self.subTest(tool=tool, platform=platform_name, arch=arch):
+                asset = CacheManager._py_default_tool_fallback_asset(
+                    tool, platform_name, arch, "https://mirror"
+                )
+                self.assertEqual(asset["name"], expected_name)
+        with self.assertRaisesRegex(RuntimeError, "no BBDown"):
+            CacheManager._py_default_tool_fallback_asset(
+                "bbdown", "freebsd", "x64", "https://mirror"
+            )
+        with self.assertRaisesRegex(RuntimeError, "no aria2c"):
+            CacheManager._py_default_tool_fallback_asset(
+                "aria2c", "linux", "x64", "https://mirror"
+            )
+
+    def test_public_wrapper_falls_back_completely(self):
+        asset = {"name": "tool", "browser_download_url": "primary"}
+        with patch.object(
+            rust_backend, "try_plan_tool_download_candidates", return_value=(False, None)
+        ), patch.object(
+            CacheManager,
+            "_py_tool_download_candidates",
+            wraps=CacheManager._py_tool_download_candidates,
+        ) as fallback:
+            self.assertEqual(
+                CacheManager._plan_tool_download_candidates(
+                    "bbdown", asset, "unused", ["mirror"]
+                ),
+                ["primary", "mirror/tool"],
+            )
+            fallback.assert_called_once()
+
+    def test_real_native_equivalence_for_generated_candidates_and_targets(self):
+        available = rust_backend.backend_status()["capabilities"].get(
+            "plan_tool_download_candidates", False
+        )
+        if not available:
+            if os.environ.get("BILIKARA_REQUIRE_RUST_LIB") == "1":
+                self.fail("strict native suite requires tool candidate planning")
+            self.skipTest("tool candidate planning capability unavailable")
+        for primary, name, bases in itertools.product(
+            ["", "primary", " primary "],
+            ["tool", "歌曲", "already%20encoded"],
+            [[], [""], ["mirror"], ["mirror", "mirror"]],
+        ):
+            asset = {"name": name, "browser_download_url": primary}
+            self.assertEqual(
+                CacheManager._plan_tool_download_candidates(
+                    "ytdlp", asset, "unused", bases
+                ),
+                CacheManager._py_tool_download_candidates(asset, "unused", bases),
+            )
+        with patch("bilikara.cache.TOOL_ASSET_BASE_URL", "https://mirror"):
+            self.assertEqual(
+                CacheManager._fallback_tool_asset("tool name"),
+                CacheManager._py_fallback_tool_asset(
+                    "tool name", "https://mirror"
+                ),
+            )
+            for tool, platform_name, arch in [
+                ("bbdown", "linux", "x64"),
+                ("ytdlp", "windows", "arm64"),
+                ("aria2c", "windows", "x86"),
+            ]:
+                self.assertEqual(
+                    CacheManager._default_tool_fallback_asset(tool, platform_name, arch),
+                    CacheManager._py_default_tool_fallback_asset(
+                        tool, platform_name, arch, "https://mirror"
+                    ),
+                )

--- a/tests/test_update_download_candidate_planning_backend.py
+++ b/tests/test_update_download_candidate_planning_backend.py
@@ -1,0 +1,421 @@
+import json
+import os
+import unittest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+from bilikara import rust_backend, updater
+
+
+def request(
+    urls: list[str],
+    sources: list[str] | None = None,
+    *,
+    proxy: str | None = None,
+    proxy_first: bool = False,
+) -> dict[str, object]:
+    if sources is None:
+        sources = ["primary"] * len(urls)
+    return {
+        "schema_version": 1,
+        "candidates": [
+            {"original_index": index, "url": url, "source": sources[index]}
+            for index, url in enumerate(urls)
+        ],
+        "proxy": (
+            {"template": proxy, "proxy_first": proxy_first}
+            if proxy is not None
+            else None
+        ),
+    }
+
+
+class UpdateDownloadCandidatePlanningBackendTest(unittest.TestCase):
+    def _mock_native_response(self, response_json: str, *, capability: bool = True):
+        class DummyLibrary:
+            pass
+
+        library = rust_backend._rust_lib or DummyLibrary()
+
+        class MockPointer:
+            pass
+
+        stack = ExitStack()
+        self.addCleanup(stack.close)
+        stack.enter_context(patch.object(rust_backend, "_rust_lib", library))
+        stack.enter_context(
+            patch.dict(
+                rust_backend._CAPABILITIES,
+                {"plan_update_download_candidates": capability},
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                library,
+                "rust_plan_update_download_candidates",
+                new=lambda _payload: MockPointer(),
+                create=True,
+            )
+        )
+        stack.enter_context(
+            patch.object(
+                rust_backend,
+                "_read_rust_string",
+                new=lambda pointer: response_json if isinstance(pointer, MockPointer) else None,
+            )
+        )
+
+    def test_valid_empty_plan_is_success_not_failure(self):
+        self._mock_native_response(
+            json.dumps({"schema_version": 1, "status": "empty", "candidates": []})
+        )
+        self.assertEqual(
+            rust_backend.try_plan_update_download_candidates(request([])),
+            (
+                True,
+                {"schema_version": 1, "status": "empty", "candidates": []},
+            ),
+        )
+
+    def test_valid_native_plan_is_accepted_without_python_fallback(self):
+        response = {
+            "schema_version": 1,
+            "status": "planned",
+            "candidates": [
+                {"input_index": 0, "source": "primary", "route": "proxy", "url": "https://proxy/https://example/app.zip"},
+                {"input_index": 0, "source": "primary", "route": "direct", "url": "https://example/app.zip"},
+            ],
+        }
+        self._mock_native_response(json.dumps(response))
+        with patch.object(
+            updater,
+            "_py_download_url_candidates",
+            wraps=updater._py_download_url_candidates,
+        ) as fallback, patch.object(
+            updater,
+            "APP_UPDATE_DOWNLOAD_PROXY",
+            "https://proxy/{url}",
+        ), patch.object(
+            updater,
+            "APP_UPDATE_DOWNLOAD_PROXY_FIRST",
+            True,
+        ):
+            self.assertEqual(
+                updater._download_url_candidates("https://example/app.zip"),
+                ["https://proxy/https://example/app.zip", "https://example/app.zip"],
+            )
+            fallback.assert_not_called()
+
+    def test_request_validation_is_strict(self):
+        valid = request(["https://example/a"])
+        invalid = [
+            None,
+            [],
+            {**valid, "schema_version": True},
+            {**valid, "schema_version": 2},
+            {**valid, "extra": True},
+            {**valid, "candidates": "invalid"},
+            {
+                **valid,
+                "candidates": [{**valid["candidates"][0], "original_index": True}],
+            },
+            {
+                **valid,
+                "candidates": [{**valid["candidates"][0], "original_index": -1}],
+            },
+            {
+                **valid,
+                "candidates": [
+                    valid["candidates"][0],
+                    {**valid["candidates"][0], "url": "https://example/b"},
+                ],
+            },
+            {**valid, "candidates": [{**valid["candidates"][0], "url": None}]},
+            {**valid, "candidates": [{**valid["candidates"][0], "source": "unknown"}]},
+            {**valid, "candidates": [{**valid["candidates"][0], "extra": True}]},
+            {**valid, "proxy": []},
+            {**valid, "proxy": {"template": 3, "proxy_first": False}},
+            {**valid, "proxy": {"template": "x", "proxy_first": 1}},
+            {**valid, "proxy": {"template": "x", "proxy_first": False, "extra": 1}},
+        ]
+        for value in invalid:
+            with self.subTest(value=value):
+                self.assertIsNone(rust_backend._update_download_plan_request(value))
+
+    def test_response_validation_rejects_every_untrusted_invariant(self):
+        req = request(
+            ["https://example/a", "https://example/b"],
+            ["primary", "mirror"],
+            proxy="https://proxy/{url}",
+            proxy_first=False,
+        )
+        candidates, proxy = rust_backend._update_download_plan_request(req)
+        expected = rust_backend._expected_update_download_candidates(candidates, proxy)
+        base = {"schema_version": 1, "status": "planned", "candidates": expected}
+        invalid = [
+            None,
+            [],
+            {**base, "schema_version": True},
+            {**base, "schema_version": 2},
+            {**base, "status": "unknown"},
+            {**base, "status": "empty"},
+            {**base, "candidates": "invalid"},
+            {**base, "extra": True},
+            {**base, "candidates": [{**expected[0], "input_index": True}, *expected[1:]]},
+            {**base, "candidates": [{**expected[0], "input_index": 99}, *expected[1:]]},
+            {**base, "candidates": [{**expected[0], "source": "unknown"}, *expected[1:]]},
+            {**base, "candidates": [{**expected[0], "source": "mirror"}, *expected[1:]]},
+            {**base, "candidates": [{**expected[0], "route": "unknown"}, *expected[1:]]},
+            {**base, "candidates": [{**expected[0], "url": ""}, *expected[1:]]},
+            {**base, "candidates": [{**expected[0], "url": f" {expected[0]['url']} "}, *expected[1:]]},
+            {**base, "candidates": [expected[0], expected[0], *expected[2:]]},
+            {**base, "candidates": list(reversed(expected))},
+            {**base, "candidates": [{**expected[0], "url": "https://invented"}, *expected[1:]]},
+            {**base, "candidates": [{**expected[0], "extra": True}, *expected[1:]]},
+        ]
+        for value in invalid:
+            with self.subTest(value=value):
+                self.assertFalse(
+                    rust_backend._valid_update_download_plan_response(
+                        value,
+                        candidates,
+                        proxy,
+                    )
+                )
+
+    def test_proxy_output_without_proxy_configuration_is_impossible(self):
+        req = request(["https://example/a"])
+        candidates, proxy = rust_backend._update_download_plan_request(req)
+        response = {
+            "schema_version": 1,
+            "status": "planned",
+            "candidates": [
+                {"input_index": 0, "source": "primary", "route": "proxy", "url": "https://example/a"}
+            ],
+        }
+        self.assertFalse(
+            rust_backend._valid_update_download_plan_response(response, candidates, proxy)
+        )
+
+    def test_malformed_json_unknown_status_source_duplicate_index_and_order_fall_back(self):
+        invalid_responses = [
+            "not json",
+            json.dumps({"schema_version": 1, "status": "unknown", "candidates": []}),
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "planned",
+                    "candidates": [
+                        {"input_index": 0, "source": "unknown", "route": "direct", "url": "https://example/a"}
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "planned",
+                    "candidates": [
+                        {"input_index": 99, "source": "primary", "route": "direct", "url": "https://example/a"}
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "status": "planned",
+                    "candidates": [
+                        {"input_index": 0, "source": "primary", "route": "direct", "url": "https://example/a"},
+                        {"input_index": 0, "source": "primary", "route": "direct", "url": "https://example/a"},
+                    ],
+                }
+            ),
+        ]
+        for response_json in invalid_responses:
+            with self.subTest(response_json=response_json):
+                expected = updater._py_download_url_candidates(
+                    "https://example/a",
+                    updater.APP_UPDATE_DOWNLOAD_PROXY,
+                    updater.APP_UPDATE_DOWNLOAD_PROXY_FIRST,
+                )
+                self._mock_native_response(response_json)
+                with patch.object(
+                    updater,
+                    "_py_download_url_candidates",
+                    wraps=updater._py_download_url_candidates,
+                ) as fallback:
+                    self.assertEqual(
+                        updater._download_url_candidates("https://example/a"),
+                        expected,
+                    )
+                    fallback.assert_called_once()
+
+    def test_missing_library_symbol_incompatible_abi_null_and_exception_fall_back(self):
+        expected = updater._py_download_url_candidates(
+            "https://example/a", "", False
+        )
+        scenarios = [
+            (None, rust_backend._empty_capabilities(), None),
+            (object(), rust_backend._empty_capabilities(), None),
+        ]
+        for library, capabilities, _ in scenarios:
+            with self.subTest(library=library), patch.object(
+                rust_backend, "_rust_lib", library
+            ), patch.object(
+                rust_backend, "_CAPABILITIES", capabilities
+            ), patch.object(
+                updater, "APP_UPDATE_DOWNLOAD_PROXY", ""
+            ), patch.object(
+                updater, "APP_UPDATE_DOWNLOAD_PROXY_FIRST", False
+            ):
+                self.assertEqual(updater._download_url_candidates("https://example/a"), expected)
+
+        capabilities = rust_backend._empty_capabilities()
+        with patch.object(rust_backend, "_rust_lib", None), patch.object(
+            rust_backend, "_CAPABILITIES", capabilities
+        ), patch.object(rust_backend, "_ABI_COMPATIBLE", False):
+            self.assertEqual(updater._download_url_candidates("https://example/a"), expected)
+
+        class NullLibrary:
+            rust_plan_update_download_candidates = staticmethod(lambda _payload: None)
+
+        capabilities["plan_update_download_candidates"] = True
+        with patch.object(rust_backend, "_rust_lib", NullLibrary()), patch.object(
+            rust_backend, "_CAPABILITIES", capabilities
+        ):
+            self.assertEqual(updater._download_url_candidates("https://example/a"), expected)
+
+        class RaisingLibrary:
+            rust_plan_update_download_candidates = staticmethod(
+                lambda _payload: (_ for _ in ()).throw(RuntimeError("native failure"))
+            )
+
+        with patch.object(rust_backend, "_rust_lib", RaisingLibrary()), patch.object(
+            rust_backend, "_CAPABILITIES", capabilities
+        ):
+            self.assertEqual(updater._download_url_candidates("https://example/a"), expected)
+
+    def test_capability_isolation(self):
+        capabilities = rust_backend._empty_capabilities()
+        capabilities["select_update_asset"] = True
+        with patch.object(rust_backend, "_rust_lib", object()), patch.object(
+            rust_backend, "_CAPABILITIES", capabilities
+        ):
+            self.assertEqual(updater._download_url_candidates("https://example/a"), ["https://example/a"])
+            self.assertTrue(rust_backend._CAPABILITIES["select_update_asset"])
+            self.assertFalse(rust_backend._CAPABILITIES["plan_update_download_candidates"])
+
+    def test_every_public_updater_helper_uses_its_complete_reference_on_failure(self):
+        with patch.object(
+            rust_backend,
+            "try_plan_update_download_candidates",
+            return_value=(False, None),
+        ), patch.object(
+            updater,
+            "_py_dedupe_urls",
+            wraps=updater._py_dedupe_urls,
+        ) as dedupe_fallback, patch.object(
+            updater,
+            "_py_latest_release_api_urls",
+            wraps=updater._py_latest_release_api_urls,
+        ) as latest_fallback, patch.object(
+            updater,
+            "_py_release_list_api_urls",
+            wraps=updater._py_release_list_api_urls,
+        ) as list_fallback, patch.object(
+            updater,
+            "_py_download_url_candidates",
+            wraps=updater._py_download_url_candidates,
+        ) as download_fallback:
+            self.assertEqual(
+                updater._dedupe_urls([" a ", "a", "b"]),
+                ["a", "b"],
+            )
+            self.assertTrue(updater._latest_release_api_urls())
+            self.assertTrue(updater._release_list_api_urls())
+            self.assertEqual(
+                updater._download_url_candidates("https://example/a"),
+                ["https://example/a"],
+            )
+
+        self.assertGreaterEqual(dedupe_fallback.call_count, 1)
+        latest_fallback.assert_called_once()
+        list_fallback.assert_called_once()
+        download_fallback.assert_called_once()
+
+
+class UpdateDownloadCandidatePlanningNativeEquivalenceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        status = rust_backend.backend_status()
+        available = status["loaded"] and status["capabilities"].get(
+            "plan_update_download_candidates", False
+        )
+        if available:
+            return
+        if os.environ.get("BILIKARA_REQUIRE_RUST_LIB") == "1":
+            raise AssertionError(
+                "BILIKARA_REQUIRE_RUST_LIB=1 but native update download planning "
+                f"is unavailable: {status}"
+            )
+        raise unittest.SkipTest("native update download planning is unavailable")
+
+    def assert_equivalent(self, payload: dict[str, object]):
+        validated = rust_backend._update_download_plan_request(payload)
+        self.assertIsNotNone(validated)
+        candidates, proxy = validated
+        expected = updater._py_plan_update_download_candidates(
+            candidates,
+            proxy=str(proxy["template"]) if proxy is not None else None,
+            proxy_first=bool(proxy["proxy_first"]) if proxy is not None else False,
+        )
+        completed, response = rust_backend.try_plan_update_download_candidates(payload)
+        self.assertTrue(completed)
+        self.assertIsNotNone(response)
+        self.assertEqual(response["candidates"], expected)
+        self.assertEqual(response["status"], "planned" if expected else "empty")
+
+    def test_fixed_fixtures(self):
+        fixtures = [
+            request([]),
+            request(["https://example/a"]),
+            request([" ", "https://example/a", "https://example/a"]),
+            request(
+                ["https://primary", "https://mirror-b", "https://mirror-a"],
+                ["primary", "mirror", "derived_mirror"],
+            ),
+            request(
+                ["https://例子.test/歌曲.zip", "https://example/%E6%AD%8C.zip"],
+                ["primary", "mirror"],
+                proxy="https://proxy/{url_encoded}",
+                proxy_first=True,
+            ),
+        ]
+        for payload in fixtures:
+            with self.subTest(payload=payload):
+                self.assert_equivalent(payload)
+
+    def test_generated_direct_mirror_proxy_combinations(self):
+        url_sets = [
+            [],
+            ["https://primary"],
+            ["https://primary", "https://mirror"],
+            [" https://same ", "https://same", "", "https://other"],
+            ["https://例子.test/歌", "https://example/%E6%AD%8C"],
+        ]
+        proxies = [None, "", "{url}", "https://proxy/{url}", "https://proxy/{url_encoded}", "https://proxy="]
+        for urls in url_sets:
+            sources = ["primary", *("mirror" for _ in urls[1:])]
+            for proxy in proxies:
+                for proxy_first in (False, True):
+                    payload = request(
+                        urls,
+                        sources,
+                        proxy=proxy,
+                        proxy_first=proxy_first,
+                    )
+                    with self.subTest(urls=urls, proxy=proxy, proxy_first=proxy_first):
+                        self.assert_equivalent(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_update_download_candidate_planning_policy.py
+++ b/tests/test_update_download_candidate_planning_policy.py
@@ -1,0 +1,180 @@
+import unittest
+
+from bilikara import updater
+
+
+def inputs(*items: tuple[str, str]) -> list[dict[str, object]]:
+    return [
+        {"original_index": index, "url": url, "source": source}
+        for index, (url, source) in enumerate(items)
+    ]
+
+
+class UpdateDownloadCandidatePlanningPolicyTest(unittest.TestCase):
+    def test_python_dedupe_trims_drops_empty_and_keeps_first(self):
+        self.assertEqual(
+            updater._py_dedupe_urls(
+                ["  https://primary  ", "", " \t ", "https://primary", "https://mirror"]
+            ),
+            ["https://primary", "https://mirror"],
+        )
+
+    def test_empty_plan_is_valid(self):
+        self.assertEqual(updater._py_plan_update_download_candidates([]), [])
+        self.assertEqual(
+            updater._py_plan_update_download_candidates(
+                inputs(("   ", "primary"), ("\n", "mirror"))
+            ),
+            [],
+        )
+
+    def test_source_identity_and_order_are_preserved(self):
+        plan = updater._py_plan_update_download_candidates(
+            inputs(
+                ("https://primary", "primary"),
+                ("https://mirror-b", "mirror"),
+                ("https://mirror-a", "derived_mirror"),
+            )
+        )
+        self.assertEqual(
+            plan,
+            [
+                {"input_index": 0, "source": "primary", "route": "direct", "url": "https://primary"},
+                {"input_index": 1, "source": "mirror", "route": "direct", "url": "https://mirror-b"},
+                {"input_index": 2, "source": "derived_mirror", "route": "direct", "url": "https://mirror-a"},
+            ],
+        )
+
+    def test_duplicates_across_primary_and_mirrors_keep_first_identity(self):
+        plan = updater._py_plan_update_download_candidates(
+            inputs(
+                (" https://same ", "primary"),
+                ("https://same", "mirror"),
+                ("https://other", "derived_mirror"),
+            )
+        )
+        self.assertEqual([candidate["url"] for candidate in plan], ["https://same", "https://other"])
+        self.assertEqual([candidate["input_index"] for candidate in plan], [0, 2])
+
+    def test_direct_and_proxy_order_follow_proxy_first(self):
+        candidates = inputs(("https://example/app.zip", "primary"))
+        direct_first = updater._py_plan_update_download_candidates(
+            candidates,
+            proxy="https://proxy/{url}",
+            proxy_first=False,
+        )
+        proxy_first = updater._py_plan_update_download_candidates(
+            candidates,
+            proxy="https://proxy/{url}",
+            proxy_first=True,
+        )
+        self.assertEqual([item["route"] for item in direct_first], ["direct", "proxy"])
+        self.assertEqual([item["route"] for item in proxy_first], ["proxy", "direct"])
+
+    def test_proxy_placeholder_encoding_and_suffixes_match_phase1(self):
+        url = "https://example/歌曲 a.zip?x=1&y=2"
+        encoded = updater._py_plan_update_download_candidates(
+            inputs((url, "primary")),
+            proxy="https://proxy/{url_encoded}",
+            proxy_first=True,
+        )
+        self.assertEqual(
+            encoded[0]["url"],
+            "https://proxy/https%3A%2F%2Fexample%2F%E6%AD%8C%E6%9B%B2%20a.zip%3Fx%3D1%26y%3D2",
+        )
+        for proxy in ("https://proxy/", "https://proxy=", "https://proxy?", "https://proxy&"):
+            with self.subTest(proxy=proxy):
+                plan = updater._py_plan_update_download_candidates(
+                    inputs(("https://example/a", "primary")),
+                    proxy=proxy,
+                    proxy_first=True,
+                )
+                self.assertEqual(plan[0]["url"], f"{proxy}https://example/a")
+
+    def test_empty_and_equal_proxy_do_not_create_proxy_candidate(self):
+        candidates = inputs(("https://example/a", "primary"))
+        for proxy in ("", "   ", "{url}"):
+            with self.subTest(proxy=proxy):
+                plan = updater._py_plan_update_download_candidates(
+                    candidates,
+                    proxy=proxy,
+                    proxy_first=True,
+                )
+                self.assertEqual(
+                    plan,
+                    [{"input_index": 0, "source": "primary", "route": "direct", "url": "https://example/a"}],
+                )
+
+    def test_generated_proxy_duplicates_are_removed_stably(self):
+        plan = updater._py_plan_update_download_candidates(
+            inputs(
+                ("https://example/a", "primary"),
+                ("https://proxy/https://example/a", "mirror"),
+            ),
+            proxy="https://proxy/{url}",
+            proxy_first=False,
+        )
+        urls = [candidate["url"] for candidate in plan]
+        self.assertEqual(len(urls), len(set(urls)))
+        self.assertEqual(urls[1], "https://proxy/https://example/a")
+        self.assertEqual(plan[1]["input_index"], 0)
+
+    def test_unicode_and_percent_encoded_urls_are_opaque(self):
+        urls = ["https://例子.test/歌曲.zip", "https://example/%E6%AD%8C.zip"]
+        plan = updater._py_plan_update_download_candidates(
+            inputs((urls[0], "primary"), (urls[1], "mirror"))
+        )
+        self.assertEqual([candidate["url"] for candidate in plan], urls)
+
+    def test_reference_updater_helpers_preserve_existing_sequences(self):
+        self.assertEqual(
+            updater._py_latest_release_api_urls(
+                " https://api.example/latest ",
+                ["https://mirror/latest", "https://api.example/latest"],
+            ),
+            ["https://api.example/latest", "https://mirror/latest"],
+        )
+        self.assertEqual(
+            updater._py_release_list_api_urls(
+                "https://api.example/releases",
+                ["https://mirror/releases"],
+                ["https://derived/releases/latest", "invalid"],
+            ),
+            [
+                "https://api.example/releases",
+                "https://mirror/releases",
+                "https://derived/releases",
+            ],
+        )
+        self.assertEqual(
+            updater._py_download_url_candidates(
+                " https://example/app.zip ",
+                "https://proxy/{url}",
+                True,
+            ),
+            ["https://proxy/https://example/app.zip", "https://example/app.zip"],
+        )
+
+    def test_reference_planning_is_deterministic(self):
+        candidates = inputs(
+            ("https://primary", "primary"),
+            ("https://mirror", "mirror"),
+        )
+        expected = updater._py_plan_update_download_candidates(
+            candidates,
+            proxy="https://proxy/{url_encoded}",
+            proxy_first=True,
+        )
+        for _ in range(20):
+            self.assertEqual(
+                updater._py_plan_update_download_candidates(
+                    candidates,
+                    proxy="https://proxy/{url_encoded}",
+                    proxy_first=True,
+                ),
+                expected,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -462,6 +462,39 @@ class UpdateCheckTest(unittest.TestCase):
             "https://mirror.example/releases/latest",
         ])
 
+    def test_update_api_candidate_helpers_preserve_primary_mirror_and_derived_order(self):
+        with patch("bilikara.updater.APP_RELEASE_API", " https://api.example/releases/latest "), patch(
+            "bilikara.updater.APP_RELEASE_API_FALLBACKS",
+            (
+                "https://mirror-b.example/releases/latest",
+                "https://mirror-a.example/releases/latest",
+                "https://api.example/releases/latest",
+            ),
+        ), patch(
+            "bilikara.updater.APP_RELEASES_API",
+            "https://api.example/releases",
+        ), patch(
+            "bilikara.updater.APP_RELEASES_API_FALLBACKS",
+            ("https://explicit.example/releases",),
+        ):
+            self.assertEqual(
+                updater._latest_release_api_urls(),
+                [
+                    "https://api.example/releases/latest",
+                    "https://mirror-b.example/releases/latest",
+                    "https://mirror-a.example/releases/latest",
+                ],
+            )
+            self.assertEqual(
+                updater._release_list_api_urls(),
+                [
+                    "https://api.example/releases",
+                    "https://explicit.example/releases",
+                    "https://mirror-b.example/releases",
+                    "https://mirror-a.example/releases",
+                ],
+            )
+
     def test_download_url_candidates_supports_proxy_template(self):
         with patch("bilikara.updater.APP_UPDATE_DOWNLOAD_PROXY", "https://mirror.example/{url_encoded}"), patch(
             "bilikara.updater.APP_UPDATE_DOWNLOAD_PROXY_FIRST",


### PR DESCRIPTION
## Summary
- Completes Phase 2 Item 5 by migrating deterministic updater, media and tool download-candidate planning into typed Rust domains.
- Retains complete Python reference fallbacks.
- Keeps all network, retry, subprocess, filesystem and mutable-state behavior in Python.

## Migrated scope
- Updater API candidates (`_dedupe_urls`, `_latest_release_api_urls`, `_release_list_api_urls`) and direct/proxy download candidates (`_download_url_candidates`).
- Media `_dash_stream_urls` primary/backup flattening and preferred-audio URL flattening after Python selects the descriptor.
- Tool `_tool_fallback_url`, fallback asset construction for BBDown/yt-dlp/aria2c, and `_download_tool_asset` primary/fallback ordering.
- Updater URLs are trimmed, empty values removed, and globally deduplicated with stable first occurrence; explicit `proxy_first` controls direct/proxy order.
- DASH URLs are primary-then-backups in stream order, trimmed, empty-filtered, and duplicates are preserved. Preferred-audio strings and duplicates are preserved exactly.
- Tool URLs are supplied/built-in primary first, then configured fallback bases in order; empty bases are skipped and exact-string duplicates are removed stably without trimming.
- The policies use separate updater, media, and tool typed domains because their normalization, duplicate, source, and fallback semantics are materially different.

## Excluded scope
- HTTP and retries.
- Download execution.
- BBDown, aria2c, yt-dlp, FFmpeg and ffprobe execution.
- Quality and stream ranking.
- Cache workers and mutation.
- Filesystem publication.
- Release asset scoring and selection.

## Safety model
- Typed Rust domains are independent from serde wire types, C pointers, Python, Tauri, global configuration, filesystem state, and I/O.
- Additive ABI-version-1 JSON exports: `rust_plan_update_download_candidates`, `rust_plan_media_download_candidates`, and `rust_plan_tool_download_candidates`.
- Native responses are treated as untrusted and reconstructed against supplied inputs, source/index identity, normalization, duplicate, ordering, and URL-derivation invariants.
- Valid empty plans are concrete domain responses rather than backend failures.
- Missing libraries/symbols, incompatible ABI, null/panic/malformed responses, unknown fields/enums, invalid indices, invented URLs, or impossible ordering trigger the complete independent Python reference.

## Validation
- `cd rust && cargo fmt --check` — passed.
- `cd rust && cargo clippy --all-targets --locked -- -D warnings` — passed.
- `cd rust && cargo test --locked` — passed, 126 tests.
- `cd rust && cargo build --release --locked` — passed.
- `BILIKARA_REQUIRE_RUST_LIB=1 python -m unittest discover -s tests -v` — passed, 579 tests using the real release library.
- `python -m compileall -q bilikara` — passed.
- `python -m py_compile start_bilikara.py build_bundle.py` — passed.
- `cd src-tauri && cargo fmt --check` — passed.
- `cd src-tauri && cargo clippy --all-targets --locked -- -D warnings` — passed.
- `cd src-tauri && cargo test --locked` — passed.
- `cd src-tauri && cargo build --release --locked` — passed.
- `node --version` — host default is v12.22.9 and was not accepted as the build environment.
- `npx --yes --package=node@20 -- node --version` — v20.20.2.
- `npx --yes --package=node@20 -- sh -c 'NODE_PATH=/usr/share/nodejs npm ci'` — passed.
- `npx --yes --package=node@20 -- sh -c 'NODE_PATH=/usr/share/nodejs npm run build'` — passed; deb, rpm, and AppImage bundles built.
- `git diff --check` — passed.
- `git status --short` — clean after commit.

The first direct Node-20-wrapped npm attempt lacked Debian's global `semver` module; setting `NODE_PATH=/usr/share/nodejs` supplied the host npm dependencies and both required Node 20 commands then passed.

## Migration status
Phase 2 progress: 5/8.
Item 5: completed.
