### PR TITLE
feat: migrate quality and stream ranking to Rust

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,9 @@ When completing a task, agents must report:
 | `src/download_candidate_planning.rs` | Pure updater download URL construction, source labeling, ordering, and deduplication policy. |
 | `src/media_download_candidate_planning.rs` | Pure DASH and preferred-audio primary/backup URL flattening, identity, and ordering policy. |
 | `src/tool_download_candidate_planning.rs` | Pure BBDown, yt-dlp, and aria2c asset fallback construction, labeling, ordering, and deduplication policy. |
+| `src/quality_policy.rs` | Pure quality-label/ID normalization plus BBDown and yt-dlp preference intent. |
+| `src/video_stream_ranking.rs` | Pure DASH video codec, quality, bandwidth, AVC-cap, fallback, and stable ranking policy. |
+| `src/audio_stream_ranking.rs` | Pure DASH audio quality, Hi-Res, Dolby, FLAC, and stable source-selection policy. |
 | `src/release_selection.rs` | Semantic version sorting and release filtering rules. |
 | `src/asset_selection.rs` | Update package scoring by platform and architecture. |
 | `src/ffi.rs` | FFI wrapper utilities, memory safety helpers, panic containment. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,8 @@ When completing a task, agents must report:
 | `src/tool_download_candidate_planning.rs` | Pure BBDown, yt-dlp, and aria2c asset fallback construction, labeling, ordering, and deduplication policy. |
 | `src/quality_policy.rs` | Pure quality-label/ID normalization plus BBDown and yt-dlp preference intent. |
 | `src/video_stream_ranking.rs` | Pure DASH video codec, quality, bandwidth, AVC-cap, fallback, and stable ranking policy. |
-| `src/audio_stream_ranking.rs` | Pure DASH audio quality, Hi-Res, Dolby, FLAC, and stable source-selection policy. |
+| `src/audio_stream_ranking.rs` | Pure regular DASH audio quality ordering, Hi-Res filtering/fallback, and stable ties. |
+| `src/preferred_audio_source_binding.rs` | Pure first-regular, FLAC, and Dolby preferred-audio source binding without regular ranking. |
 | `src/release_selection.rs` | Semantic version sorting and release filtering rules. |
 | `src/asset_selection.rs` | Update package scoring by platform and architecture. |
 | `src/ffi.rs` | FFI wrapper utilities, memory safety helpers, panic containment. |

--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -438,7 +438,7 @@ class CacheManager:
         return self.media_capabilities_snapshot()
 
     @staticmethod
-    def _quality_from_choice_index(index: object) -> str | None:
+    def _py_quality_from_choice_index(index: object) -> str | None:
         try:
             normalized_index = int(index)
         except (TypeError, ValueError):
@@ -448,11 +448,46 @@ class CacheManager:
         return None
 
     @staticmethod
-    def _optional_video_quality(video_quality: object) -> str | None:
+    def _py_optional_video_quality(video_quality: object) -> str | None:
         value = str(video_quality or "").strip()
         if value in VIDEO_QUALITY_CHOICES:
             return value
         return None
+
+    @staticmethod
+    def _native_quality_policy(
+        video_quality: object,
+        quality_cap: object = "",
+        choice_index: int | None = None,
+    ) -> dict[str, Any] | None:
+        request = {
+            "schema_version": 1,
+            "raw_quality": str(video_quality or ""),
+            "raw_cap": str(quality_cap or ""),
+            "choice_index": choice_index,
+        }
+        completed, response = rust_backend.try_decide_quality_policy(request)
+        return response if completed else None
+
+    @staticmethod
+    def _quality_from_choice_index(index: object) -> str | None:
+        try:
+            normalized_index = int(index)
+        except (TypeError, ValueError):
+            normalized_index = None
+        response = CacheManager._native_quality_policy(
+            "", choice_index=normalized_index
+        )
+        if response is not None:
+            return response["indexed_quality"]
+        return CacheManager._py_quality_from_choice_index(index)
+
+    @staticmethod
+    def _optional_video_quality(video_quality: object) -> str | None:
+        response = CacheManager._native_quality_policy(video_quality)
+        if response is not None:
+            return response["optional_quality"]
+        return CacheManager._py_optional_video_quality(video_quality)
 
     def enrich_snapshot(
         self,
@@ -667,11 +702,18 @@ class CacheManager:
         return bounded
 
     @staticmethod
-    def _normalize_video_quality(video_quality: object) -> str:
+    def _py_normalize_video_quality(video_quality: object) -> str:
         value = str(video_quality or "").strip()
         if value in VIDEO_QUALITY_CHOICES:
             return value
         return DEFAULT_VIDEO_QUALITY
+
+    @staticmethod
+    def _normalize_video_quality(video_quality: object) -> str:
+        response = CacheManager._native_quality_policy(video_quality)
+        if response is not None:
+            return str(response["normalized_quality"])
+        return CacheManager._py_normalize_video_quality(video_quality)
 
     @staticmethod
     def _normalize_download_source(download_source: object) -> str:
@@ -2066,8 +2108,10 @@ class CacheManager:
         )
 
     @staticmethod
-    def _ytdlp_max_height(video_quality: object, quality_cap: object = "") -> int:
-        quality = CacheManager._optional_video_quality(quality_cap) or CacheManager._normalize_video_quality(video_quality)
+    def _py_ytdlp_max_height(video_quality: object, quality_cap: object = "") -> int:
+        quality = CacheManager._py_optional_video_quality(
+            quality_cap
+        ) or CacheManager._py_normalize_video_quality(video_quality)
         if "360" in quality:
             return 360
         if "480" in quality:
@@ -2081,6 +2125,13 @@ class CacheManager:
         if "8K" in quality:
             return 4320
         return 1080
+
+    @staticmethod
+    def _ytdlp_max_height(video_quality: object, quality_cap: object = "") -> int:
+        response = CacheManager._native_quality_policy(video_quality, quality_cap)
+        if response is not None:
+            return int(response["effective_max_height"])
+        return CacheManager._py_ytdlp_max_height(video_quality, quality_cap)
 
     @staticmethod
     def _ytdlp_browser_cookie_source() -> str:
@@ -2235,7 +2286,8 @@ class CacheManager:
         except RuntimeError:
             return 0
 
-    def _dash_max_quality_id(self, video_quality: str) -> int:
+    @staticmethod
+    def _py_dash_max_quality_id(video_quality: str) -> int:
         quality_id_map = {
             "360P 流畅": 16,
             "480P 清晰": 32,
@@ -2251,15 +2303,28 @@ class CacheManager:
         }
         return quality_id_map.get(video_quality, 80)
 
-    def _select_dash_video_stream(
-        self,
+    @staticmethod
+    def _dash_max_quality_id(video_quality: str) -> int:
+        if not isinstance(video_quality, str):
+            return CacheManager._py_dash_max_quality_id(video_quality)
+        response = CacheManager._native_quality_policy(video_quality)
+        if response is not None:
+            return int(response["dash_max_quality_id"])
+        return CacheManager._py_dash_max_quality_id(video_quality)
+
+    @staticmethod
+    def _py_select_dash_video_stream(
         video_streams: list[dict],
         *,
         max_quality_id: int,
         codec_filter: str | None = None,
         avc_quality_cap: str = "",
     ) -> dict | None:
-        max_avc_quality_id = self._dash_max_quality_id(avc_quality_cap) if avc_quality_cap else 0
+        max_avc_quality_id = (
+            CacheManager._py_dash_max_quality_id(avc_quality_cap)
+            if avc_quality_cap
+            else 0
+        )
         candidates = []
         for stream in video_streams:
             quality_id = stream.get("quality_id", 0)
@@ -2283,7 +2348,54 @@ class CacheManager:
         candidates.sort(key=lambda s: (-s.get("quality_id", 0), -s.get("bandwidth", 0)))
         return candidates[0]
 
-    def _select_dash_audio_stream(self, audio_streams: list[dict], *, audio_hires: bool = True) -> dict | None:
+    @staticmethod
+    def _select_dash_video_stream(
+        video_streams: list[dict],
+        *,
+        max_quality_id: int,
+        codec_filter: str | None = None,
+        avc_quality_cap: str = "",
+    ) -> dict | None:
+        try:
+            streams = [
+                {
+                    "original_index": index,
+                    "quality_id": stream.get("quality_id", 0),
+                    "bandwidth": stream.get("bandwidth", 0),
+                    "codec": stream.get("codec_name", ""),
+                }
+                for index, stream in enumerate(video_streams)
+            ]
+            max_avc_quality_id = (
+                CacheManager._dash_max_quality_id(avc_quality_cap)
+                if avc_quality_cap
+                else None
+            )
+            request = {
+                "schema_version": 1,
+                "max_quality_id": max_quality_id,
+                "codec_filter": codec_filter,
+                "max_avc_quality_id": max_avc_quality_id,
+                "streams": streams,
+            }
+            completed, response = rust_backend.try_select_video_stream(request)
+            if completed and response is not None:
+                if response["status"] == "no_match":
+                    return None
+                return video_streams[response["selected_index"]]
+        except (AttributeError, IndexError, TypeError, ValueError):
+            pass
+        return CacheManager._py_select_dash_video_stream(
+            video_streams,
+            max_quality_id=max_quality_id,
+            codec_filter=codec_filter,
+            avc_quality_cap=avc_quality_cap,
+        )
+
+    @staticmethod
+    def _py_select_dash_audio_stream(
+        audio_streams: list[dict], *, audio_hires: bool = True
+    ) -> dict | None:
         if not audio_streams:
             return None
         candidates = list(audio_streams)
@@ -2301,6 +2413,93 @@ class CacheManager:
                 candidates = list(audio_streams)
         candidates.sort(key=lambda s: quality_order.get(s.get("quality_id", 0), 99))
         return candidates[0]
+
+    @staticmethod
+    def _select_dash_audio_stream(
+        audio_streams: list[dict], *, audio_hires: bool = True
+    ) -> dict | None:
+        try:
+            request = {
+                "schema_version": 1,
+                "audio_hires": audio_hires,
+                "regular_streams": [
+                    {
+                        "original_index": index,
+                        "quality_id": stream.get("quality_id", 0),
+                        "bandwidth": stream.get("bandwidth", 0),
+                    }
+                    for index, stream in enumerate(audio_streams)
+                ],
+                "flac_available": False,
+                "dolby_available": False,
+            }
+            completed, response = rust_backend.try_select_audio_stream(request)
+            if completed and response is not None:
+                selected_index = response["selected_regular_index"]
+                return None if selected_index is None else audio_streams[selected_index]
+        except (AttributeError, IndexError, TypeError, ValueError):
+            pass
+        return CacheManager._py_select_dash_audio_stream(
+            audio_streams, audio_hires=audio_hires
+        )
+
+    @staticmethod
+    def _py_select_preferred_dash_audio(
+        best_audio: list[dict],
+        flac_audio: dict | None,
+        dolby_audio: dict | None,
+        *,
+        audio_hires: bool,
+    ) -> dict | None:
+        preferred_audio = best_audio[0] if best_audio else None
+        if flac_audio and audio_hires:
+            preferred_audio = flac_audio
+        if dolby_audio and audio_hires:
+            preferred_audio = dolby_audio
+        return preferred_audio
+
+    @staticmethod
+    def _select_preferred_dash_audio(
+        best_audio: list[dict],
+        flac_audio: dict | None,
+        dolby_audio: dict | None,
+        *,
+        audio_hires: bool,
+    ) -> dict | None:
+        try:
+            request = {
+                "schema_version": 1,
+                "audio_hires": audio_hires,
+                "regular_streams": [
+                    {
+                        "original_index": index,
+                        "quality_id": stream.get("quality_id", 0),
+                        "bandwidth": stream.get("bandwidth", 0),
+                    }
+                    for index, stream in enumerate(best_audio)
+                ],
+                "flac_available": bool(flac_audio),
+                "dolby_available": bool(dolby_audio),
+            }
+            completed, response = rust_backend.try_select_audio_stream(request)
+            if completed and response is not None:
+                source = response["preferred_source"]
+                if source == "dolby":
+                    return dolby_audio
+                if source == "flac":
+                    return flac_audio
+                if source == "regular":
+                    selected_index = response["selected_regular_index"]
+                    return best_audio[selected_index]
+                return None
+        except (AttributeError, IndexError, TypeError, ValueError):
+            pass
+        return CacheManager._py_select_preferred_dash_audio(
+            best_audio,
+            flac_audio,
+            dolby_audio,
+            audio_hires=audio_hires,
+        )
 
     def _download_dash_streams_with_aria2c(
         self,
@@ -2363,11 +2562,12 @@ class CacheManager:
             best_audio = page_dash_streams.get("audio") or []
             flac_audio = page_dash_streams.get("flac")
             dolby_audio = page_dash_streams.get("dolby")
-            preferred_audio = best_audio[0] if best_audio else None
-            if flac_audio and audio_hires:
-                preferred_audio = flac_audio
-            if dolby_audio and audio_hires:
-                preferred_audio = dolby_audio
+            preferred_audio = self._select_preferred_dash_audio(
+                best_audio,
+                flac_audio,
+                dolby_audio,
+                audio_hires=audio_hires,
+            )
 
             if preferred_audio:
                 audio_urls = self._preferred_audio_urls(preferred_audio)
@@ -2961,13 +3161,20 @@ class CacheManager:
         self._terminate_processes(active_processes)
 
     @staticmethod
-    def _video_quality_priority(video_quality: object, quality_cap: object = "") -> str:
-        normalized_quality = CacheManager._normalize_video_quality(video_quality)
+    def _py_video_quality_priority(video_quality: object, quality_cap: object = "") -> str:
+        normalized_quality = CacheManager._py_normalize_video_quality(video_quality)
         start_index = VIDEO_QUALITY_CHOICES.index(normalized_quality)
-        cap_quality = CacheManager._optional_video_quality(quality_cap)
+        cap_quality = CacheManager._py_optional_video_quality(quality_cap)
         if cap_quality:
             start_index = max(start_index, VIDEO_QUALITY_CHOICES.index(cap_quality))
         return ",".join(VIDEO_QUALITY_CHOICES[start_index:])
+
+    @staticmethod
+    def _video_quality_priority(video_quality: object, quality_cap: object = "") -> str:
+        response = CacheManager._native_quality_policy(video_quality, quality_cap)
+        if response is not None:
+            return ",".join(response["bbdown_quality_order"])
+        return CacheManager._py_video_quality_priority(video_quality, quality_cap)
 
     def _run_item_command(
         self,

--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -2430,12 +2430,10 @@ class CacheManager:
                     }
                     for index, stream in enumerate(audio_streams)
                 ],
-                "flac_available": False,
-                "dolby_available": False,
             }
             completed, response = rust_backend.try_select_audio_stream(request)
             if completed and response is not None:
-                selected_index = response["selected_regular_index"]
+                selected_index = response["selected_index"]
                 return None if selected_index is None else audio_streams[selected_index]
         except (AttributeError, IndexError, TypeError, ValueError):
             pass
@@ -2470,18 +2468,13 @@ class CacheManager:
             request = {
                 "schema_version": 1,
                 "audio_hires": audio_hires,
-                "regular_streams": [
-                    {
-                        "original_index": index,
-                        "quality_id": stream.get("quality_id", 0),
-                        "bandwidth": stream.get("bandwidth", 0),
-                    }
-                    for index, stream in enumerate(best_audio)
+                "regular_candidates": [
+                    {"original_index": index} for index in range(len(best_audio))
                 ],
                 "flac_available": bool(flac_audio),
                 "dolby_available": bool(dolby_audio),
             }
-            completed, response = rust_backend.try_select_audio_stream(request)
+            completed, response = rust_backend.try_select_preferred_audio_source(request)
             if completed and response is not None:
                 source = response["preferred_source"]
                 if source == "dolby":

--- a/bilikara/rust_backend.py
+++ b/bilikara/rust_backend.py
@@ -37,12 +37,18 @@ PHASE2_CAPABILITIES = (
     "plan_update_download_candidates",
     "plan_media_download_candidates",
     "plan_tool_download_candidates",
+    "decide_quality_policy",
+    "select_video_stream",
+    "select_audio_stream",
 )
 
 MAX_UPDATE_DOWNLOAD_CANDIDATE_INPUTS = 4096
 MAX_MEDIA_DOWNLOAD_STREAM_INPUTS = 4096
 MAX_MEDIA_DOWNLOAD_CANDIDATES = 16384
 MAX_TOOL_FALLBACK_BASES = 256
+MAX_STREAM_RANKING_INPUTS = 512
+MAX_CODEC_STRING_BYTES = 256
+MAX_QUALITY_LABEL_BYTES = 256
 
 
 def _rust_library_name() -> str:
@@ -173,6 +179,21 @@ _SYMBOLS = {
     ),
     "plan_tool_download_candidates": (
         "rust_plan_tool_download_candidates",
+        [ctypes.c_char_p],
+        ctypes.c_void_p,
+    ),
+    "decide_quality_policy": (
+        "rust_decide_quality_policy",
+        [ctypes.c_char_p],
+        ctypes.c_void_p,
+    ),
+    "select_video_stream": (
+        "rust_select_video_stream",
+        [ctypes.c_char_p],
+        ctypes.c_void_p,
+    ),
+    "select_audio_stream": (
+        "rust_select_audio_stream",
         [ctypes.c_char_p],
         ctypes.c_void_p,
     ),
@@ -1613,6 +1634,471 @@ def try_plan_tool_download_candidates(
         if not _valid_tool_download_plan_response(
             response, tool, expected_asset_name, expected_candidates
         ):
+            return False, None
+        return True, response
+    except Exception:
+        return False, None
+
+
+_ACTIVE_VIDEO_QUALITIES = (
+    "1080P 高帧率",
+    "1080P 高清",
+    "720P 高清",
+    "480P 清晰",
+    "360P 流畅",
+)
+_DEFAULT_VIDEO_QUALITY = _ACTIVE_VIDEO_QUALITIES[0]
+_DASH_QUALITY_IDS = {
+    "360P 流畅": 16,
+    "480P 清晰": 32,
+    "720P 高清": 64,
+    "720P 60帧": 74,
+    "1080P 高清": 80,
+    "1080P 高码率": 112,
+    "1080P 高帧率": 116,
+    "4K 超清": 120,
+    "HDR 真彩": 125,
+    "杜比视界": 126,
+    "8K 超高清": 127,
+}
+_I64_MIN = -(2**63)
+_I64_MAX = 2**63 - 1
+_USIZE_MAX = 2 ** (ctypes.sizeof(ctypes.c_size_t) * 8) - 1
+
+
+def _bounded_utf8_string(value: object, max_bytes: int) -> str | None:
+    if not isinstance(value, str) or len(value.encode("utf-8")) > max_bytes:
+        return None
+    return value
+
+
+def _quality_policy_request(request: object) -> dict[str, object] | None:
+    if not isinstance(request, dict) or set(request) != {
+        "schema_version",
+        "raw_quality",
+        "raw_cap",
+        "choice_index",
+    }:
+        return None
+    schema_version = request.get("schema_version")
+    raw_quality = _bounded_utf8_string(
+        request.get("raw_quality"), MAX_QUALITY_LABEL_BYTES
+    )
+    raw_cap = _bounded_utf8_string(request.get("raw_cap"), MAX_QUALITY_LABEL_BYTES)
+    choice_index = request.get("choice_index")
+    if (
+        isinstance(schema_version, bool)
+        or schema_version != 1
+        or raw_quality is None
+        or raw_cap is None
+        or (
+            choice_index is not None
+            and (
+                isinstance(choice_index, bool)
+                or not isinstance(choice_index, int)
+                or not _I64_MIN <= choice_index <= _I64_MAX
+            )
+        )
+    ):
+        return None
+    return {
+        "schema_version": 1,
+        "raw_quality": raw_quality,
+        "raw_cap": raw_cap,
+        "choice_index": choice_index,
+    }
+
+
+def _expected_quality_policy(request: dict[str, object]) -> dict[str, object]:
+    raw_quality = str(request["raw_quality"])
+    raw_cap = str(request["raw_cap"])
+    stripped_quality = raw_quality.strip()
+    stripped_cap = raw_cap.strip()
+    optional_quality = (
+        stripped_quality if stripped_quality in _ACTIVE_VIDEO_QUALITIES else None
+    )
+    normalized_quality = optional_quality or _DEFAULT_VIDEO_QUALITY
+    optional_cap = stripped_cap if stripped_cap in _ACTIVE_VIDEO_QUALITIES else None
+    choice_index = request["choice_index"]
+    indexed_quality = (
+        _ACTIVE_VIDEO_QUALITIES[choice_index]
+        if isinstance(choice_index, int)
+        and not isinstance(choice_index, bool)
+        and 0 <= choice_index < len(_ACTIVE_VIDEO_QUALITIES)
+        else None
+    )
+    effective_quality = optional_cap or normalized_quality
+    if "360" in effective_quality:
+        max_height = 360
+    elif "480" in effective_quality:
+        max_height = 480
+    elif "720" in effective_quality:
+        max_height = 720
+    elif "1080" in effective_quality:
+        max_height = 1080
+    elif "4K" in effective_quality:
+        max_height = 2160
+    elif "8K" in effective_quality:
+        max_height = 4320
+    else:
+        max_height = 1080
+    start_index = _ACTIVE_VIDEO_QUALITIES.index(normalized_quality)
+    if optional_cap:
+        start_index = max(start_index, _ACTIVE_VIDEO_QUALITIES.index(optional_cap))
+    return {
+        "schema_version": 1,
+        "status": "decided",
+        "normalized_quality": normalized_quality,
+        "optional_quality": optional_quality,
+        "optional_cap": optional_cap,
+        "indexed_quality": indexed_quality,
+        "dash_max_quality_id": _DASH_QUALITY_IDS.get(raw_quality, 80),
+        "effective_max_height": max_height,
+        "bbdown_quality_order": list(_ACTIVE_VIDEO_QUALITIES[start_index:]),
+    }
+
+
+def _valid_quality_policy_response(
+    response: object, request: dict[str, object]
+) -> bool:
+    return isinstance(response, dict) and response == _expected_quality_policy(request)
+
+
+def try_decide_quality_policy(
+    request: dict[str, object],
+) -> tuple[bool, dict[str, Any] | None]:
+    """Call and strictly reconstruct the canonical quality-policy decision."""
+
+    validated = _quality_policy_request(request)
+    if (
+        validated is None
+        or _rust_lib is None
+        or not _CAPABILITIES.get("decide_quality_policy", False)
+    ):
+        return False, None
+    try:
+        payload = json.dumps(validated, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        pointer = _rust_lib.rust_decide_quality_policy(payload)
+        response_json = _read_rust_string(pointer)
+        if response_json is None:
+            return False, None
+        response = json.loads(response_json)
+        if not _valid_quality_policy_response(response, validated):
+            return False, None
+        return True, response
+    except Exception:
+        return False, None
+
+
+def _video_stream_request(
+    request: object,
+) -> dict[str, object] | None:
+    if not isinstance(request, dict) or set(request) != {
+        "schema_version",
+        "max_quality_id",
+        "codec_filter",
+        "max_avc_quality_id",
+        "streams",
+    }:
+        return None
+    schema_version = request.get("schema_version")
+    max_quality_id = request.get("max_quality_id")
+    max_avc_quality_id = request.get("max_avc_quality_id")
+    codec_filter = request.get("codec_filter")
+    streams = request.get("streams")
+    if (
+        isinstance(schema_version, bool)
+        or schema_version != 1
+        or isinstance(max_quality_id, bool)
+        or not isinstance(max_quality_id, int)
+        or not _I64_MIN <= max_quality_id <= _I64_MAX
+        or (
+            max_avc_quality_id is not None
+            and (
+                isinstance(max_avc_quality_id, bool)
+                or not isinstance(max_avc_quality_id, int)
+                or not _I64_MIN <= max_avc_quality_id <= _I64_MAX
+            )
+        )
+        or (
+            codec_filter is not None
+            and _bounded_utf8_string(codec_filter, MAX_CODEC_STRING_BYTES) is None
+        )
+        or not isinstance(streams, list)
+        or len(streams) > MAX_STREAM_RANKING_INPUTS
+    ):
+        return None
+    validated_streams: list[dict[str, object]] = []
+    previous_index: int | None = None
+    for stream in streams:
+        if not isinstance(stream, dict) or set(stream) != {
+            "original_index",
+            "quality_id",
+            "bandwidth",
+            "codec",
+        }:
+            return None
+        original_index = stream.get("original_index")
+        quality_id = stream.get("quality_id")
+        bandwidth = stream.get("bandwidth")
+        codec = _bounded_utf8_string(stream.get("codec"), MAX_CODEC_STRING_BYTES)
+        if (
+            isinstance(original_index, bool)
+            or not isinstance(original_index, int)
+            or not 0 <= original_index <= _USIZE_MAX
+            or (previous_index is not None and original_index <= previous_index)
+            or isinstance(quality_id, bool)
+            or not isinstance(quality_id, int)
+            or not _I64_MIN <= quality_id <= _I64_MAX
+            or isinstance(bandwidth, bool)
+            or not isinstance(bandwidth, int)
+            or not _I64_MIN <= bandwidth <= _I64_MAX
+            or codec is None
+        ):
+            return None
+        previous_index = original_index
+        validated_streams.append(
+            {
+                "original_index": original_index,
+                "quality_id": quality_id,
+                "bandwidth": bandwidth,
+                "codec": codec,
+            }
+        )
+    return {
+        "schema_version": 1,
+        "max_quality_id": max_quality_id,
+        "codec_filter": codec_filter,
+        "max_avc_quality_id": max_avc_quality_id,
+        "streams": validated_streams,
+    }
+
+
+def _expected_video_stream_selection(request: dict[str, object]) -> dict[str, object]:
+    streams = list(request["streams"])
+    if not streams:
+        return {
+            "schema_version": 1,
+            "status": "no_match",
+            "selected_index": None,
+            "ranked_indices": [],
+            "reason": None,
+        }
+    max_quality_id = int(request["max_quality_id"])
+    codec_filter = request["codec_filter"]
+    max_avc_quality_id = request["max_avc_quality_id"]
+    candidates = [
+        stream
+        for stream in streams
+        if int(stream["quality_id"]) <= max_quality_id
+        and (not codec_filter or stream["codec"] == codec_filter)
+        and not (
+            codec_filter == "avc"
+            and isinstance(max_avc_quality_id, int)
+            and max_avc_quality_id != 0
+            and int(stream["quality_id"]) > max_avc_quality_id
+        )
+    ]
+    if candidates:
+        reason = "preferred"
+    else:
+        candidates = [
+            stream
+            for stream in streams
+            if int(stream["quality_id"]) <= max_quality_id
+        ]
+        if candidates:
+            reason = "quality_fallback"
+        else:
+            candidates = streams
+            reason = "uncapped_fallback"
+    ranked = sorted(
+        candidates,
+        key=lambda stream: (-int(stream["quality_id"]), -int(stream["bandwidth"])),
+    )
+    ranked_indices = [stream["original_index"] for stream in ranked]
+    return {
+        "schema_version": 1,
+        "status": "selected",
+        "selected_index": ranked_indices[0],
+        "ranked_indices": ranked_indices,
+        "reason": reason,
+    }
+
+
+def _valid_video_stream_response(
+    response: object, request: dict[str, object]
+) -> bool:
+    return isinstance(response, dict) and response == _expected_video_stream_selection(
+        request
+    )
+
+
+def try_select_video_stream(
+    request: dict[str, object],
+) -> tuple[bool, dict[str, Any] | None]:
+    """Call and strictly reconstruct DASH video ranking."""
+
+    validated = _video_stream_request(request)
+    if (
+        validated is None
+        or _rust_lib is None
+        or not _CAPABILITIES.get("select_video_stream", False)
+    ):
+        return False, None
+    try:
+        payload = json.dumps(validated, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        pointer = _rust_lib.rust_select_video_stream(payload)
+        response_json = _read_rust_string(pointer)
+        if response_json is None:
+            return False, None
+        response = json.loads(response_json)
+        if not _valid_video_stream_response(response, validated):
+            return False, None
+        return True, response
+    except Exception:
+        return False, None
+
+
+def _audio_stream_request(request: object) -> dict[str, object] | None:
+    if not isinstance(request, dict) or set(request) != {
+        "schema_version",
+        "audio_hires",
+        "regular_streams",
+        "flac_available",
+        "dolby_available",
+    }:
+        return None
+    schema_version = request.get("schema_version")
+    audio_hires = request.get("audio_hires")
+    flac_available = request.get("flac_available")
+    dolby_available = request.get("dolby_available")
+    streams = request.get("regular_streams")
+    if (
+        isinstance(schema_version, bool)
+        or schema_version != 1
+        or not isinstance(audio_hires, bool)
+        or not isinstance(flac_available, bool)
+        or not isinstance(dolby_available, bool)
+        or not isinstance(streams, list)
+        or len(streams) > MAX_STREAM_RANKING_INPUTS
+    ):
+        return None
+    validated_streams: list[dict[str, object]] = []
+    previous_index: int | None = None
+    for stream in streams:
+        if not isinstance(stream, dict) or set(stream) != {
+            "original_index",
+            "quality_id",
+            "bandwidth",
+        }:
+            return None
+        original_index = stream.get("original_index")
+        quality_id = stream.get("quality_id")
+        bandwidth = stream.get("bandwidth")
+        if (
+            isinstance(original_index, bool)
+            or not isinstance(original_index, int)
+            or not 0 <= original_index <= _USIZE_MAX
+            or (previous_index is not None and original_index <= previous_index)
+            or isinstance(quality_id, bool)
+            or not isinstance(quality_id, int)
+            or not _I64_MIN <= quality_id <= _I64_MAX
+            or isinstance(bandwidth, bool)
+            or not isinstance(bandwidth, int)
+            or not _I64_MIN <= bandwidth <= _I64_MAX
+        ):
+            return None
+        previous_index = original_index
+        validated_streams.append(
+            {
+                "original_index": original_index,
+                "quality_id": quality_id,
+                "bandwidth": bandwidth,
+            }
+        )
+    return {
+        "schema_version": 1,
+        "audio_hires": audio_hires,
+        "regular_streams": validated_streams,
+        "flac_available": flac_available,
+        "dolby_available": dolby_available,
+    }
+
+
+def _expected_audio_stream_selection(request: dict[str, object]) -> dict[str, object]:
+    streams = list(request["regular_streams"])
+    audio_hires = bool(request["audio_hires"])
+    candidates = streams
+    regular_reason: str | None = "hires_enabled" if streams and audio_hires else None
+    if streams and not audio_hires:
+        standard = [
+            stream for stream in streams if stream["quality_id"] not in {30250, 30251}
+        ]
+        if standard:
+            candidates = standard
+            regular_reason = "standard_only"
+        else:
+            regular_reason = "hires_only_fallback"
+    quality_order = {30250: 0, 30251: 1, 30280: 2, 30232: 3, 30216: 4}
+    ranked = sorted(
+        candidates,
+        key=lambda stream: quality_order.get(stream["quality_id"], 99),
+    )
+    ranked_indices = [stream["original_index"] for stream in ranked]
+    selected_regular_index = ranked_indices[0] if ranked_indices else None
+    if audio_hires and request["dolby_available"]:
+        preferred_source = "dolby"
+    elif audio_hires and request["flac_available"]:
+        preferred_source = "flac"
+    elif selected_regular_index is not None:
+        preferred_source = "regular"
+    else:
+        preferred_source = None
+    return {
+        "schema_version": 1,
+        "status": "selected" if preferred_source else "no_match",
+        "selected_regular_index": selected_regular_index,
+        "ranked_regular_indices": ranked_indices,
+        "regular_reason": regular_reason,
+        "preferred_source": preferred_source,
+    }
+
+
+def _valid_audio_stream_response(
+    response: object, request: dict[str, object]
+) -> bool:
+    return isinstance(response, dict) and response == _expected_audio_stream_selection(
+        request
+    )
+
+
+def try_select_audio_stream(
+    request: dict[str, object],
+) -> tuple[bool, dict[str, Any] | None]:
+    """Call and strictly reconstruct DASH audio ranking and source preference."""
+
+    validated = _audio_stream_request(request)
+    if (
+        validated is None
+        or _rust_lib is None
+        or not _CAPABILITIES.get("select_audio_stream", False)
+    ):
+        return False, None
+    try:
+        payload = json.dumps(validated, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        pointer = _rust_lib.rust_select_audio_stream(payload)
+        response_json = _read_rust_string(pointer)
+        if response_json is None:
+            return False, None
+        response = json.loads(response_json)
+        if not _valid_audio_stream_response(response, validated):
             return False, None
         return True, response
     except Exception:

--- a/bilikara/rust_backend.py
+++ b/bilikara/rust_backend.py
@@ -40,6 +40,7 @@ PHASE2_CAPABILITIES = (
     "decide_quality_policy",
     "select_video_stream",
     "select_audio_stream",
+    "select_preferred_audio_source",
 )
 
 MAX_UPDATE_DOWNLOAD_CANDIDATE_INPUTS = 4096
@@ -194,6 +195,11 @@ _SYMBOLS = {
     ),
     "select_audio_stream": (
         "rust_select_audio_stream",
+        [ctypes.c_char_p],
+        ctypes.c_void_p,
+    ),
+    "select_preferred_audio_source": (
+        "rust_select_preferred_audio_source",
         [ctypes.c_char_p],
         ctypes.c_void_p,
     ),
@@ -1969,21 +1975,15 @@ def _audio_stream_request(request: object) -> dict[str, object] | None:
         "schema_version",
         "audio_hires",
         "regular_streams",
-        "flac_available",
-        "dolby_available",
     }:
         return None
     schema_version = request.get("schema_version")
     audio_hires = request.get("audio_hires")
-    flac_available = request.get("flac_available")
-    dolby_available = request.get("dolby_available")
     streams = request.get("regular_streams")
     if (
         isinstance(schema_version, bool)
         or schema_version != 1
         or not isinstance(audio_hires, bool)
-        or not isinstance(flac_available, bool)
-        or not isinstance(dolby_available, bool)
         or not isinstance(streams, list)
         or len(streams) > MAX_STREAM_RANKING_INPUTS
     ):
@@ -2025,8 +2025,6 @@ def _audio_stream_request(request: object) -> dict[str, object] | None:
         "schema_version": 1,
         "audio_hires": audio_hires,
         "regular_streams": validated_streams,
-        "flac_available": flac_available,
-        "dolby_available": dolby_available,
     }
 
 
@@ -2050,22 +2048,13 @@ def _expected_audio_stream_selection(request: dict[str, object]) -> dict[str, ob
         key=lambda stream: quality_order.get(stream["quality_id"], 99),
     )
     ranked_indices = [stream["original_index"] for stream in ranked]
-    selected_regular_index = ranked_indices[0] if ranked_indices else None
-    if audio_hires and request["dolby_available"]:
-        preferred_source = "dolby"
-    elif audio_hires and request["flac_available"]:
-        preferred_source = "flac"
-    elif selected_regular_index is not None:
-        preferred_source = "regular"
-    else:
-        preferred_source = None
+    selected_index = ranked_indices[0] if ranked_indices else None
     return {
         "schema_version": 1,
-        "status": "selected" if preferred_source else "no_match",
-        "selected_regular_index": selected_regular_index,
-        "ranked_regular_indices": ranked_indices,
-        "regular_reason": regular_reason,
-        "preferred_source": preferred_source,
+        "status": "selected" if selected_index is not None else "no_match",
+        "selected_index": selected_index,
+        "ranked_indices": ranked_indices,
+        "reason": regular_reason,
     }
 
 
@@ -2080,7 +2069,7 @@ def _valid_audio_stream_response(
 def try_select_audio_stream(
     request: dict[str, object],
 ) -> tuple[bool, dict[str, Any] | None]:
-    """Call and strictly reconstruct DASH audio ranking and source preference."""
+    """Call and strictly reconstruct regular DASH audio ranking."""
 
     validated = _audio_stream_request(request)
     if (
@@ -2099,6 +2088,113 @@ def try_select_audio_stream(
             return False, None
         response = json.loads(response_json)
         if not _valid_audio_stream_response(response, validated):
+            return False, None
+        return True, response
+    except Exception:
+        return False, None
+
+
+def _preferred_audio_source_request(request: object) -> dict[str, object] | None:
+    if not isinstance(request, dict) or set(request) != {
+        "schema_version",
+        "audio_hires",
+        "regular_candidates",
+        "flac_available",
+        "dolby_available",
+    }:
+        return None
+    schema_version = request.get("schema_version")
+    audio_hires = request.get("audio_hires")
+    candidates = request.get("regular_candidates")
+    flac_available = request.get("flac_available")
+    dolby_available = request.get("dolby_available")
+    if (
+        isinstance(schema_version, bool)
+        or schema_version != 1
+        or not isinstance(audio_hires, bool)
+        or not isinstance(candidates, list)
+        or len(candidates) > MAX_STREAM_RANKING_INPUTS
+        or not isinstance(flac_available, bool)
+        or not isinstance(dolby_available, bool)
+    ):
+        return None
+    validated_candidates: list[dict[str, int]] = []
+    previous_index: int | None = None
+    for candidate in candidates:
+        if not isinstance(candidate, dict) or set(candidate) != {"original_index"}:
+            return None
+        original_index = candidate.get("original_index")
+        if (
+            isinstance(original_index, bool)
+            or not isinstance(original_index, int)
+            or not 0 <= original_index <= _USIZE_MAX
+            or (previous_index is not None and original_index <= previous_index)
+        ):
+            return None
+        previous_index = original_index
+        validated_candidates.append({"original_index": original_index})
+    return {
+        "schema_version": 1,
+        "audio_hires": audio_hires,
+        "regular_candidates": validated_candidates,
+        "flac_available": flac_available,
+        "dolby_available": dolby_available,
+    }
+
+
+def _expected_preferred_audio_source_selection(
+    request: dict[str, object],
+) -> dict[str, object]:
+    candidates = list(request["regular_candidates"])
+    selected_regular_index = (
+        candidates[0]["original_index"] if candidates else None
+    )
+    if request["audio_hires"] and request["dolby_available"]:
+        preferred_source = "dolby"
+    elif request["audio_hires"] and request["flac_available"]:
+        preferred_source = "flac"
+    elif selected_regular_index is not None:
+        preferred_source = "regular"
+    else:
+        preferred_source = None
+    return {
+        "schema_version": 1,
+        "status": "selected" if preferred_source is not None else "no_match",
+        "preferred_source": preferred_source,
+        "selected_regular_index": selected_regular_index,
+    }
+
+
+def _valid_preferred_audio_source_response(
+    response: object, request: dict[str, object]
+) -> bool:
+    return isinstance(response, dict) and response == (
+        _expected_preferred_audio_source_selection(request)
+    )
+
+
+def try_select_preferred_audio_source(
+    request: dict[str, object],
+) -> tuple[bool, dict[str, Any] | None]:
+    """Call and strictly reconstruct preferred DASH audio source binding."""
+
+    validated = _preferred_audio_source_request(request)
+    if (
+        validated is None
+        or _rust_lib is None
+        or not _CAPABILITIES.get("select_preferred_audio_source", False)
+    ):
+        return False, None
+    try:
+        payload = json.dumps(validated, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        pointer = _rust_lib.rust_select_preferred_audio_source(payload)
+        response_json = _read_rust_string(pointer)
+        if response_json is None:
+            return False, None
+        response = json.loads(response_json)
+        if not _valid_preferred_audio_source_response(response, validated):
             return False, None
         return True, response
     except Exception:

--- a/docs/rust-business-rule-migration-plan.md
+++ b/docs/rust-business-rule-migration-plan.md
@@ -254,62 +254,86 @@ Remaining risks:
 - Variant-ID construction is still duplicated in Python and was outside this
   migration's scope.
 
-### 5. Quality and stream ranking
+### 6. Quality and stream ranking
 
-Status: deferred, not started. No quality/stream selection, BBDown, aria2,
-cache, or FFmpeg work was begun as part of download-candidate planning.
+Status: **completed**. Phase 2 is **6/8 complete**. Item 6 uses three typed
+domains so quality normalization, video ranking, and audio ranking retain their
+different invariants instead of being hidden behind a generic scorer.
 
-Current Python ownership:
+Migrated Python helpers and ownership:
 
-- `bilikara/cache.py`
-- `_quality_from_choice_index`
-- `_optional_video_quality`
-- `_normalize_video_quality`
-- `_dash_max_quality_id`
-- `_video_quality_priority`
-- `_select_dash_video_stream`
-- `_select_dash_audio_stream`
-- `_ytdlp_max_height` and `_ytdlp_format_selector` consume the policy but
-  command creation remains Python.
+- `bilikara/cache.py` retains complete independent references named
+  `_py_quality_from_choice_index`, `_py_optional_video_quality`,
+  `_py_normalize_video_quality`, `_py_dash_max_quality_id`,
+  `_py_video_quality_priority`, `_py_ytdlp_max_height`,
+  `_py_select_dash_video_stream`, `_py_select_dash_audio_stream`, and
+  `_py_select_preferred_dash_audio`.
+- Their public wrappers adapt immutable strings, integers, codec names, source
+  availability, and original indices; each calls one native operation and maps
+  accepted indices back to the original dictionaries. Any unavailable or
+  invalid native result invokes the complete corresponding `_py_*` policy.
+- Python still reads cache/client configuration under its existing locks,
+  fetches DASH metadata, owns URLs, creates BBDown and yt-dlp syntax, performs
+  downloads, runs subprocesses, validates files, and mutates cache state.
 
-Input/output model: explicit quality preference, codec constraints, Hi-Res
-flag, AVC cap, and normalized stream descriptors; output selected stream index
-and a reason/rank vector. Python retains URLs, cookies, and download commands.
-
-Dependencies: current quality constants, codec aliases, quality IDs, bandwidth,
-and audio-quality ordering.
-
-User-visible policy: maximum resolution, codec fallback, AVC caps, Hi-Res/Dolby
-preference, and fallback when requested streams are unavailable.
-
-Proposed Rust structures:
+Typed domain APIs:
 
 ```text
-VideoStream { index, quality_id, bandwidth, codec }
-AudioStream { index, quality_id, bandwidth }
-StreamPolicy { max_quality_id, codec, avc_cap, allow_hires }
-StreamSelection { selected_index, ranked_indices, reason }
+decide_quality_policy(QualityPolicyRequest) -> QualityPolicyDecision
+select_video_stream(VideoStreamSelectionRequest) -> VideoStreamSelection
+select_audio_stream(AudioStreamSelectionRequest) -> AudioStreamSelection
 ```
 
-Proposed FFI:
+- `quality_policy` represents all historical Bilibili quality-ID labels while
+  restricting configurable normalized choices to the current five labels. It
+  returns normalized/optional/indexed quality identities, the exact raw-label
+  DASH cap, effective yt-dlp maximum height, and ordered BBDown quality labels.
+- `video_stream_ranking` receives original index, quality ID, integer bandwidth,
+  and exact codec identity. It preserves the three current stages: constrained
+  codec/quality/AVC selection, quality-only fallback, then uncapped fallback.
+  Each chosen stage ranks descending quality ID, descending bandwidth, then
+  stable original input order. Unknown codec strings retain exact identity;
+  Bilibili's `7 -> avc`, `12 -> hevc`, and `13 -> av1` metadata normalization
+  remains in the Python API parser.
+- `audio_stream_ranking` ranks regular audio by the existing fixed order
+  Dolby 30250, FLAC 30251, 192K 30280, 132K 30232, and 64K 30216. Bandwidth is
+  deliberately ignored and original input order breaks ties. With Hi-Res off,
+  Dolby/FLAC entries in the regular list are removed when a standard entry
+  exists, but an all-Hi-Res regular list is retained as the existing fallback.
+  Separate preferred sources remain Dolby, then FLAC, then selected regular
+  audio when Hi-Res is enabled; separate Hi-Res sources are unavailable when it
+  is disabled.
+
+Additive ABI-v1 JSON exports and capabilities:
 
 ```text
-rust_rank_media_streams(request_json) -> owned response JSON or null
+rust_decide_quality_policy / decide_quality_policy
+rust_select_video_stream / select_video_stream
+rust_select_audio_stream / select_audio_stream
 ```
 
-Python fallback: retain current selectors as a single policy group and validate
-that selected indices refer to supplied streams before using Rust output.
+All three return Rust-owned JSON freed by `rust_free_string`, reject null,
+invalid UTF-8, malformed JSON, unsupported schemas, unknown fields, and invalid
+or duplicate wire indices, and distinguish valid `no_match` from FFI failure.
+The Python backend caps stream counts and UTF-8 label/codec lengths, rejects
+Boolean-as-integer and out-of-range values, and reconstructs the entire expected
+decision/ranking before accepting it. Selected and ranked indices, reasons,
+quality/codec caps, preferred source, and order must match exactly.
 
-Golden tests: every quality label/ID, cap boundaries, codec requested/missing,
-bandwidth ties, Dolby/FLAC preference, Hi-Res disabled, empty streams, and
-current BBDown/yt-dlp/DASH policy regressions without executing commands.
+Tests cover typed Rust policy, wire adapters, FFI panic/null/UTF-8/schema and
+repeated allocation/free behavior; independent Python golden references;
+missing-library/symbol/ABI and malicious native responses; and strict-native
+fixed/generated equivalence across qualities, caps, codecs, permutations,
+fallback stages, bandwidth ties, Dolby, FLAC, and Hi-Res combinations. Existing
+cache command regressions confirm that only policy decisions changed ownership.
 
-Risk: high. Small ranking changes affect bandwidth, compatibility, and media
-quality, while several download sources consume related policy differently.
+Remaining risk: source metadata can contain malformed scalar values. Such
+requests fail closed to the original Python policy, preserving its behavior.
+Cross-platform CI remains necessary because the JSON ABI is loaded through
+platform-specific dynamic libraries. Downloader-specific selector strings and
+arguments intentionally remain Python adapters rather than canonical policy.
 
-Recommended order: only after page and binding domains.
-
-### 6. Download candidate planning
+### 5. Download candidate planning
 
 Status: **completed**. Phase 2 is **5/8 complete**. Item 5 uses three precise
 typed domains because updater, media, and tool planners have materially
@@ -356,8 +380,8 @@ Typed domain model:
 - Media `DashStreams` mode trims and removes empty URLs while preserving every
   duplicate. `PreferredAudio` mode accepts at most one audio descriptor and
   preserves the raw strings, empties, duplicates, and order used by the
-  existing special path. Choosing that descriptor remains Python Item 6
-  policy and was not migrated.
+  existing special path. Preferred audio descriptor selection is now owned by
+  the separate Item 6 audio-ranking domain; URL flattening remains Item 5.
 - Tool input is `ToolDownloadPlanRequest { tool, asset, fallback_bases }`.
   `ToolAssetInput` is either a supplied asset name/primary URL or a
   `DefaultForTarget` with explicit platform/architecture. Output includes the
@@ -425,8 +449,9 @@ Cohesion decision and completed boundary:
   yt-dlp/FFmpeg/ffprobe command construction and execution, extraction,
   filesystem publication, cache workers/mutation, cancellation, and download
   loops remain Python.
-- Tool release asset scoring/selection and preferred-audio/video stream
-  selection remain deferred ranking policy. No Item 6 work was started.
+- Tool release asset scoring stays in its existing typed selection domain.
+  Preferred-audio/video stream selection is separate from candidate URLs and
+  is now completed by the Item 6 ranking domains above.
 
 Test coverage:
 
@@ -454,7 +479,8 @@ this risk for all three domains. Cross-platform release-gate confirmation and
 production variation in externally supplied URL strings remain the residual
 risks; neither can move I/O or mutable state into Rust.
 
-Recommended order: complete; proceed to Item 6 only as a separate migration.
+Recommended order: complete; Item 6 was subsequently implemented as a separate
+migration without redesigning these candidate schemas.
 
 ### 7. Playlist ordering and deduplication
 

--- a/docs/rust-business-rule-migration-plan.md
+++ b/docs/rust-business-rule-migration-plan.md
@@ -256,9 +256,10 @@ Remaining risks:
 
 ### 6. Quality and stream ranking
 
-Status: **completed**. Phase 2 is **6/8 complete**. Item 6 uses three typed
-domains so quality normalization, video ranking, and audio ranking retain their
-different invariants instead of being hidden behind a generic scorer.
+Status: **completed**. Phase 2 is **6/8 complete**. Item 6 uses four typed
+domains so quality normalization, video ranking, regular-audio ranking, and
+preferred-audio source binding retain their different invariants instead of
+being hidden behind a generic scorer.
 
 Migrated Python helpers and ownership:
 
@@ -282,6 +283,7 @@ Typed domain APIs:
 decide_quality_policy(QualityPolicyRequest) -> QualityPolicyDecision
 select_video_stream(VideoStreamSelectionRequest) -> VideoStreamSelection
 select_audio_stream(AudioStreamSelectionRequest) -> AudioStreamSelection
+select_preferred_audio_source(PreferredAudioSourceRequest) -> PreferredAudioSourceSelection
 ```
 
 - `quality_policy` represents all historical Bilibili quality-ID labels while
@@ -300,9 +302,11 @@ select_audio_stream(AudioStreamSelectionRequest) -> AudioStreamSelection
   deliberately ignored and original input order breaks ties. With Hi-Res off,
   Dolby/FLAC entries in the regular list are removed when a standard entry
   exists, but an all-Hi-Res regular list is retained as the existing fallback.
-  Separate preferred sources remain Dolby, then FLAC, then selected regular
-  audio when Hi-Res is enabled; separate Hi-Res sources are unavailable when it
-  is disabled.
+- `preferred_audio_source_binding` deliberately does not receive quality IDs or
+  bandwidth and never ranks regular audio. It preserves the first supplied
+  regular candidate exactly; with Hi-Res enabled FLAC overrides regular and
+  Dolby overrides FLAC, while with Hi-Res disabled both separate sources are
+  ignored. This is distinct from `_select_dash_audio_stream` ranking policy.
 
 Additive ABI-v1 JSON exports and capabilities:
 
@@ -310,22 +314,25 @@ Additive ABI-v1 JSON exports and capabilities:
 rust_decide_quality_policy / decide_quality_policy
 rust_select_video_stream / select_video_stream
 rust_select_audio_stream / select_audio_stream
+rust_select_preferred_audio_source / select_preferred_audio_source
 ```
 
-All three return Rust-owned JSON freed by `rust_free_string`, reject null,
+All four return Rust-owned JSON freed by `rust_free_string`, reject null,
 invalid UTF-8, malformed JSON, unsupported schemas, unknown fields, and invalid
 or duplicate wire indices, and distinguish valid `no_match` from FFI failure.
 The Python backend caps stream counts and UTF-8 label/codec lengths, rejects
 Boolean-as-integer and out-of-range values, and reconstructs the entire expected
 decision/ranking before accepting it. Selected and ranked indices, reasons,
-quality/codec caps, preferred source, and order must match exactly.
+quality/codec caps, preferred source, first-regular identity, and order must
+match exactly.
 
 Tests cover typed Rust policy, wire adapters, FFI panic/null/UTF-8/schema and
 repeated allocation/free behavior; independent Python golden references;
 missing-library/symbol/ABI and malicious native responses; and strict-native
 fixed/generated equivalence across qualities, caps, codecs, permutations,
-fallback stages, bandwidth ties, Dolby, FLAC, and Hi-Res combinations. Existing
-cache command regressions confirm that only policy decisions changed ownership.
+fallback stages, bandwidth ties, unsorted regular-audio inputs, object identity,
+Dolby, FLAC, and Hi-Res combinations. Existing cache command regressions
+confirm that only policy decisions changed ownership.
 
 Remaining risk: source metadata can contain malformed scalar values. Such
 requests fail closed to the original Python policy, preserving its behavior.

--- a/docs/rust-native-utility-inventory.md
+++ b/docs/rust-native-utility-inventory.md
@@ -55,13 +55,13 @@ No other helper is approved for Phase 1. The tables below document why.
 
 | Helpers reviewed | Category / dependencies | Pure | Decision and reason |
 | --- | --- | --- | --- |
-| `_quality_from_choice_index`, `_optional_video_quality`, `_normalize_video_quality` | quality label validation/defaulting | yes | Intentionally defer. They are tiny Python membership checks and the default is cache policy; FFI overhead exceeds the work. |
+| `_quality_from_choice_index`, `_optional_video_quality`, `_normalize_video_quality` | quality label validation/defaulting | yes | Excluded from Phase 1; migrated together with consumer decisions as Phase 2 Item 6 `quality_policy`, with complete `_py_*` references. |
 | `_normalize_download_source`, `_current_download_source`, `_download_source_label` | source normalization/label policy | yes | Excluded: source preference and cache policy. |
 | `_bounded_cache_items` | integer coercion/clamping | yes | Defer: trivial scalar coercion tied to cache policy. |
 | `_variant_id`, `_download_track_key`, `_download_track_label`, `_part_label_for_page` | download-track identifiers/labels | yes | Defer: tiny helpers embedded in download planning; `_variant_id` should first be consolidated with `bilibili.py`. |
 | `_page_url`, `_build_media_url` | URL composition | yes | Defer: each is a trivial operation in downloader/local-serving code, not a reusable URL parsing domain. |
 | `_normalize_output_line`, `_extract_progress`, `_compact_probe_error`, `_format_stage_bytes` | subprocess output cleanup/parsing | core yes | Excluded from this phase because their primary purpose is subprocess/progress handling. |
-| `_dash_max_quality_id`, `_video_quality_priority`, format selectors and stream selectors | quality lookup/ranking | yes | Excluded: download policy, scoring, ranking, and selection. |
+| `_dash_max_quality_id`, `_video_quality_priority`, `_ytdlp_max_height`, and stream selectors | quality lookup/ranking | yes | Excluded from Phase 1; deterministic decisions migrated as Phase 2 Item 6. BBDown/yt-dlp syntax and all execution remain Python. |
 | `_dash_stream_urls`, `_current_platform_tokens`, release asset-name helpers | response adapters/platform selection | mostly | Excluded from Phase 1. The pure URL flattening and fallback asset construction were later migrated as Phase 2 Item 5; runtime detection and dictionary adaptation remain Python. |
 | All command, downloader, archive extraction, file lookup, path-size, process, worker, retry, cache-window, and filesystem helpers | I/O, subprocess, state, scheduling, policy | no/mixed | Outside Phase 1 by definition. |
 
@@ -282,6 +282,9 @@ Missing optional symbols disable only their matching capabilities.
 | `download_candidate_planning` (updater) | `rust_plan_update_download_candidates` / `plan_update_download_candidates` | Implements updater API/direct/proxy construction with trimming, stable deduplication, explicit sources/routes, and complete Python fallback. |
 | `media_download_candidate_planning` | `rust_plan_media_download_candidates` / `plan_media_download_candidates` | Implements DASH primary/backup flattening and preferred-audio URL flattening. DASH trims/drops empties and preserves duplicates; preferred audio preserves raw strings and duplicates. Python retains descriptor selection, all I/O, and complete `_py_*` references. |
 | `tool_download_candidate_planning` | `rust_plan_tool_download_candidates` / `plan_tool_download_candidates` | Implements supplied/built-in primary plus configured fallback ordering, tool/target fallback asset identity, name quoting, and exact stable deduplication for BBDown, yt-dlp, and aria2c. Python retains runtime detection, asset scoring, downloads, installation, and complete `_py_*` references. |
+| `quality_policy` | `rust_decide_quality_policy` / `decide_quality_policy` | Implements active-label normalization, all historical DASH quality IDs, choice-index mapping, AVC-cap evaluation, yt-dlp maximum-height intent, and BBDown ordered quality intent. Python retains configuration, selector/argument syntax, and complete `_py_*` references. |
+| `video_stream_ranking` | `rust_select_video_stream` / `select_video_stream` | Implements exact codec/quality/AVC filtering, current two fallback stages, descending quality/bandwidth ranking, stable ties, and selected/ranked original indices. Python retains DASH fetching, stream dictionaries, URLs, and fallback. |
+| `audio_stream_ranking` | `rust_select_audio_stream` / `select_audio_stream` | Implements regular audio quality ordering, Hi-Res filtering/fallback, and Dolby/FLAC/regular source preference. Bandwidth remains intentionally irrelevant. Python retains DASH fetching, URL planning, file extension/application, and fallback. |
 
 Audio binding transports only original index, page number, duration, and part
 label. It does not transport CID or arbitrary Bilibili metadata. The Rust
@@ -289,11 +292,11 @@ domain preserves the existing broad keyword substring policy and returns
 `single`, `automatic`, `manual_required`, or domain-level `no_match`.
 
 Variant-ID construction remains entirely in Python and was not consolidated.
-Phase 2 Item 5 is complete and Phase 2 is 5/8. The three candidate domains are
-separate because their normalization, duplicate, source, and ordering policies
-are intentionally different. No quality/stream ranking, cache planning,
-playlist ordering, downloader execution, mobile plugin, or FFmpeg migration
-was started.
+Phase 2 Items 5 and 6 are complete and Phase 2 is 6/8. Candidate planning,
+quality policy, video ranking, and audio ranking remain separate because their
+normalization, duplicate, fallback, and ordering policies are intentionally
+different. No cache planning, playlist ordering, downloader execution, mobile
+plugin, or FFmpeg migration was started.
 
 ### Criteria for future migration
 
@@ -305,9 +308,8 @@ I/O and mutable policy in Python unless that later phase explicitly changes
 the boundary.
 
 The intentionally deferred helpers in the audit remain deferred. In
-particular, release and asset scoring/selection, Bilibili short-link
-resolution, cache quality/source defaults, stream ranking, cache-window and
-playlist planning, path traversal checks, persistent schema adapters,
-rendering utilities, and all filesystem/network/subprocess/thread behavior are
-not part of Phase 1. Updater, media, and tool candidate planning are the later
-completed Phase-2 Item 5 domains documented above.
+particular, Bilibili short-link resolution, download-source defaults,
+cache-window and playlist planning, path traversal checks, persistent schema
+adapters, rendering utilities, and all filesystem/network/subprocess/thread
+behavior are not part of Phase 1. Candidate planning and quality/stream ranking
+are the later completed Phase-2 Items 5 and 6 documented above.

--- a/docs/rust-native-utility-inventory.md
+++ b/docs/rust-native-utility-inventory.md
@@ -284,7 +284,8 @@ Missing optional symbols disable only their matching capabilities.
 | `tool_download_candidate_planning` | `rust_plan_tool_download_candidates` / `plan_tool_download_candidates` | Implements supplied/built-in primary plus configured fallback ordering, tool/target fallback asset identity, name quoting, and exact stable deduplication for BBDown, yt-dlp, and aria2c. Python retains runtime detection, asset scoring, downloads, installation, and complete `_py_*` references. |
 | `quality_policy` | `rust_decide_quality_policy` / `decide_quality_policy` | Implements active-label normalization, all historical DASH quality IDs, choice-index mapping, AVC-cap evaluation, yt-dlp maximum-height intent, and BBDown ordered quality intent. Python retains configuration, selector/argument syntax, and complete `_py_*` references. |
 | `video_stream_ranking` | `rust_select_video_stream` / `select_video_stream` | Implements exact codec/quality/AVC filtering, current two fallback stages, descending quality/bandwidth ranking, stable ties, and selected/ranked original indices. Python retains DASH fetching, stream dictionaries, URLs, and fallback. |
-| `audio_stream_ranking` | `rust_select_audio_stream` / `select_audio_stream` | Implements regular audio quality ordering, Hi-Res filtering/fallback, and Dolby/FLAC/regular source preference. Bandwidth remains intentionally irrelevant. Python retains DASH fetching, URL planning, file extension/application, and fallback. |
+| `audio_stream_ranking` | `rust_select_audio_stream` / `select_audio_stream` | Implements only regular audio quality ordering and Hi-Res filtering/fallback. Bandwidth remains intentionally irrelevant and equal quality preserves input order. Python retains DASH fetching, stream dictionaries, and complete fallback. |
+| `preferred_audio_source_binding` | `rust_select_preferred_audio_source` / `select_preferred_audio_source` | Implements preferred-source binding without regular ranking: the first supplied regular candidate is retained, then FLAC and Dolby override it in that order only when Hi-Res is enabled. Python retains object mapping, URLs, file extension/application, and complete fallback. |
 
 Audio binding transports only original index, page number, duration, and part
 label. It does not transport CID or arbitrary Bilibili metadata. The Rust
@@ -293,10 +294,10 @@ domain preserves the existing broad keyword substring policy and returns
 
 Variant-ID construction remains entirely in Python and was not consolidated.
 Phase 2 Items 5 and 6 are complete and Phase 2 is 6/8. Candidate planning,
-quality policy, video ranking, and audio ranking remain separate because their
-normalization, duplicate, fallback, and ordering policies are intentionally
-different. No cache planning, playlist ordering, downloader execution, mobile
-plugin, or FFmpeg migration was started.
+quality policy, video ranking, regular-audio ranking, and preferred-source
+binding remain separate because their normalization, fallback, and ordering
+policies are intentionally different. No cache planning, playlist ordering,
+downloader execution, mobile plugin, or FFmpeg migration was started.
 
 ### Criteria for future migration
 

--- a/rust/src/audio_stream_ranking.rs
+++ b/rust/src/audio_stream_ranking.rs
@@ -17,8 +17,6 @@ pub struct AudioStreamDescriptor {
 pub struct AudioStreamSelectionRequest {
     pub audio_hires: bool,
     pub regular_streams: Vec<AudioStreamDescriptor>,
-    pub flac_available: bool,
-    pub dolby_available: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,20 +26,12 @@ pub enum AudioRegularReason {
     HiresOnlyFallback,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PreferredAudioSource {
-    Regular,
-    Flac,
-    Dolby,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AudioStreamSelection {
     Selected {
-        selected_regular_index: Option<usize>,
-        ranked_regular_indices: Vec<usize>,
-        regular_reason: Option<AudioRegularReason>,
-        preferred_source: PreferredAudioSource,
+        selected_index: usize,
+        ranked_indices: Vec<usize>,
+        reason: AudioRegularReason,
     },
     NoMatch,
 }
@@ -76,7 +66,7 @@ pub fn select_audio_stream(
 
     let mut ranked: Vec<(usize, &AudioStreamDescriptor)> =
         request.regular_streams.iter().enumerate().collect();
-    let regular_reason = if request.audio_hires {
+    let reason = if request.audio_hires {
         (!ranked.is_empty()).then_some(AudioRegularReason::HiresEnabled)
     } else {
         let standard: Vec<_> = ranked
@@ -92,29 +82,17 @@ pub fn select_audio_stream(
         }
     };
     ranked.sort_by_key(|(position, stream)| (quality_rank(stream.quality_id), *position));
-    let ranked_regular_indices: Vec<usize> = ranked
+    let ranked_indices: Vec<usize> = ranked
         .iter()
         .map(|(_, stream)| stream.original_index)
         .collect();
-    let selected_regular_index = ranked_regular_indices.first().copied();
-    let preferred_source = if request.audio_hires && request.dolby_available {
-        Some(PreferredAudioSource::Dolby)
-    } else if request.audio_hires && request.flac_available {
-        Some(PreferredAudioSource::Flac)
-    } else if selected_regular_index.is_some() {
-        Some(PreferredAudioSource::Regular)
-    } else {
-        None
-    };
-
-    Ok(match preferred_source {
-        Some(preferred_source) => AudioStreamSelection::Selected {
-            selected_regular_index,
-            ranked_regular_indices,
-            regular_reason,
-            preferred_source,
+    Ok(match (ranked_indices.first().copied(), reason) {
+        (Some(selected_index), Some(reason)) => AudioStreamSelection::Selected {
+            selected_index,
+            ranked_indices,
+            reason,
         },
-        None => AudioStreamSelection::NoMatch,
+        _ => AudioStreamSelection::NoMatch,
     })
 }
 
@@ -132,8 +110,6 @@ struct AudioStreamWireRequest {
     schema_version: u32,
     audio_hires: bool,
     regular_streams: Vec<AudioStreamWireDescriptor>,
-    flac_available: bool,
-    dolby_available: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -152,21 +128,12 @@ enum WireRegularReason {
 }
 
 #[derive(Debug, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum WirePreferredSource {
-    Regular,
-    Flac,
-    Dolby,
-}
-
-#[derive(Debug, Serialize)]
 struct AudioStreamWireResponse {
     schema_version: u32,
     status: WireStatus,
-    selected_regular_index: Option<usize>,
-    ranked_regular_indices: Vec<usize>,
-    regular_reason: Option<WireRegularReason>,
-    preferred_source: Option<WirePreferredSource>,
+    selected_index: Option<usize>,
+    ranked_indices: Vec<usize>,
+    reason: Option<WireRegularReason>,
 }
 
 pub(crate) fn select_audio_stream_json(request_json: &str) -> Option<String> {
@@ -190,37 +157,28 @@ pub(crate) fn select_audio_stream_json(request_json: &str) -> Option<String> {
                 bandwidth: stream.bandwidth,
             })
             .collect(),
-        flac_available: wire.flac_available,
-        dolby_available: wire.dolby_available,
     };
     let response = match select_audio_stream(&request).ok()? {
         AudioStreamSelection::NoMatch => AudioStreamWireResponse {
             schema_version: SCHEMA_VERSION,
             status: WireStatus::NoMatch,
-            selected_regular_index: None,
-            ranked_regular_indices: vec![],
-            regular_reason: None,
-            preferred_source: None,
+            selected_index: None,
+            ranked_indices: vec![],
+            reason: None,
         },
         AudioStreamSelection::Selected {
-            selected_regular_index,
-            ranked_regular_indices,
-            regular_reason,
-            preferred_source,
+            selected_index,
+            ranked_indices,
+            reason,
         } => AudioStreamWireResponse {
             schema_version: SCHEMA_VERSION,
             status: WireStatus::Selected,
-            selected_regular_index,
-            ranked_regular_indices,
-            regular_reason: regular_reason.map(|reason| match reason {
+            selected_index: Some(selected_index),
+            ranked_indices,
+            reason: Some(match reason {
                 AudioRegularReason::HiresEnabled => WireRegularReason::HiresEnabled,
                 AudioRegularReason::StandardOnly => WireRegularReason::StandardOnly,
                 AudioRegularReason::HiresOnlyFallback => WireRegularReason::HiresOnlyFallback,
-            }),
-            preferred_source: Some(match preferred_source {
-                PreferredAudioSource::Regular => WirePreferredSource::Regular,
-                PreferredAudioSource::Flac => WirePreferredSource::Flac,
-                PreferredAudioSource::Dolby => WirePreferredSource::Dolby,
             }),
         },
     };
@@ -243,8 +201,6 @@ mod tests {
         AudioStreamSelectionRequest {
             audio_hires: hires,
             regular_streams: streams,
-            flac_available: false,
-            dolby_available: false,
         }
     }
 
@@ -257,10 +213,9 @@ mod tests {
         assert_eq!(
             select_audio_stream(&request(vec![stream(4, 30280, 1)], true)).unwrap(),
             AudioStreamSelection::Selected {
-                selected_regular_index: Some(4),
-                ranked_regular_indices: vec![4],
-                regular_reason: Some(AudioRegularReason::HiresEnabled),
-                preferred_source: PreferredAudioSource::Regular,
+                selected_index: 4,
+                ranked_indices: vec![4],
+                reason: AudioRegularReason::HiresEnabled,
             }
         );
     }
@@ -280,10 +235,9 @@ mod tests {
         assert_eq!(
             result,
             AudioStreamSelection::Selected {
-                selected_regular_index: Some(2),
-                ranked_regular_indices: vec![2, 3, 1, 0],
-                regular_reason: Some(AudioRegularReason::HiresEnabled),
-                preferred_source: PreferredAudioSource::Regular,
+                selected_index: 2,
+                ranked_indices: vec![2, 3, 1, 0],
+                reason: AudioRegularReason::HiresEnabled,
             }
         );
     }
@@ -298,10 +252,9 @@ mod tests {
         assert_eq!(
             result,
             AudioStreamSelection::Selected {
-                selected_regular_index: Some(8),
-                ranked_regular_indices: vec![8, 3],
-                regular_reason: Some(AudioRegularReason::HiresEnabled),
-                preferred_source: PreferredAudioSource::Regular,
+                selected_index: 8,
+                ranked_indices: vec![8, 3],
+                reason: AudioRegularReason::HiresEnabled,
             }
         );
     }
@@ -320,10 +273,9 @@ mod tests {
         assert_eq!(
             result,
             AudioStreamSelection::Selected {
-                selected_regular_index: Some(2),
-                ranked_regular_indices: vec![2],
-                regular_reason: Some(AudioRegularReason::StandardOnly),
-                preferred_source: PreferredAudioSource::Regular,
+                selected_index: 2,
+                ranked_indices: vec![2],
+                reason: AudioRegularReason::StandardOnly,
             }
         );
     }
@@ -338,54 +290,10 @@ mod tests {
         assert_eq!(
             result,
             AudioStreamSelection::Selected {
-                selected_regular_index: Some(1),
-                ranked_regular_indices: vec![1, 0],
-                regular_reason: Some(AudioRegularReason::HiresOnlyFallback),
-                preferred_source: PreferredAudioSource::Regular,
+                selected_index: 1,
+                ranked_indices: vec![1, 0],
+                reason: AudioRegularReason::HiresOnlyFallback,
             }
-        );
-    }
-
-    #[test]
-    fn preferred_source_is_dolby_then_flac_then_regular() {
-        let mut req = request(vec![stream(0, 30280, 1)], true);
-        req.flac_available = true;
-        assert!(matches!(
-            select_audio_stream(&req).unwrap(),
-            AudioStreamSelection::Selected {
-                preferred_source: PreferredAudioSource::Flac,
-                ..
-            }
-        ));
-        req.dolby_available = true;
-        assert!(matches!(
-            select_audio_stream(&req).unwrap(),
-            AudioStreamSelection::Selected {
-                preferred_source: PreferredAudioSource::Dolby,
-                ..
-            }
-        ));
-        req.audio_hires = false;
-        assert!(matches!(
-            select_audio_stream(&req).unwrap(),
-            AudioStreamSelection::Selected {
-                preferred_source: PreferredAudioSource::Regular,
-                ..
-            }
-        ));
-    }
-
-    #[test]
-    fn separate_hires_sources_are_unavailable_when_hires_is_disabled() {
-        let req = AudioStreamSelectionRequest {
-            audio_hires: false,
-            regular_streams: vec![],
-            flac_available: true,
-            dolby_available: true,
-        };
-        assert_eq!(
-            select_audio_stream(&req).unwrap(),
-            AudioStreamSelection::NoMatch
         );
     }
 
@@ -409,7 +317,18 @@ mod tests {
     #[test]
     fn wire_rejects_invalid_schema_and_duplicate_indices() {
         assert!(select_audio_stream_json("not json").is_none());
-        assert!(select_audio_stream_json(r#"{"schema_version":2,"audio_hires":true,"regular_streams":[],"flac_available":false,"dolby_available":false}"#).is_none());
-        assert!(select_audio_stream_json(r#"{"schema_version":1,"audio_hires":true,"regular_streams":[{"original_index":0,"quality_id":30280,"bandwidth":1},{"original_index":0,"quality_id":30232,"bandwidth":1}],"flac_available":false,"dolby_available":false}"#).is_none());
+        assert!(
+            select_audio_stream_json(
+                r#"{"schema_version":2,"audio_hires":true,"regular_streams":[]}"#
+            )
+            .is_none()
+        );
+        assert!(select_audio_stream_json(r#"{"schema_version":1,"audio_hires":true,"regular_streams":[{"original_index":0,"quality_id":30280,"bandwidth":1},{"original_index":0,"quality_id":30232,"bandwidth":1}]}"#).is_none());
+        assert!(
+            select_audio_stream_json(
+                r#"{"schema_version":1,"audio_hires":true,"regular_streams":[],"extra":true}"#
+            )
+            .is_none()
+        );
     }
 }

--- a/rust/src/audio_stream_ranking.rs
+++ b/rust/src/audio_stream_ranking.rs
@@ -1,0 +1,415 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+const DOLBY_QUALITY_ID: i64 = 30250;
+const FLAC_QUALITY_ID: i64 = 30251;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AudioStreamDescriptor {
+    pub original_index: usize,
+    pub quality_id: i64,
+    pub bandwidth: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AudioStreamSelectionRequest {
+    pub audio_hires: bool,
+    pub regular_streams: Vec<AudioStreamDescriptor>,
+    pub flac_available: bool,
+    pub dolby_available: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioRegularReason {
+    HiresEnabled,
+    StandardOnly,
+    HiresOnlyFallback,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreferredAudioSource {
+    Regular,
+    Flac,
+    Dolby,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AudioStreamSelection {
+    Selected {
+        selected_regular_index: Option<usize>,
+        ranked_regular_indices: Vec<usize>,
+        regular_reason: Option<AudioRegularReason>,
+        preferred_source: PreferredAudioSource,
+    },
+    NoMatch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AudioStreamSelectionError {
+    InvalidRequest,
+}
+
+fn quality_rank(quality_id: i64) -> u8 {
+    match quality_id {
+        30250 => 0,
+        30251 => 1,
+        30280 => 2,
+        30232 => 3,
+        30216 => 4,
+        _ => 99,
+    }
+}
+
+pub fn select_audio_stream(
+    request: &AudioStreamSelectionRequest,
+) -> Result<AudioStreamSelection, AudioStreamSelectionError> {
+    let mut indices = HashSet::with_capacity(request.regular_streams.len());
+    if request
+        .regular_streams
+        .iter()
+        .any(|stream| !indices.insert(stream.original_index))
+    {
+        return Err(AudioStreamSelectionError::InvalidRequest);
+    }
+
+    let mut ranked: Vec<(usize, &AudioStreamDescriptor)> =
+        request.regular_streams.iter().enumerate().collect();
+    let regular_reason = if request.audio_hires {
+        (!ranked.is_empty()).then_some(AudioRegularReason::HiresEnabled)
+    } else {
+        let standard: Vec<_> = ranked
+            .iter()
+            .copied()
+            .filter(|(_, stream)| !matches!(stream.quality_id, DOLBY_QUALITY_ID | FLAC_QUALITY_ID))
+            .collect();
+        if standard.is_empty() {
+            (!ranked.is_empty()).then_some(AudioRegularReason::HiresOnlyFallback)
+        } else {
+            ranked = standard;
+            Some(AudioRegularReason::StandardOnly)
+        }
+    };
+    ranked.sort_by_key(|(position, stream)| (quality_rank(stream.quality_id), *position));
+    let ranked_regular_indices: Vec<usize> = ranked
+        .iter()
+        .map(|(_, stream)| stream.original_index)
+        .collect();
+    let selected_regular_index = ranked_regular_indices.first().copied();
+    let preferred_source = if request.audio_hires && request.dolby_available {
+        Some(PreferredAudioSource::Dolby)
+    } else if request.audio_hires && request.flac_available {
+        Some(PreferredAudioSource::Flac)
+    } else if selected_regular_index.is_some() {
+        Some(PreferredAudioSource::Regular)
+    } else {
+        None
+    };
+
+    Ok(match preferred_source {
+        Some(preferred_source) => AudioStreamSelection::Selected {
+            selected_regular_index,
+            ranked_regular_indices,
+            regular_reason,
+            preferred_source,
+        },
+        None => AudioStreamSelection::NoMatch,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AudioStreamWireDescriptor {
+    original_index: usize,
+    quality_id: i64,
+    bandwidth: i64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AudioStreamWireRequest {
+    schema_version: u32,
+    audio_hires: bool,
+    regular_streams: Vec<AudioStreamWireDescriptor>,
+    flac_available: bool,
+    dolby_available: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum WireStatus {
+    Selected,
+    NoMatch,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum WireRegularReason {
+    HiresEnabled,
+    StandardOnly,
+    HiresOnlyFallback,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum WirePreferredSource {
+    Regular,
+    Flac,
+    Dolby,
+}
+
+#[derive(Debug, Serialize)]
+struct AudioStreamWireResponse {
+    schema_version: u32,
+    status: WireStatus,
+    selected_regular_index: Option<usize>,
+    ranked_regular_indices: Vec<usize>,
+    regular_reason: Option<WireRegularReason>,
+    preferred_source: Option<WirePreferredSource>,
+}
+
+pub(crate) fn select_audio_stream_json(request_json: &str) -> Option<String> {
+    let wire: AudioStreamWireRequest = serde_json::from_str(request_json).ok()?;
+    if wire.schema_version != SCHEMA_VERSION
+        || wire
+            .regular_streams
+            .windows(2)
+            .any(|pair| pair[0].original_index >= pair[1].original_index)
+    {
+        return None;
+    }
+    let request = AudioStreamSelectionRequest {
+        audio_hires: wire.audio_hires,
+        regular_streams: wire
+            .regular_streams
+            .into_iter()
+            .map(|stream| AudioStreamDescriptor {
+                original_index: stream.original_index,
+                quality_id: stream.quality_id,
+                bandwidth: stream.bandwidth,
+            })
+            .collect(),
+        flac_available: wire.flac_available,
+        dolby_available: wire.dolby_available,
+    };
+    let response = match select_audio_stream(&request).ok()? {
+        AudioStreamSelection::NoMatch => AudioStreamWireResponse {
+            schema_version: SCHEMA_VERSION,
+            status: WireStatus::NoMatch,
+            selected_regular_index: None,
+            ranked_regular_indices: vec![],
+            regular_reason: None,
+            preferred_source: None,
+        },
+        AudioStreamSelection::Selected {
+            selected_regular_index,
+            ranked_regular_indices,
+            regular_reason,
+            preferred_source,
+        } => AudioStreamWireResponse {
+            schema_version: SCHEMA_VERSION,
+            status: WireStatus::Selected,
+            selected_regular_index,
+            ranked_regular_indices,
+            regular_reason: regular_reason.map(|reason| match reason {
+                AudioRegularReason::HiresEnabled => WireRegularReason::HiresEnabled,
+                AudioRegularReason::StandardOnly => WireRegularReason::StandardOnly,
+                AudioRegularReason::HiresOnlyFallback => WireRegularReason::HiresOnlyFallback,
+            }),
+            preferred_source: Some(match preferred_source {
+                PreferredAudioSource::Regular => WirePreferredSource::Regular,
+                PreferredAudioSource::Flac => WirePreferredSource::Flac,
+                PreferredAudioSource::Dolby => WirePreferredSource::Dolby,
+            }),
+        },
+    };
+    serde_json::to_string(&response).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stream(index: usize, quality: i64, bandwidth: i64) -> AudioStreamDescriptor {
+        AudioStreamDescriptor {
+            original_index: index,
+            quality_id: quality,
+            bandwidth,
+        }
+    }
+
+    fn request(streams: Vec<AudioStreamDescriptor>, hires: bool) -> AudioStreamSelectionRequest {
+        AudioStreamSelectionRequest {
+            audio_hires: hires,
+            regular_streams: streams,
+            flac_available: false,
+            dolby_available: false,
+        }
+    }
+
+    #[test]
+    fn empty_and_one_stream() {
+        assert_eq!(
+            select_audio_stream(&request(vec![], true)).unwrap(),
+            AudioStreamSelection::NoMatch
+        );
+        assert_eq!(
+            select_audio_stream(&request(vec![stream(4, 30280, 1)], true)).unwrap(),
+            AudioStreamSelection::Selected {
+                selected_regular_index: Some(4),
+                ranked_regular_indices: vec![4],
+                regular_reason: Some(AudioRegularReason::HiresEnabled),
+                preferred_source: PreferredAudioSource::Regular,
+            }
+        );
+    }
+
+    #[test]
+    fn normal_quality_order_and_unknown_values() {
+        let result = select_audio_stream(&request(
+            vec![
+                stream(0, 0, 999),
+                stream(1, 30216, 1),
+                stream(2, 30280, 1),
+                stream(3, 30232, 1),
+            ],
+            true,
+        ))
+        .unwrap();
+        assert_eq!(
+            result,
+            AudioStreamSelection::Selected {
+                selected_regular_index: Some(2),
+                ranked_regular_indices: vec![2, 3, 1, 0],
+                regular_reason: Some(AudioRegularReason::HiresEnabled),
+                preferred_source: PreferredAudioSource::Regular,
+            }
+        );
+    }
+
+    #[test]
+    fn bandwidth_is_ignored_and_original_order_breaks_ties() {
+        let result = select_audio_stream(&request(
+            vec![stream(8, 30280, 0), stream(3, 30280, 999_999)],
+            true,
+        ))
+        .unwrap();
+        assert_eq!(
+            result,
+            AudioStreamSelection::Selected {
+                selected_regular_index: Some(8),
+                ranked_regular_indices: vec![8, 3],
+                regular_reason: Some(AudioRegularReason::HiresEnabled),
+                preferred_source: PreferredAudioSource::Regular,
+            }
+        );
+    }
+
+    #[test]
+    fn hires_disabled_filters_dolby_and_flac_when_standard_exists() {
+        let result = select_audio_stream(&request(
+            vec![
+                stream(0, 30250, 1),
+                stream(1, 30251, 1),
+                stream(2, 30280, 1),
+            ],
+            false,
+        ))
+        .unwrap();
+        assert_eq!(
+            result,
+            AudioStreamSelection::Selected {
+                selected_regular_index: Some(2),
+                ranked_regular_indices: vec![2],
+                regular_reason: Some(AudioRegularReason::StandardOnly),
+                preferred_source: PreferredAudioSource::Regular,
+            }
+        );
+    }
+
+    #[test]
+    fn hires_disabled_falls_back_when_regular_list_contains_only_hires() {
+        let result = select_audio_stream(&request(
+            vec![stream(0, 30251, 1), stream(1, 30250, 1)],
+            false,
+        ))
+        .unwrap();
+        assert_eq!(
+            result,
+            AudioStreamSelection::Selected {
+                selected_regular_index: Some(1),
+                ranked_regular_indices: vec![1, 0],
+                regular_reason: Some(AudioRegularReason::HiresOnlyFallback),
+                preferred_source: PreferredAudioSource::Regular,
+            }
+        );
+    }
+
+    #[test]
+    fn preferred_source_is_dolby_then_flac_then_regular() {
+        let mut req = request(vec![stream(0, 30280, 1)], true);
+        req.flac_available = true;
+        assert!(matches!(
+            select_audio_stream(&req).unwrap(),
+            AudioStreamSelection::Selected {
+                preferred_source: PreferredAudioSource::Flac,
+                ..
+            }
+        ));
+        req.dolby_available = true;
+        assert!(matches!(
+            select_audio_stream(&req).unwrap(),
+            AudioStreamSelection::Selected {
+                preferred_source: PreferredAudioSource::Dolby,
+                ..
+            }
+        ));
+        req.audio_hires = false;
+        assert!(matches!(
+            select_audio_stream(&req).unwrap(),
+            AudioStreamSelection::Selected {
+                preferred_source: PreferredAudioSource::Regular,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn separate_hires_sources_are_unavailable_when_hires_is_disabled() {
+        let req = AudioStreamSelectionRequest {
+            audio_hires: false,
+            regular_streams: vec![],
+            flac_available: true,
+            dolby_available: true,
+        };
+        assert_eq!(
+            select_audio_stream(&req).unwrap(),
+            AudioStreamSelection::NoMatch
+        );
+    }
+
+    #[test]
+    fn duplicate_indices_invalid_non_monotonic_unique_indices_valid() {
+        let duplicate = request(vec![stream(1, 30280, 1), stream(1, 30232, 1)], true);
+        assert_eq!(
+            select_audio_stream(&duplicate),
+            Err(AudioStreamSelectionError::InvalidRequest)
+        );
+        let non_monotonic = request(vec![stream(8, 30280, 1), stream(2, 30232, 1)], true);
+        assert!(select_audio_stream(&non_monotonic).is_ok());
+    }
+
+    #[test]
+    fn repeated_execution_is_deterministic() {
+        let req = request(vec![stream(0, 30280, 1), stream(1, 30280, 2)], true);
+        assert_eq!(select_audio_stream(&req), select_audio_stream(&req));
+    }
+
+    #[test]
+    fn wire_rejects_invalid_schema_and_duplicate_indices() {
+        assert!(select_audio_stream_json("not json").is_none());
+        assert!(select_audio_stream_json(r#"{"schema_version":2,"audio_hires":true,"regular_streams":[],"flac_available":false,"dolby_available":false}"#).is_none());
+        assert!(select_audio_stream_json(r#"{"schema_version":1,"audio_hires":true,"regular_streams":[{"original_index":0,"quality_id":30280,"bandwidth":1},{"original_index":0,"quality_id":30232,"bandwidth":1}],"flac_available":false,"dolby_available":false}"#).is_none());
+    }
+}

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -375,6 +375,59 @@ pub unsafe extern "C" fn rust_plan_tool_download_candidates(
     })
 }
 
+/// Decides normalized quality, DASH, BBDown, and yt-dlp policy from schema-v1 JSON.
+///
+/// The returned owned JSON string must be freed with [`rust_free_string`].
+/// Invalid pointers, UTF-8, JSON, or schemas return null.
+///
+/// # Safety
+///
+/// `request_json` must point to a valid null-terminated UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_decide_quality_policy(request_json: *const c_char) -> *mut c_char {
+    ffi_string_result(|| {
+        // SAFETY: Required by this export's C ABI contract.
+        let request_json = unsafe { input(request_json)? };
+        crate::quality_policy::decide_quality_policy_json(request_json)
+    })
+}
+
+/// Selects and ranks a DASH video stream from schema-v1 JSON.
+///
+/// A valid empty stream list returns `no_match`; invalid pointers, UTF-8, JSON,
+/// schemas, or indices return null. The owned result must be freed with
+/// [`rust_free_string`].
+///
+/// # Safety
+///
+/// `request_json` must point to a valid null-terminated UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_select_video_stream(request_json: *const c_char) -> *mut c_char {
+    ffi_string_result(|| {
+        // SAFETY: Required by this export's C ABI contract.
+        let request_json = unsafe { input(request_json)? };
+        crate::video_stream_ranking::select_video_stream_json(request_json)
+    })
+}
+
+/// Selects and ranks DASH regular audio and its preferred source from schema-v1 JSON.
+///
+/// A valid request without an eligible source returns `no_match`; invalid
+/// pointers, UTF-8, JSON, schemas, or indices return null. The owned result must
+/// be freed with [`rust_free_string`].
+///
+/// # Safety
+///
+/// `request_json` must point to a valid null-terminated UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_select_audio_stream(request_json: *const c_char) -> *mut c_char {
+    ffi_string_result(|| {
+        // SAFETY: Required by this export's C ABI contract.
+        let request_json = unsafe { input(request_json)? };
+        crate::audio_stream_ranking::select_audio_stream_json(request_json)
+    })
+}
+
 /// # Safety
 ///
 /// This function is unsafe because it dereferences a raw pointer. The caller must ensure
@@ -766,6 +819,119 @@ mod tests {
     fn new_download_planners_use_shared_panic_containment() {
         let result = ffi_string_result(|| -> Option<String> {
             panic!("simulated candidate planning panic");
+        });
+        assert!(result.is_null());
+    }
+
+    #[test]
+    fn quality_policy_export_rejects_invalid_inputs_and_repeatedly_frees_owned_json() {
+        let invalid_utf8 = [0xff_u8 as c_char, 0];
+        let malformed = CString::new("not json").unwrap();
+        let unsupported = CString::new(
+            r#"{"schema_version":2,"raw_quality":"","raw_cap":"","choice_index":null}"#,
+        )
+        .unwrap();
+        let valid = CString::new(
+            r#"{"schema_version":1,"raw_quality":"720P 高清","raw_cap":"","choice_index":2}"#,
+        )
+        .unwrap();
+        unsafe {
+            assert!(rust_decide_quality_policy(std::ptr::null()).is_null());
+            assert!(rust_decide_quality_policy(invalid_utf8.as_ptr()).is_null());
+            assert!(rust_decide_quality_policy(malformed.as_ptr()).is_null());
+            assert!(rust_decide_quality_policy(unsupported.as_ptr()).is_null());
+            for _ in 0..20 {
+                let result = rust_decide_quality_policy(valid.as_ptr());
+                assert!(!result.is_null());
+                let response = CStr::from_ptr(result).to_str().unwrap();
+                assert!(response.contains(r#""status":"decided""#));
+                assert!(response.contains(r#""effective_max_height":720"#));
+                rust_free_string(result);
+            }
+        }
+    }
+
+    #[test]
+    fn video_stream_export_distinguishes_no_match_and_rejects_invalid_indices() {
+        let invalid_utf8 = [0xff_u8 as c_char, 0];
+        let empty = CString::new(
+            r#"{"schema_version":1,"max_quality_id":80,"codec_filter":null,"max_avc_quality_id":null,"streams":[]}"#,
+        )
+        .unwrap();
+        let duplicate = CString::new(
+            r#"{"schema_version":1,"max_quality_id":80,"codec_filter":null,"max_avc_quality_id":null,"streams":[{"original_index":0,"quality_id":80,"bandwidth":1,"codec":"avc"},{"original_index":0,"quality_id":64,"bandwidth":1,"codec":"hevc"}]}"#,
+        )
+        .unwrap();
+        let unknown_codec = CString::new(
+            r#"{"schema_version":1,"max_quality_id":80,"codec_filter":"codec_99","max_avc_quality_id":null,"streams":[{"original_index":0,"quality_id":80,"bandwidth":1,"codec":"codec_99"}]}"#,
+        )
+        .unwrap();
+        unsafe {
+            assert!(rust_select_video_stream(std::ptr::null()).is_null());
+            assert!(rust_select_video_stream(invalid_utf8.as_ptr()).is_null());
+            assert!(rust_select_video_stream(duplicate.as_ptr()).is_null());
+            let result = rust_select_video_stream(empty.as_ptr());
+            assert!(!result.is_null());
+            assert!(
+                CStr::from_ptr(result)
+                    .to_str()
+                    .unwrap()
+                    .contains(r#""status":"no_match""#)
+            );
+            rust_free_string(result);
+            let result = rust_select_video_stream(unknown_codec.as_ptr());
+            assert!(!result.is_null());
+            assert!(
+                CStr::from_ptr(result)
+                    .to_str()
+                    .unwrap()
+                    .contains(r#""selected_index":0"#)
+            );
+            rust_free_string(result);
+        }
+    }
+
+    #[test]
+    fn audio_stream_export_distinguishes_no_match_and_repeats_allocation_free() {
+        let invalid_utf8 = [0xff_u8 as c_char, 0];
+        let empty = CString::new(
+            r#"{"schema_version":1,"audio_hires":true,"regular_streams":[],"flac_available":false,"dolby_available":false}"#,
+        )
+        .unwrap();
+        let selected = CString::new(
+            r#"{"schema_version":1,"audio_hires":true,"regular_streams":[{"original_index":0,"quality_id":30280,"bandwidth":0}],"flac_available":true,"dolby_available":true}"#,
+        )
+        .unwrap();
+        unsafe {
+            assert!(rust_select_audio_stream(std::ptr::null()).is_null());
+            assert!(rust_select_audio_stream(invalid_utf8.as_ptr()).is_null());
+            let result = rust_select_audio_stream(empty.as_ptr());
+            assert!(!result.is_null());
+            assert!(
+                CStr::from_ptr(result)
+                    .to_str()
+                    .unwrap()
+                    .contains(r#""status":"no_match""#)
+            );
+            rust_free_string(result);
+            for _ in 0..20 {
+                let result = rust_select_audio_stream(selected.as_ptr());
+                assert!(!result.is_null());
+                assert!(
+                    CStr::from_ptr(result)
+                        .to_str()
+                        .unwrap()
+                        .contains(r#""preferred_source":"dolby""#)
+                );
+                rust_free_string(result);
+            }
+        }
+    }
+
+    #[test]
+    fn quality_and_stream_exports_use_shared_panic_containment() {
+        let result = ffi_string_result(|| -> Option<String> {
+            panic!("simulated quality and stream ranking panic");
         });
         assert!(result.is_null());
     }

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -410,7 +410,7 @@ pub unsafe extern "C" fn rust_select_video_stream(request_json: *const c_char) -
     })
 }
 
-/// Selects and ranks DASH regular audio and its preferred source from schema-v1 JSON.
+/// Selects and ranks regular DASH audio from schema-v1 JSON.
 ///
 /// A valid request without an eligible source returns `no_match`; invalid
 /// pointers, UTF-8, JSON, schemas, or indices return null. The owned result must
@@ -425,6 +425,26 @@ pub unsafe extern "C" fn rust_select_audio_stream(request_json: *const c_char) -
         // SAFETY: Required by this export's C ABI contract.
         let request_json = unsafe { input(request_json)? };
         crate::audio_stream_ranking::select_audio_stream_json(request_json)
+    })
+}
+
+/// Binds a preferred audio source without ranking regular audio candidates.
+///
+/// A valid request without an eligible source returns `no_match`; invalid
+/// pointers, UTF-8, JSON, schemas, or indices return null. The owned result must
+/// be freed with [`rust_free_string`].
+///
+/// # Safety
+///
+/// `request_json` must point to a valid null-terminated UTF-8 C string.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn rust_select_preferred_audio_source(
+    request_json: *const c_char,
+) -> *mut c_char {
+    ffi_string_result(|| {
+        // SAFETY: Required by this export's C ABI contract.
+        let request_json = unsafe { input(request_json)? };
+        crate::preferred_audio_source_binding::select_preferred_audio_source_json(request_json)
     })
 }
 
@@ -894,12 +914,10 @@ mod tests {
     #[test]
     fn audio_stream_export_distinguishes_no_match_and_repeats_allocation_free() {
         let invalid_utf8 = [0xff_u8 as c_char, 0];
-        let empty = CString::new(
-            r#"{"schema_version":1,"audio_hires":true,"regular_streams":[],"flac_available":false,"dolby_available":false}"#,
-        )
-        .unwrap();
+        let empty = CString::new(r#"{"schema_version":1,"audio_hires":true,"regular_streams":[]}"#)
+            .unwrap();
         let selected = CString::new(
-            r#"{"schema_version":1,"audio_hires":true,"regular_streams":[{"original_index":0,"quality_id":30280,"bandwidth":0}],"flac_available":true,"dolby_available":true}"#,
+            r#"{"schema_version":1,"audio_hires":true,"regular_streams":[{"original_index":0,"quality_id":30280,"bandwidth":0}]}"#,
         )
         .unwrap();
         unsafe {
@@ -921,8 +939,54 @@ mod tests {
                     CStr::from_ptr(result)
                         .to_str()
                         .unwrap()
-                        .contains(r#""preferred_source":"dolby""#)
+                        .contains(r#""selected_index":0"#)
                 );
+                rust_free_string(result);
+            }
+        }
+    }
+
+    #[test]
+    fn preferred_audio_source_export_validates_input_and_repeats_allocation_free() {
+        let invalid_utf8 = [0xff_u8 as c_char, 0];
+        let malformed = CString::new("not json").unwrap();
+        let unsupported = CString::new(
+            r#"{"schema_version":2,"audio_hires":true,"regular_candidates":[],"flac_available":false,"dolby_available":false}"#,
+        )
+        .unwrap();
+        let duplicate = CString::new(
+            r#"{"schema_version":1,"audio_hires":true,"regular_candidates":[{"original_index":0},{"original_index":0}],"flac_available":false,"dolby_available":false}"#,
+        )
+        .unwrap();
+        let empty = CString::new(
+            r#"{"schema_version":1,"audio_hires":false,"regular_candidates":[],"flac_available":true,"dolby_available":true}"#,
+        )
+        .unwrap();
+        let selected = CString::new(
+            r#"{"schema_version":1,"audio_hires":true,"regular_candidates":[{"original_index":3},{"original_index":8}],"flac_available":true,"dolby_available":true}"#,
+        )
+        .unwrap();
+        unsafe {
+            assert!(rust_select_preferred_audio_source(std::ptr::null()).is_null());
+            assert!(rust_select_preferred_audio_source(invalid_utf8.as_ptr()).is_null());
+            assert!(rust_select_preferred_audio_source(malformed.as_ptr()).is_null());
+            assert!(rust_select_preferred_audio_source(unsupported.as_ptr()).is_null());
+            assert!(rust_select_preferred_audio_source(duplicate.as_ptr()).is_null());
+            let result = rust_select_preferred_audio_source(empty.as_ptr());
+            assert!(!result.is_null());
+            assert!(
+                CStr::from_ptr(result)
+                    .to_str()
+                    .unwrap()
+                    .contains(r#""status":"no_match""#)
+            );
+            rust_free_string(result);
+            for _ in 0..20 {
+                let result = rust_select_preferred_audio_source(selected.as_ptr());
+                assert!(!result.is_null());
+                let response = CStr::from_ptr(result).to_str().unwrap();
+                assert!(response.contains(r#""preferred_source":"dolby""#));
+                assert!(response.contains(r#""selected_regular_index":3"#));
                 rust_free_string(result);
             }
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -2,21 +2,28 @@ mod archive;
 mod asset_selection;
 mod asset_tokens;
 mod audio_binding;
+mod audio_stream_ranking;
 mod download_candidate_planning;
 mod ffi;
 mod filename;
 mod media_download_candidate_planning;
 mod media_page_selection;
 mod platform;
+mod quality_policy;
 mod release_selection;
 mod title_cleanup;
 mod tool_download_candidate_planning;
 mod url_utils;
 mod version;
+mod video_stream_ranking;
 
 pub use audio_binding::{
     AudioBindingDecision, AudioBindingError, AudioBindingMode, AudioBindingRequest,
     AudioBindingResult, AudioPageDescriptor, decide_audio_binding,
+};
+pub use audio_stream_ranking::{
+    AudioRegularReason, AudioStreamDescriptor, AudioStreamSelection, AudioStreamSelectionError,
+    AudioStreamSelectionRequest, PreferredAudioSource, select_audio_stream,
 };
 pub use download_candidate_planning::{
     PlannedUpdateCandidate, UpdateCandidateInput, UpdateCandidateRoute, UpdateCandidateSource,
@@ -26,12 +33,13 @@ pub use download_candidate_planning::{
 pub use ffi::{
     rust_asset_has_arm64, rust_asset_has_linux, rust_asset_has_macos, rust_asset_has_universal,
     rust_asset_has_windows, rust_asset_has_x64, rust_asset_tokens, rust_backend_abi_version,
-    rust_clean_display_title, rust_decide_audio_binding, rust_format_download_proxy_url,
-    rust_free_string, rust_is_downloadable_archive, rust_normalize_machine_arch,
-    rust_normalize_version_tag, rust_plan_media_download_candidates,
+    rust_clean_display_title, rust_decide_audio_binding, rust_decide_quality_policy,
+    rust_format_download_proxy_url, rust_free_string, rust_is_downloadable_archive,
+    rust_normalize_machine_arch, rust_normalize_version_tag, rust_plan_media_download_candidates,
     rust_plan_tool_download_candidates, rust_plan_update_download_candidates,
-    rust_release_list_api_from_latest, rust_safe_filename, rust_select_media_pages,
-    rust_select_release, rust_select_update_asset, rust_version_sort_key, rust_version_tuple,
+    rust_release_list_api_from_latest, rust_safe_filename, rust_select_audio_stream,
+    rust_select_media_pages, rust_select_release, rust_select_update_asset,
+    rust_select_video_stream, rust_version_sort_key, rust_version_tuple,
 };
 pub use media_download_candidate_planning::{
     MediaCandidateSource, MediaDownloadPlan, MediaDownloadPlanError, MediaDownloadPlanMode,
@@ -42,6 +50,9 @@ pub use media_page_selection::{
     MediaPageDescriptor, MediaPageSelection, MediaPageSelectionError, MediaPageSelectionRequest,
     select_media_pages,
 };
+pub use quality_policy::{
+    QualityPolicyDecision, QualityPolicyRequest, VideoQuality, decide_quality_policy,
+};
 pub use release_selection::{
     ReleaseCandidate, ReleaseSelection, ReleaseSelectionError, ReleaseSelectionRequest,
     select_release,
@@ -50,4 +61,8 @@ pub use tool_download_candidate_planning::{
     PlannedToolCandidate, ToolAssetInput, ToolCandidateSource, ToolDownloadPlan,
     ToolDownloadPlanError, ToolDownloadPlanRequest, ToolFallbackBaseInput, ToolKind, ToolTarget,
     plan_tool_download_candidates,
+};
+pub use video_stream_ranking::{
+    VideoCodec, VideoSelectionReason, VideoStreamDescriptor, VideoStreamSelection,
+    VideoStreamSelectionError, VideoStreamSelectionRequest, select_video_stream,
 };

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -9,6 +9,7 @@ mod filename;
 mod media_download_candidate_planning;
 mod media_page_selection;
 mod platform;
+mod preferred_audio_source_binding;
 mod quality_policy;
 mod release_selection;
 mod title_cleanup;
@@ -23,7 +24,7 @@ pub use audio_binding::{
 };
 pub use audio_stream_ranking::{
     AudioRegularReason, AudioStreamDescriptor, AudioStreamSelection, AudioStreamSelectionError,
-    AudioStreamSelectionRequest, PreferredAudioSource, select_audio_stream,
+    AudioStreamSelectionRequest, select_audio_stream,
 };
 pub use download_candidate_planning::{
     PlannedUpdateCandidate, UpdateCandidateInput, UpdateCandidateRoute, UpdateCandidateSource,
@@ -38,8 +39,8 @@ pub use ffi::{
     rust_normalize_machine_arch, rust_normalize_version_tag, rust_plan_media_download_candidates,
     rust_plan_tool_download_candidates, rust_plan_update_download_candidates,
     rust_release_list_api_from_latest, rust_safe_filename, rust_select_audio_stream,
-    rust_select_media_pages, rust_select_release, rust_select_update_asset,
-    rust_select_video_stream, rust_version_sort_key, rust_version_tuple,
+    rust_select_media_pages, rust_select_preferred_audio_source, rust_select_release,
+    rust_select_update_asset, rust_select_video_stream, rust_version_sort_key, rust_version_tuple,
 };
 pub use media_download_candidate_planning::{
     MediaCandidateSource, MediaDownloadPlan, MediaDownloadPlanError, MediaDownloadPlanMode,
@@ -49,6 +50,10 @@ pub use media_download_candidate_planning::{
 pub use media_page_selection::{
     MediaPageDescriptor, MediaPageSelection, MediaPageSelectionError, MediaPageSelectionRequest,
     select_media_pages,
+};
+pub use preferred_audio_source_binding::{
+    PreferredAudioSource, PreferredAudioSourceError, PreferredAudioSourceRequest,
+    PreferredAudioSourceSelection, PreferredRegularAudioCandidate, select_preferred_audio_source,
 };
 pub use quality_policy::{
     QualityPolicyDecision, QualityPolicyRequest, VideoQuality, decide_quality_policy,

--- a/rust/src/preferred_audio_source_binding.rs
+++ b/rust/src/preferred_audio_source_binding.rs
@@ -1,0 +1,278 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PreferredRegularAudioCandidate {
+    pub original_index: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreferredAudioSourceRequest {
+    pub audio_hires: bool,
+    pub regular_candidates: Vec<PreferredRegularAudioCandidate>,
+    pub flac_available: bool,
+    pub dolby_available: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreferredAudioSource {
+    Regular,
+    Flac,
+    Dolby,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PreferredAudioSourceSelection {
+    Selected {
+        preferred_source: PreferredAudioSource,
+        selected_regular_index: Option<usize>,
+    },
+    NoMatch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreferredAudioSourceError {
+    InvalidRequest,
+}
+
+pub fn select_preferred_audio_source(
+    request: &PreferredAudioSourceRequest,
+) -> Result<PreferredAudioSourceSelection, PreferredAudioSourceError> {
+    let mut indices = HashSet::with_capacity(request.regular_candidates.len());
+    if request
+        .regular_candidates
+        .iter()
+        .any(|candidate| !indices.insert(candidate.original_index))
+    {
+        return Err(PreferredAudioSourceError::InvalidRequest);
+    }
+
+    let selected_regular_index = request
+        .regular_candidates
+        .first()
+        .map(|candidate| candidate.original_index);
+    let preferred_source = if request.audio_hires && request.dolby_available {
+        Some(PreferredAudioSource::Dolby)
+    } else if request.audio_hires && request.flac_available {
+        Some(PreferredAudioSource::Flac)
+    } else if selected_regular_index.is_some() {
+        Some(PreferredAudioSource::Regular)
+    } else {
+        None
+    };
+
+    Ok(match preferred_source {
+        Some(preferred_source) => PreferredAudioSourceSelection::Selected {
+            preferred_source,
+            selected_regular_index,
+        },
+        None => PreferredAudioSourceSelection::NoMatch,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PreferredRegularAudioWireCandidate {
+    original_index: usize,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PreferredAudioSourceWireRequest {
+    schema_version: u32,
+    audio_hires: bool,
+    regular_candidates: Vec<PreferredRegularAudioWireCandidate>,
+    flac_available: bool,
+    dolby_available: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum WireStatus {
+    Selected,
+    NoMatch,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum WirePreferredSource {
+    Regular,
+    Flac,
+    Dolby,
+}
+
+#[derive(Debug, Serialize)]
+struct PreferredAudioSourceWireResponse {
+    schema_version: u32,
+    status: WireStatus,
+    preferred_source: Option<WirePreferredSource>,
+    selected_regular_index: Option<usize>,
+}
+
+pub(crate) fn select_preferred_audio_source_json(request_json: &str) -> Option<String> {
+    let wire: PreferredAudioSourceWireRequest = serde_json::from_str(request_json).ok()?;
+    if wire.schema_version != SCHEMA_VERSION
+        || wire
+            .regular_candidates
+            .windows(2)
+            .any(|pair| pair[0].original_index >= pair[1].original_index)
+    {
+        return None;
+    }
+    let request = PreferredAudioSourceRequest {
+        audio_hires: wire.audio_hires,
+        regular_candidates: wire
+            .regular_candidates
+            .into_iter()
+            .map(|candidate| PreferredRegularAudioCandidate {
+                original_index: candidate.original_index,
+            })
+            .collect(),
+        flac_available: wire.flac_available,
+        dolby_available: wire.dolby_available,
+    };
+    let response = match select_preferred_audio_source(&request).ok()? {
+        PreferredAudioSourceSelection::NoMatch => PreferredAudioSourceWireResponse {
+            schema_version: SCHEMA_VERSION,
+            status: WireStatus::NoMatch,
+            preferred_source: None,
+            selected_regular_index: None,
+        },
+        PreferredAudioSourceSelection::Selected {
+            preferred_source,
+            selected_regular_index,
+        } => PreferredAudioSourceWireResponse {
+            schema_version: SCHEMA_VERSION,
+            status: WireStatus::Selected,
+            preferred_source: Some(match preferred_source {
+                PreferredAudioSource::Regular => WirePreferredSource::Regular,
+                PreferredAudioSource::Flac => WirePreferredSource::Flac,
+                PreferredAudioSource::Dolby => WirePreferredSource::Dolby,
+            }),
+            selected_regular_index,
+        },
+    };
+    serde_json::to_string(&response).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(index: usize) -> PreferredRegularAudioCandidate {
+        PreferredRegularAudioCandidate {
+            original_index: index,
+        }
+    }
+
+    fn request(
+        indices: &[usize],
+        audio_hires: bool,
+        flac_available: bool,
+        dolby_available: bool,
+    ) -> PreferredAudioSourceRequest {
+        PreferredAudioSourceRequest {
+            audio_hires,
+            regular_candidates: indices.iter().copied().map(candidate).collect(),
+            flac_available,
+            dolby_available,
+        }
+    }
+
+    #[test]
+    fn regular_first_nonzero_index_is_preserved_without_ranking() {
+        let selection =
+            select_preferred_audio_source(&request(&[7, 2], false, false, false)).unwrap();
+        assert_eq!(
+            selection,
+            PreferredAudioSourceSelection::Selected {
+                preferred_source: PreferredAudioSource::Regular,
+                selected_regular_index: Some(7),
+            }
+        );
+    }
+
+    #[test]
+    fn dolby_overrides_flac_and_regular_when_hires_is_enabled() {
+        assert_eq!(
+            select_preferred_audio_source(&request(&[4], true, true, true)).unwrap(),
+            PreferredAudioSourceSelection::Selected {
+                preferred_source: PreferredAudioSource::Dolby,
+                selected_regular_index: Some(4),
+            }
+        );
+        assert_eq!(
+            select_preferred_audio_source(&request(&[4], true, true, false)).unwrap(),
+            PreferredAudioSourceSelection::Selected {
+                preferred_source: PreferredAudioSource::Flac,
+                selected_regular_index: Some(4),
+            }
+        );
+    }
+
+    #[test]
+    fn hires_disabled_ignores_separate_sources() {
+        assert_eq!(
+            select_preferred_audio_source(&request(&[3, 1], false, true, true)).unwrap(),
+            PreferredAudioSourceSelection::Selected {
+                preferred_source: PreferredAudioSource::Regular,
+                selected_regular_index: Some(3),
+            }
+        );
+        assert_eq!(
+            select_preferred_audio_source(&request(&[], false, true, true)).unwrap(),
+            PreferredAudioSourceSelection::NoMatch
+        );
+    }
+
+    #[test]
+    fn hires_sources_work_without_regular_and_empty_input_is_no_match() {
+        assert_eq!(
+            select_preferred_audio_source(&request(&[], true, true, false)).unwrap(),
+            PreferredAudioSourceSelection::Selected {
+                preferred_source: PreferredAudioSource::Flac,
+                selected_regular_index: None,
+            }
+        );
+        assert_eq!(
+            select_preferred_audio_source(&request(&[], true, false, true)).unwrap(),
+            PreferredAudioSourceSelection::Selected {
+                preferred_source: PreferredAudioSource::Dolby,
+                selected_regular_index: None,
+            }
+        );
+        assert_eq!(
+            select_preferred_audio_source(&request(&[], true, false, false)).unwrap(),
+            PreferredAudioSourceSelection::NoMatch
+        );
+    }
+
+    #[test]
+    fn duplicate_indices_are_invalid_but_unique_nonmonotonic_typed_input_is_valid() {
+        assert_eq!(
+            select_preferred_audio_source(&request(&[2, 2], true, false, false)),
+            Err(PreferredAudioSourceError::InvalidRequest)
+        );
+        assert!(select_preferred_audio_source(&request(&[9, 1], true, false, false)).is_ok());
+    }
+
+    #[test]
+    fn repeated_execution_is_deterministic() {
+        let request = request(&[5, 2], true, true, true);
+        assert_eq!(
+            select_preferred_audio_source(&request),
+            select_preferred_audio_source(&request)
+        );
+    }
+
+    #[test]
+    fn wire_rejects_malformed_schema_duplicate_indices_and_unknown_fields() {
+        assert!(select_preferred_audio_source_json("not json").is_none());
+        assert!(select_preferred_audio_source_json(r#"{"schema_version":2,"audio_hires":true,"regular_candidates":[],"flac_available":false,"dolby_available":false}"#).is_none());
+        assert!(select_preferred_audio_source_json(r#"{"schema_version":1,"audio_hires":true,"regular_candidates":[{"original_index":0},{"original_index":0}],"flac_available":false,"dolby_available":false}"#).is_none());
+        assert!(select_preferred_audio_source_json(r#"{"schema_version":1,"audio_hires":true,"regular_candidates":[],"flac_available":false,"dolby_available":false,"extra":true}"#).is_none());
+    }
+}

--- a/rust/src/quality_policy.rs
+++ b/rust/src/quality_policy.rs
@@ -1,0 +1,315 @@
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VideoQuality {
+    Q360,
+    Q480,
+    Q720,
+    Q720HighFrameRate,
+    Q1080,
+    Q1080HighBitrate,
+    Q1080HighFrameRate,
+    Q4k,
+    Hdr,
+    DolbyVision,
+    Q8k,
+}
+
+impl VideoQuality {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Q360 => "360P 流畅",
+            Self::Q480 => "480P 清晰",
+            Self::Q720 => "720P 高清",
+            Self::Q720HighFrameRate => "720P 60帧",
+            Self::Q1080 => "1080P 高清",
+            Self::Q1080HighBitrate => "1080P 高码率",
+            Self::Q1080HighFrameRate => "1080P 高帧率",
+            Self::Q4k => "4K 超清",
+            Self::Hdr => "HDR 真彩",
+            Self::DolbyVision => "杜比视界",
+            Self::Q8k => "8K 超高清",
+        }
+    }
+
+    pub fn dash_quality_id(self) -> i64 {
+        match self {
+            Self::Q360 => 16,
+            Self::Q480 => 32,
+            Self::Q720 => 64,
+            Self::Q720HighFrameRate => 74,
+            Self::Q1080 => 80,
+            Self::Q1080HighBitrate => 112,
+            Self::Q1080HighFrameRate => 116,
+            Self::Q4k => 120,
+            Self::Hdr => 125,
+            Self::DolbyVision => 126,
+            Self::Q8k => 127,
+        }
+    }
+
+    fn from_exact_label(value: &str) -> Option<Self> {
+        ALL_QUALITIES
+            .iter()
+            .copied()
+            .find(|quality| quality.label() == value)
+    }
+
+    fn from_active_label(value: &str) -> Option<Self> {
+        ACTIVE_QUALITIES
+            .iter()
+            .copied()
+            .find(|quality| quality.label() == value.trim())
+    }
+
+    fn active_index(self) -> Option<usize> {
+        ACTIVE_QUALITIES.iter().position(|quality| *quality == self)
+    }
+
+    fn max_height(self) -> u32 {
+        match self {
+            Self::Q360 => 360,
+            Self::Q480 => 480,
+            Self::Q720 | Self::Q720HighFrameRate => 720,
+            Self::Q1080 | Self::Q1080HighBitrate | Self::Q1080HighFrameRate => 1080,
+            Self::Q4k => 2160,
+            Self::Q8k => 4320,
+            Self::Hdr | Self::DolbyVision => 1080,
+        }
+    }
+}
+
+const ACTIVE_QUALITIES: [VideoQuality; 5] = [
+    VideoQuality::Q1080HighFrameRate,
+    VideoQuality::Q1080,
+    VideoQuality::Q720,
+    VideoQuality::Q480,
+    VideoQuality::Q360,
+];
+
+const ALL_QUALITIES: [VideoQuality; 11] = [
+    VideoQuality::Q360,
+    VideoQuality::Q480,
+    VideoQuality::Q720,
+    VideoQuality::Q720HighFrameRate,
+    VideoQuality::Q1080,
+    VideoQuality::Q1080HighBitrate,
+    VideoQuality::Q1080HighFrameRate,
+    VideoQuality::Q4k,
+    VideoQuality::Hdr,
+    VideoQuality::DolbyVision,
+    VideoQuality::Q8k,
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QualityPolicyRequest {
+    pub raw_quality: String,
+    pub raw_cap: String,
+    pub choice_index: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QualityPolicyDecision {
+    pub normalized_quality: VideoQuality,
+    pub optional_quality: Option<VideoQuality>,
+    pub optional_cap: Option<VideoQuality>,
+    pub indexed_quality: Option<VideoQuality>,
+    pub dash_max_quality_id: i64,
+    pub effective_max_height: u32,
+    pub bbdown_quality_order: Vec<VideoQuality>,
+}
+
+pub fn decide_quality_policy(request: &QualityPolicyRequest) -> QualityPolicyDecision {
+    let optional_quality = VideoQuality::from_active_label(&request.raw_quality);
+    let normalized_quality = optional_quality.unwrap_or(VideoQuality::Q1080HighFrameRate);
+    let optional_cap = VideoQuality::from_active_label(&request.raw_cap);
+    let indexed_quality = request
+        .choice_index
+        .and_then(|index| usize::try_from(index).ok())
+        .and_then(|index| ACTIVE_QUALITIES.get(index).copied());
+    let dash_max_quality_id = VideoQuality::from_exact_label(&request.raw_quality)
+        .map(VideoQuality::dash_quality_id)
+        .unwrap_or(80);
+    let effective_quality = optional_cap.unwrap_or(normalized_quality);
+    let start_index = normalized_quality
+        .active_index()
+        .expect("normalized quality is active")
+        .max(
+            optional_cap
+                .and_then(VideoQuality::active_index)
+                .unwrap_or(0),
+        );
+
+    QualityPolicyDecision {
+        normalized_quality,
+        optional_quality,
+        optional_cap,
+        indexed_quality,
+        dash_max_quality_id,
+        effective_max_height: effective_quality.max_height(),
+        bbdown_quality_order: ACTIVE_QUALITIES[start_index..].to_vec(),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct QualityPolicyWireRequest {
+    schema_version: u32,
+    raw_quality: String,
+    raw_cap: String,
+    choice_index: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct QualityPolicyWireResponse {
+    schema_version: u32,
+    status: &'static str,
+    normalized_quality: &'static str,
+    optional_quality: Option<&'static str>,
+    optional_cap: Option<&'static str>,
+    indexed_quality: Option<&'static str>,
+    dash_max_quality_id: i64,
+    effective_max_height: u32,
+    bbdown_quality_order: Vec<&'static str>,
+}
+
+pub(crate) fn decide_quality_policy_json(request_json: &str) -> Option<String> {
+    let wire: QualityPolicyWireRequest = serde_json::from_str(request_json).ok()?;
+    if wire.schema_version != SCHEMA_VERSION {
+        return None;
+    }
+    let decision = decide_quality_policy(&QualityPolicyRequest {
+        raw_quality: wire.raw_quality,
+        raw_cap: wire.raw_cap,
+        choice_index: wire.choice_index,
+    });
+    serde_json::to_string(&QualityPolicyWireResponse {
+        schema_version: SCHEMA_VERSION,
+        status: "decided",
+        normalized_quality: decision.normalized_quality.label(),
+        optional_quality: decision.optional_quality.map(VideoQuality::label),
+        optional_cap: decision.optional_cap.map(VideoQuality::label),
+        indexed_quality: decision.indexed_quality.map(VideoQuality::label),
+        dash_max_quality_id: decision.dash_max_quality_id,
+        effective_max_height: decision.effective_max_height,
+        bbdown_quality_order: decision
+            .bbdown_quality_order
+            .into_iter()
+            .map(VideoQuality::label)
+            .collect(),
+    })
+    .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn decide(raw: &str, cap: &str, index: Option<i64>) -> QualityPolicyDecision {
+        decide_quality_policy(&QualityPolicyRequest {
+            raw_quality: raw.to_string(),
+            raw_cap: cap.to_string(),
+            choice_index: index,
+        })
+    }
+
+    #[test]
+    fn normalizes_every_active_quality_and_defaults_invalid_labels() {
+        for quality in ACTIVE_QUALITIES {
+            let result = decide(&format!("  {}  ", quality.label()), "", None);
+            assert_eq!(result.normalized_quality, quality);
+            assert_eq!(result.optional_quality, Some(quality));
+        }
+        let result = decide("unknown", "", None);
+        assert_eq!(result.normalized_quality, VideoQuality::Q1080HighFrameRate);
+        assert_eq!(result.optional_quality, None);
+    }
+
+    #[test]
+    fn maps_every_dash_quality_id_without_trimming() {
+        for quality in ALL_QUALITIES {
+            assert_eq!(
+                decide(quality.label(), "", None).dash_max_quality_id,
+                quality.dash_quality_id()
+            );
+        }
+        assert_eq!(decide(" 4K 超清 ", "", None).dash_max_quality_id, 80);
+        assert_eq!(decide("", "", None).dash_max_quality_id, 80);
+    }
+
+    #[test]
+    fn choice_indices_and_boundaries_match_active_choices() {
+        for (index, quality) in ACTIVE_QUALITIES.iter().enumerate() {
+            assert_eq!(
+                decide("", "", Some(index as i64)).indexed_quality,
+                Some(*quality)
+            );
+        }
+        assert_eq!(decide("", "", Some(-1)).indexed_quality, None);
+        assert_eq!(decide("", "", Some(5)).indexed_quality, None);
+        assert_eq!(decide("", "", None).indexed_quality, None);
+    }
+
+    #[test]
+    fn cap_controls_height_and_never_raises_bbdown_manual_quality() {
+        let capped = decide("1080P 高帧率", "720P 高清", None);
+        assert_eq!(capped.effective_max_height, 720);
+        assert_eq!(
+            capped.bbdown_quality_order,
+            vec![VideoQuality::Q720, VideoQuality::Q480, VideoQuality::Q360]
+        );
+
+        let lower_manual = decide("480P 清晰", "720P 高清", None);
+        assert_eq!(lower_manual.effective_max_height, 720);
+        assert_eq!(
+            lower_manual.bbdown_quality_order,
+            vec![VideoQuality::Q480, VideoQuality::Q360]
+        );
+    }
+
+    #[test]
+    fn height_mapping_covers_active_boundaries() {
+        let cases = [
+            ("360P 流畅", 360),
+            ("480P 清晰", 480),
+            ("720P 高清", 720),
+            ("1080P 高清", 1080),
+            ("invalid", 1080),
+        ];
+        for (label, expected) in cases {
+            assert_eq!(decide(label, "", None).effective_max_height, expected);
+        }
+    }
+
+    #[test]
+    fn repeated_execution_is_deterministic() {
+        let request = QualityPolicyRequest {
+            raw_quality: "歌曲 1080P".to_string(),
+            raw_cap: "720P 高清".to_string(),
+            choice_index: Some(2),
+        };
+        assert_eq!(
+            decide_quality_policy(&request),
+            decide_quality_policy(&request)
+        );
+    }
+
+    #[test]
+    fn wire_rejects_malformed_schema_and_unknown_fields() {
+        assert!(decide_quality_policy_json("not json").is_none());
+        assert!(
+            decide_quality_policy_json(
+                r#"{"schema_version":2,"raw_quality":"","raw_cap":"","choice_index":null}"#
+            )
+            .is_none()
+        );
+        assert!(
+            decide_quality_policy_json(
+                r#"{"schema_version":1,"raw_quality":"","raw_cap":"","choice_index":null,"extra":true}"#
+            )
+            .is_none()
+        );
+    }
+}

--- a/rust/src/video_stream_ranking.rs
+++ b/rust/src/video_stream_ranking.rs
@@ -1,0 +1,416 @@
+use std::collections::HashSet;
+
+use serde::{Deserialize, Serialize};
+
+const SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VideoCodec {
+    Avc,
+    Hevc,
+    Av1,
+    Other(String),
+}
+
+impl VideoCodec {
+    pub fn from_name(value: &str) -> Self {
+        match value {
+            "avc" => Self::Avc,
+            "hevc" => Self::Hevc,
+            "av1" => Self::Av1,
+            _ => Self::Other(value.to_string()),
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Avc => "avc",
+            Self::Hevc => "hevc",
+            Self::Av1 => "av1",
+            Self::Other(value) => value,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VideoStreamDescriptor {
+    pub original_index: usize,
+    pub quality_id: i64,
+    pub bandwidth: i64,
+    pub codec: VideoCodec,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VideoStreamSelectionRequest {
+    pub max_quality_id: i64,
+    pub codec_filter: Option<VideoCodec>,
+    pub max_avc_quality_id: Option<i64>,
+    pub streams: Vec<VideoStreamDescriptor>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VideoSelectionReason {
+    Preferred,
+    QualityFallback,
+    UncappedFallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VideoStreamSelection {
+    Selected {
+        selected_index: usize,
+        ranked_indices: Vec<usize>,
+        reason: VideoSelectionReason,
+    },
+    NoMatch,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VideoStreamSelectionError {
+    InvalidRequest,
+}
+
+pub fn select_video_stream(
+    request: &VideoStreamSelectionRequest,
+) -> Result<VideoStreamSelection, VideoStreamSelectionError> {
+    let mut indices = HashSet::with_capacity(request.streams.len());
+    if request
+        .streams
+        .iter()
+        .any(|stream| !indices.insert(stream.original_index))
+    {
+        return Err(VideoStreamSelectionError::InvalidRequest);
+    }
+    if request.streams.is_empty() {
+        return Ok(VideoStreamSelection::NoMatch);
+    }
+
+    let codec_filter = request
+        .codec_filter
+        .as_ref()
+        .filter(|codec| !codec.name().is_empty());
+
+    let mut ranked: Vec<(usize, &VideoStreamDescriptor)> = request
+        .streams
+        .iter()
+        .enumerate()
+        .filter(|(_, stream)| {
+            stream.quality_id <= request.max_quality_id
+                && codec_filter.is_none_or(|codec| stream.codec == *codec)
+                && !(codec_filter == Some(&VideoCodec::Avc)
+                    && request
+                        .max_avc_quality_id
+                        .is_some_and(|cap| cap != 0 && stream.quality_id > cap))
+        })
+        .collect();
+    let reason = if ranked.is_empty() {
+        ranked = request
+            .streams
+            .iter()
+            .enumerate()
+            .filter(|(_, stream)| stream.quality_id <= request.max_quality_id)
+            .collect();
+        if ranked.is_empty() {
+            ranked = request.streams.iter().enumerate().collect();
+            VideoSelectionReason::UncappedFallback
+        } else {
+            VideoSelectionReason::QualityFallback
+        }
+    } else {
+        VideoSelectionReason::Preferred
+    };
+
+    ranked.sort_by_key(|(position, stream)| {
+        (
+            std::cmp::Reverse(stream.quality_id),
+            std::cmp::Reverse(stream.bandwidth),
+            *position,
+        )
+    });
+    let ranked_indices: Vec<usize> = ranked
+        .iter()
+        .map(|(_, stream)| stream.original_index)
+        .collect();
+    Ok(VideoStreamSelection::Selected {
+        selected_index: ranked_indices[0],
+        ranked_indices,
+        reason,
+    })
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VideoStreamWireDescriptor {
+    original_index: usize,
+    quality_id: i64,
+    bandwidth: i64,
+    codec: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct VideoStreamWireRequest {
+    schema_version: u32,
+    max_quality_id: i64,
+    codec_filter: Option<String>,
+    max_avc_quality_id: Option<i64>,
+    streams: Vec<VideoStreamWireDescriptor>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum WireStatus {
+    Selected,
+    NoMatch,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum WireReason {
+    Preferred,
+    QualityFallback,
+    UncappedFallback,
+}
+
+#[derive(Debug, Serialize)]
+struct VideoStreamWireResponse {
+    schema_version: u32,
+    status: WireStatus,
+    selected_index: Option<usize>,
+    ranked_indices: Vec<usize>,
+    reason: Option<WireReason>,
+}
+
+pub(crate) fn select_video_stream_json(request_json: &str) -> Option<String> {
+    let wire: VideoStreamWireRequest = serde_json::from_str(request_json).ok()?;
+    if wire.schema_version != SCHEMA_VERSION
+        || wire
+            .streams
+            .windows(2)
+            .any(|pair| pair[0].original_index >= pair[1].original_index)
+    {
+        return None;
+    }
+    let request = VideoStreamSelectionRequest {
+        max_quality_id: wire.max_quality_id,
+        codec_filter: wire.codec_filter.as_deref().map(VideoCodec::from_name),
+        max_avc_quality_id: wire.max_avc_quality_id,
+        streams: wire
+            .streams
+            .into_iter()
+            .map(|stream| VideoStreamDescriptor {
+                original_index: stream.original_index,
+                quality_id: stream.quality_id,
+                bandwidth: stream.bandwidth,
+                codec: VideoCodec::from_name(&stream.codec),
+            })
+            .collect(),
+    };
+    let response = match select_video_stream(&request).ok()? {
+        VideoStreamSelection::NoMatch => VideoStreamWireResponse {
+            schema_version: SCHEMA_VERSION,
+            status: WireStatus::NoMatch,
+            selected_index: None,
+            ranked_indices: vec![],
+            reason: None,
+        },
+        VideoStreamSelection::Selected {
+            selected_index,
+            ranked_indices,
+            reason,
+        } => VideoStreamWireResponse {
+            schema_version: SCHEMA_VERSION,
+            status: WireStatus::Selected,
+            selected_index: Some(selected_index),
+            ranked_indices,
+            reason: Some(match reason {
+                VideoSelectionReason::Preferred => WireReason::Preferred,
+                VideoSelectionReason::QualityFallback => WireReason::QualityFallback,
+                VideoSelectionReason::UncappedFallback => WireReason::UncappedFallback,
+            }),
+        },
+    };
+    serde_json::to_string(&response).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stream(index: usize, quality: i64, bandwidth: i64, codec: &str) -> VideoStreamDescriptor {
+        VideoStreamDescriptor {
+            original_index: index,
+            quality_id: quality,
+            bandwidth,
+            codec: VideoCodec::from_name(codec),
+        }
+    }
+
+    fn request(streams: Vec<VideoStreamDescriptor>) -> VideoStreamSelectionRequest {
+        VideoStreamSelectionRequest {
+            max_quality_id: 80,
+            codec_filter: None,
+            max_avc_quality_id: None,
+            streams,
+        }
+    }
+
+    #[test]
+    fn empty_and_one_stream() {
+        assert_eq!(
+            select_video_stream(&request(vec![])).unwrap(),
+            VideoStreamSelection::NoMatch
+        );
+        assert_eq!(
+            select_video_stream(&request(vec![stream(7, 80, 0, "avc")])).unwrap(),
+            VideoStreamSelection::Selected {
+                selected_index: 7,
+                ranked_indices: vec![7],
+                reason: VideoSelectionReason::Preferred,
+            }
+        );
+    }
+
+    #[test]
+    fn exact_quality_bandwidth_and_stable_order() {
+        let result = select_video_stream(&request(vec![
+            stream(4, 64, 999, "avc"),
+            stream(2, 80, 100, "hevc"),
+            stream(9, 80, 200, "av1"),
+            stream(6, 80, 200, "avc"),
+        ]))
+        .unwrap();
+        assert_eq!(
+            result,
+            VideoStreamSelection::Selected {
+                selected_index: 9,
+                ranked_indices: vec![9, 6, 2, 4],
+                reason: VideoSelectionReason::Preferred,
+            }
+        );
+    }
+
+    #[test]
+    fn codec_aliases_and_unknown_values_preserve_exact_identity() {
+        assert_eq!(VideoCodec::from_name("avc"), VideoCodec::Avc);
+        assert_eq!(VideoCodec::from_name("hevc"), VideoCodec::Hevc);
+        assert_eq!(VideoCodec::from_name("av1"), VideoCodec::Av1);
+        assert_eq!(VideoCodec::from_name("avc1").name(), "avc1");
+        let mut req = request(vec![stream(0, 80, 1, "avc1"), stream(1, 80, 2, "avc")]);
+        req.codec_filter = Some(VideoCodec::from_name("avc1"));
+        assert_eq!(
+            select_video_stream(&req).unwrap(),
+            VideoStreamSelection::Selected {
+                selected_index: 0,
+                ranked_indices: vec![0],
+                reason: VideoSelectionReason::Preferred,
+            }
+        );
+    }
+
+    #[test]
+    fn unavailable_codec_uses_quality_fallback() {
+        let mut req = request(vec![stream(0, 80, 1, "hevc"), stream(1, 64, 2, "av1")]);
+        req.codec_filter = Some(VideoCodec::Avc);
+        assert_eq!(
+            select_video_stream(&req).unwrap(),
+            VideoStreamSelection::Selected {
+                selected_index: 0,
+                ranked_indices: vec![0, 1],
+                reason: VideoSelectionReason::QualityFallback,
+            }
+        );
+    }
+
+    #[test]
+    fn empty_codec_filter_means_no_filter() {
+        let mut req = request(vec![stream(0, 80, 1, "hevc"), stream(1, 64, 2, "avc")]);
+        req.codec_filter = Some(VideoCodec::from_name(""));
+        assert_eq!(
+            select_video_stream(&req).unwrap(),
+            VideoStreamSelection::Selected {
+                selected_index: 0,
+                ranked_indices: vec![0, 1],
+                reason: VideoSelectionReason::Preferred,
+            }
+        );
+    }
+
+    #[test]
+    fn requested_quality_unavailable_uses_uncapped_fallback() {
+        let mut req = request(vec![stream(0, 116, 1, "avc"), stream(1, 120, 2, "hevc")]);
+        req.max_quality_id = 64;
+        assert_eq!(
+            select_video_stream(&req).unwrap(),
+            VideoStreamSelection::Selected {
+                selected_index: 1,
+                ranked_indices: vec![1, 0],
+                reason: VideoSelectionReason::UncappedFallback,
+            }
+        );
+    }
+
+    #[test]
+    fn avc_cap_applies_only_to_preferred_avc_stage() {
+        let mut req = request(vec![stream(0, 80, 1, "avc"), stream(1, 64, 1, "avc")]);
+        req.codec_filter = Some(VideoCodec::Avc);
+        req.max_avc_quality_id = Some(64);
+        assert_eq!(
+            select_video_stream(&req).unwrap(),
+            VideoStreamSelection::Selected {
+                selected_index: 1,
+                ranked_indices: vec![1],
+                reason: VideoSelectionReason::Preferred,
+            }
+        );
+
+        req.streams = vec![stream(0, 80, 1, "avc")];
+        assert_eq!(
+            select_video_stream(&req).unwrap(),
+            VideoStreamSelection::Selected {
+                selected_index: 0,
+                ranked_indices: vec![0],
+                reason: VideoSelectionReason::QualityFallback,
+            }
+        );
+    }
+
+    #[test]
+    fn zero_bandwidth_and_non_monotonic_indices_are_valid() {
+        let result = select_video_stream(&request(vec![
+            stream(10, 80, 0, "avc"),
+            stream(3, 80, 0, "avc"),
+        ]))
+        .unwrap();
+        assert_eq!(
+            result,
+            VideoStreamSelection::Selected {
+                selected_index: 10,
+                ranked_indices: vec![10, 3],
+                reason: VideoSelectionReason::Preferred,
+            }
+        );
+    }
+
+    #[test]
+    fn duplicate_indices_are_invalid() {
+        let req = request(vec![stream(1, 80, 1, "avc"), stream(1, 64, 2, "hevc")]);
+        assert_eq!(
+            select_video_stream(&req),
+            Err(VideoStreamSelectionError::InvalidRequest)
+        );
+    }
+
+    #[test]
+    fn repeated_execution_is_deterministic() {
+        let req = request(vec![stream(0, 80, 1, "avc"), stream(1, 80, 1, "avc")]);
+        assert_eq!(select_video_stream(&req), select_video_stream(&req));
+    }
+
+    #[test]
+    fn wire_rejects_invalid_schema_duplicate_or_non_increasing_indices() {
+        assert!(select_video_stream_json("not json").is_none());
+        assert!(select_video_stream_json(r#"{"schema_version":2,"max_quality_id":80,"codec_filter":null,"max_avc_quality_id":null,"streams":[]}"#).is_none());
+        assert!(select_video_stream_json(r#"{"schema_version":1,"max_quality_id":80,"codec_filter":null,"max_avc_quality_id":null,"streams":[{"original_index":1,"quality_id":80,"bandwidth":1,"codec":"avc"},{"original_index":1,"quality_id":64,"bandwidth":1,"codec":"hevc"}]}"#).is_none());
+    }
+}

--- a/tests/test_native_utility_release_gate.py
+++ b/tests/test_native_utility_release_gate.py
@@ -35,6 +35,9 @@ EXPECTED_PHASE2_CAPABILITIES = {
     "plan_update_download_candidates",
     "plan_media_download_candidates",
     "plan_tool_download_candidates",
+    "decide_quality_policy",
+    "select_video_stream",
+    "select_audio_stream",
 }
 
 
@@ -160,6 +163,61 @@ class NativeUtilityReleaseGateTest(unittest.TestCase):
             [candidate["url"] for candidate in tool_plan["candidates"]],
             ["https://primary/yt-dlp", "https://mirror/yt-dlp"],
         )
+        completed, quality = rust_backend.try_decide_quality_policy(
+            {
+                "schema_version": 1,
+                "raw_quality": "1080P 高帧率",
+                "raw_cap": "720P 高清",
+                "choice_index": 2,
+            }
+        )
+        self.assertTrue(completed)
+        self.assertEqual(quality["effective_max_height"], 720)
+        self.assertEqual(quality["dash_max_quality_id"], 116)
+
+        completed, video = rust_backend.try_select_video_stream(
+            {
+                "schema_version": 1,
+                "max_quality_id": 80,
+                "codec_filter": "avc",
+                "max_avc_quality_id": 64,
+                "streams": [
+                    {
+                        "original_index": 0,
+                        "quality_id": 80,
+                        "bandwidth": 100,
+                        "codec": "hevc",
+                    },
+                    {
+                        "original_index": 1,
+                        "quality_id": 64,
+                        "bandwidth": 200,
+                        "codec": "avc",
+                    },
+                ],
+            }
+        )
+        self.assertTrue(completed)
+        self.assertEqual(video["selected_index"], 1)
+        self.assertEqual(video["reason"], "preferred")
+
+        completed, audio = rust_backend.try_select_audio_stream(
+            {
+                "schema_version": 1,
+                "audio_hires": True,
+                "regular_streams": [
+                    {
+                        "original_index": 0,
+                        "quality_id": 30280,
+                        "bandwidth": 0,
+                    }
+                ],
+                "flac_available": True,
+                "dolby_available": True,
+            }
+        )
+        self.assertTrue(completed)
+        self.assertEqual(audio["preferred_source"], "dolby")
 
     def test_phase1_capability_documentation_matches_backend_symbols(self):
         self.assertEqual(set(rust_backend.PHASE1_CAPABILITIES), EXPECTED_PHASE1_CAPABILITIES)

--- a/tests/test_native_utility_release_gate.py
+++ b/tests/test_native_utility_release_gate.py
@@ -38,6 +38,7 @@ EXPECTED_PHASE2_CAPABILITIES = {
     "decide_quality_policy",
     "select_video_stream",
     "select_audio_stream",
+    "select_preferred_audio_source",
 }
 
 
@@ -212,12 +213,27 @@ class NativeUtilityReleaseGateTest(unittest.TestCase):
                         "bandwidth": 0,
                     }
                 ],
+            }
+        )
+        self.assertTrue(completed)
+        self.assertEqual(audio["selected_index"], 0)
+        self.assertEqual(audio["ranked_indices"], [0])
+
+        completed, preferred_audio = rust_backend.try_select_preferred_audio_source(
+            {
+                "schema_version": 1,
+                "audio_hires": True,
+                "regular_candidates": [
+                    {"original_index": 0},
+                    {"original_index": 1},
+                ],
                 "flac_available": True,
                 "dolby_available": True,
             }
         )
         self.assertTrue(completed)
-        self.assertEqual(audio["preferred_source"], "dolby")
+        self.assertEqual(preferred_audio["preferred_source"], "dolby")
+        self.assertEqual(preferred_audio["selected_regular_index"], 0)
 
     def test_phase1_capability_documentation_matches_backend_symbols(self):
         self.assertEqual(set(rust_backend.PHASE1_CAPABILITIES), EXPECTED_PHASE1_CAPABILITIES)

--- a/tests/test_quality_stream_ranking_backend.py
+++ b/tests/test_quality_stream_ranking_backend.py
@@ -4,6 +4,7 @@ from contextlib import ExitStack
 from unittest.mock import patch
 
 from bilikara import rust_backend
+from bilikara.cache import CacheManager
 
 
 def quality_request(**changes):
@@ -34,6 +35,16 @@ def audio_request(streams=None, **changes):
         "schema_version": 1,
         "audio_hires": True,
         "regular_streams": streams or [],
+    }
+    request.update(changes)
+    return request
+
+
+def preferred_audio_request(candidates=None, **changes):
+    request = {
+        "schema_version": 1,
+        "audio_hires": True,
+        "regular_candidates": candidates or [],
         "flac_available": False,
         "dolby_available": False,
     }
@@ -133,28 +144,26 @@ class QualityStreamBackendValidationTest(unittest.TestCase):
         for response in invalid_responses:
             self.assertFalse(rust_backend._valid_video_stream_response(response, request))
 
-    def test_audio_valid_dolby_result_and_strict_ordering(self):
+    def test_audio_valid_result_and_strict_ordering(self):
         request = audio_request(
             [
                 {"original_index": 0, "quality_id": 30232, "bandwidth": 999},
                 {"original_index": 1, "quality_id": 30280, "bandwidth": 0},
-            ],
-            flac_available=True,
-            dolby_available=True,
+            ]
         )
         validated = rust_backend._audio_stream_request(request)
         expected = rust_backend._expected_audio_stream_selection(validated)
-        self.assertEqual(expected["preferred_source"], "dolby")
-        self.assertEqual(expected["ranked_regular_indices"], [1, 0])
+        self.assertEqual(expected["selected_index"], 1)
+        self.assertEqual(expected["ranked_indices"], [1, 0])
         self._mock_response("select_audio_stream", "rust_select_audio_stream", expected)
         self.assertEqual(rust_backend.try_select_audio_stream(request), (True, expected))
 
         for invalid in (
-            {**expected, "preferred_source": "unknown"},
-            {**expected, "selected_regular_index": 99},
-            {**expected, "ranked_regular_indices": [0, 1]},
-            {**expected, "ranked_regular_indices": [1, 1]},
-            {**expected, "regular_reason": "unknown"},
+            {**expected, "status": "unknown"},
+            {**expected, "selected_index": 99},
+            {**expected, "ranked_indices": [0, 1]},
+            {**expected, "ranked_indices": [1, 1]},
+            {**expected, "reason": "unknown"},
             {**expected, "extra": True},
         ):
             self.assertFalse(rust_backend._valid_audio_stream_response(invalid, validated))
@@ -172,11 +181,120 @@ class QualityStreamBackendValidationTest(unittest.TestCase):
         for request in invalid:
             self.assertIsNone(rust_backend._audio_stream_request(request))
 
+    def test_preferred_audio_source_preserves_first_regular_and_strict_response(self):
+        request = preferred_audio_request(
+            [{"original_index": 0}, {"original_index": 1}],
+            audio_hires=False,
+            flac_available=True,
+            dolby_available=True,
+        )
+        validated = rust_backend._preferred_audio_source_request(request)
+        expected = rust_backend._expected_preferred_audio_source_selection(validated)
+        self.assertEqual(expected["preferred_source"], "regular")
+        self.assertEqual(expected["selected_regular_index"], 0)
+        self._mock_response(
+            "select_preferred_audio_source",
+            "rust_select_preferred_audio_source",
+            expected,
+        )
+        self.assertEqual(
+            rust_backend.try_select_preferred_audio_source(request), (True, expected)
+        )
+
+        no_match_request = preferred_audio_request(
+            [], audio_hires=False, flac_available=True, dolby_available=True
+        )
+        validated_no_match = rust_backend._preferred_audio_source_request(
+            no_match_request
+        )
+        expected_no_match = rust_backend._expected_preferred_audio_source_selection(
+            validated_no_match
+        )
+        self.assertEqual(expected_no_match["status"], "no_match")
+        self._mock_response(
+            "select_preferred_audio_source",
+            "rust_select_preferred_audio_source",
+            expected_no_match,
+        )
+        self.assertEqual(
+            rust_backend.try_select_preferred_audio_source(no_match_request),
+            (True, expected_no_match),
+        )
+
+        for invalid in (
+            {**expected, "status": "unknown"},
+            {**expected, "preferred_source": "invented"},
+            {**expected, "selected_regular_index": 1},
+            {**expected, "selected_regular_index": 99},
+            {**expected, "extra": True},
+        ):
+            self.assertFalse(
+                rust_backend._valid_preferred_audio_source_response(invalid, validated)
+            )
+
+    def test_preferred_audio_source_rejects_bad_requests_and_excessive_input(self):
+        candidate = {"original_index": 0}
+        invalid = [
+            preferred_audio_request([candidate], audio_hires=1),
+            preferred_audio_request([candidate], flac_available=1),
+            preferred_audio_request([{"original_index": True}]),
+            preferred_audio_request([candidate, candidate]),
+            preferred_audio_request(
+                [candidate] * (rust_backend.MAX_STREAM_RANKING_INPUTS + 1)
+            ),
+            {**preferred_audio_request([candidate]), "extra": True},
+        ]
+        for request in invalid:
+            self.assertIsNone(rust_backend._preferred_audio_source_request(request))
+
+    def test_preferred_audio_invalid_native_results_fall_back_to_first_object(self):
+        best_audio = [
+            {"quality_id": 30216, "bandwidth": 1, "url": "first"},
+            {"quality_id": 30280, "bandwidth": 999, "url": "second"},
+        ]
+        expected = {
+            "schema_version": 1,
+            "status": "selected",
+            "preferred_source": "regular",
+            "selected_regular_index": 0,
+        }
+        invalid_responses = (
+            "not json",
+            {**expected, "selected_regular_index": 1},
+            {**expected, "selected_regular_index": 99},
+            {**expected, "preferred_source": "invented"},
+            {**expected, "extra": True},
+        )
+        for invalid in invalid_responses:
+            with self.subTest(response=invalid):
+                class Library:
+                    rust_select_preferred_audio_source = staticmethod(
+                        lambda _payload: object()
+                    )
+
+                response_json = (
+                    invalid if isinstance(invalid, str) else json.dumps(invalid)
+                )
+                with patch.object(rust_backend, "_rust_lib", Library()), patch.dict(
+                    rust_backend._CAPABILITIES,
+                    {"select_preferred_audio_source": True},
+                ), patch.object(
+                    rust_backend, "_read_rust_string", return_value=response_json
+                ):
+                    selected = CacheManager._select_preferred_dash_audio(
+                        best_audio, None, None, audio_hires=False
+                    )
+                self.assertIs(selected, best_audio[0])
+
     def test_missing_library_symbol_malformed_json_null_and_capability_isolation(self):
         calls = (
             (rust_backend.try_decide_quality_policy, quality_request()),
             (rust_backend.try_select_video_stream, video_request()),
             (rust_backend.try_select_audio_stream, audio_request()),
+            (
+                rust_backend.try_select_preferred_audio_source,
+                preferred_audio_request(),
+            ),
         )
         with patch.object(rust_backend, "_rust_lib", None):
             for function, request in calls:
@@ -186,6 +304,11 @@ class QualityStreamBackendValidationTest(unittest.TestCase):
             ("decide_quality_policy", rust_backend.try_decide_quality_policy, quality_request()),
             ("select_video_stream", rust_backend.try_select_video_stream, video_request()),
             ("select_audio_stream", rust_backend.try_select_audio_stream, audio_request()),
+            (
+                "select_preferred_audio_source",
+                rust_backend.try_select_preferred_audio_source,
+                preferred_audio_request(),
+            ),
         ):
             with patch.object(rust_backend, "_rust_lib", object()), patch.dict(
                 rust_backend._CAPABILITIES, {capability: False}
@@ -202,15 +325,28 @@ class QualityStreamBackendValidationTest(unittest.TestCase):
             self.assertEqual(
                 rust_backend.try_select_audio_stream(audio_request()), (False, None)
             )
+        class PreferredLibrary:
+            rust_select_preferred_audio_source = staticmethod(lambda _payload: object())
+
+        with patch.object(rust_backend, "_rust_lib", PreferredLibrary()), patch.dict(
+            rust_backend._CAPABILITIES, {"select_preferred_audio_source": True}
+        ), patch.object(rust_backend, "_read_rust_string", return_value=None):
+            self.assertEqual(
+                rust_backend.try_select_preferred_audio_source(
+                    preferred_audio_request()
+                ),
+                (False, None),
+            )
         self.assertEqual(
             len(
                 {
                     rust_backend._SYMBOLS["decide_quality_policy"][0],
                     rust_backend._SYMBOLS["select_video_stream"][0],
                     rust_backend._SYMBOLS["select_audio_stream"][0],
+                    rust_backend._SYMBOLS["select_preferred_audio_source"][0],
                 }
             ),
-            3,
+            4,
         )
 
 

--- a/tests/test_quality_stream_ranking_backend.py
+++ b/tests/test_quality_stream_ranking_backend.py
@@ -1,0 +1,218 @@
+import json
+import unittest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+from bilikara import rust_backend
+
+
+def quality_request(**changes):
+    request = {
+        "schema_version": 1,
+        "raw_quality": "720P 高清",
+        "raw_cap": "",
+        "choice_index": 2,
+    }
+    request.update(changes)
+    return request
+
+
+def video_request(streams=None, **changes):
+    request = {
+        "schema_version": 1,
+        "max_quality_id": 80,
+        "codec_filter": "avc",
+        "max_avc_quality_id": 64,
+        "streams": streams or [],
+    }
+    request.update(changes)
+    return request
+
+
+def audio_request(streams=None, **changes):
+    request = {
+        "schema_version": 1,
+        "audio_hires": True,
+        "regular_streams": streams or [],
+        "flac_available": False,
+        "dolby_available": False,
+    }
+    request.update(changes)
+    return request
+
+
+class QualityStreamBackendValidationTest(unittest.TestCase):
+    def _mock_response(self, capability, symbol, response):
+        class Library:
+            pass
+
+        setattr(Library, symbol, staticmethod(lambda _payload: object()))
+        stack = ExitStack()
+        self.addCleanup(stack.close)
+        stack.enter_context(patch.object(rust_backend, "_rust_lib", Library()))
+        stack.enter_context(patch.dict(rust_backend._CAPABILITIES, {capability: True}))
+        stack.enter_context(
+            patch.object(
+                rust_backend,
+                "_read_rust_string",
+                return_value=response if isinstance(response, str) else json.dumps(response),
+            )
+        )
+
+    def test_quality_valid_response_and_strict_reconstruction(self):
+        request = quality_request()
+        validated = rust_backend._quality_policy_request(request)
+        expected = rust_backend._expected_quality_policy(validated)
+        self._mock_response(
+            "decide_quality_policy", "rust_decide_quality_policy", expected
+        )
+        self.assertEqual(rust_backend.try_decide_quality_policy(request), (True, expected))
+
+        for invalid in (
+            {**expected, "status": "unknown"},
+            {**expected, "normalized_quality": "invented"},
+            {**expected, "effective_max_height": 2160},
+            {**expected, "bbdown_quality_order": list(reversed(expected["bbdown_quality_order"]))},
+            {**expected, "extra": True},
+        ):
+            self.assertFalse(rust_backend._valid_quality_policy_response(invalid, validated))
+
+    def test_quality_request_limits_types_and_boolean_indices(self):
+        invalid = [
+            quality_request(schema_version=2),
+            quality_request(choice_index=True),
+            quality_request(raw_quality=[]),
+            quality_request(raw_cap="x" * (rust_backend.MAX_QUALITY_LABEL_BYTES + 1)),
+            {**quality_request(), "extra": True},
+        ]
+        for request in invalid:
+            self.assertIsNone(rust_backend._quality_policy_request(request))
+
+    def test_video_valid_no_match_and_selected_responses(self):
+        empty = video_request()
+        expected_empty = rust_backend._expected_video_stream_selection(
+            rust_backend._video_stream_request(empty)
+        )
+        self._mock_response("select_video_stream", "rust_select_video_stream", expected_empty)
+        self.assertEqual(rust_backend.try_select_video_stream(empty), (True, expected_empty))
+
+        selected = video_request(
+            [
+                {"original_index": 0, "quality_id": 80, "bandwidth": 10, "codec": "hevc"},
+                {"original_index": 1, "quality_id": 64, "bandwidth": 20, "codec": "avc"},
+            ]
+        )
+        validated = rust_backend._video_stream_request(selected)
+        expected = rust_backend._expected_video_stream_selection(validated)
+        self._mock_response("select_video_stream", "rust_select_video_stream", expected)
+        self.assertEqual(rust_backend.try_select_video_stream(selected), (True, expected))
+
+    def test_video_rejects_bad_requests_and_untrusted_rankings(self):
+        stream = {"original_index": 0, "quality_id": 80, "bandwidth": 1, "codec": "avc"}
+        invalid_requests = [
+            video_request([stream], max_quality_id=True),
+            video_request([{**stream, "quality_id": True}]),
+            video_request([{**stream, "bandwidth": float("inf")}]),
+            video_request([{**stream, "codec": "x" * (rust_backend.MAX_CODEC_STRING_BYTES + 1)}]),
+            video_request([stream, stream]),
+            video_request([stream] * (rust_backend.MAX_STREAM_RANKING_INPUTS + 1)),
+        ]
+        for request in invalid_requests:
+            self.assertIsNone(rust_backend._video_stream_request(request))
+
+        request = rust_backend._video_stream_request(video_request([stream]))
+        expected = rust_backend._expected_video_stream_selection(request)
+        invalid_responses = [
+            {**expected, "status": "unknown"},
+            {**expected, "selected_index": 99},
+            {**expected, "ranked_indices": [0, 0]},
+            {**expected, "ranked_indices": []},
+            {**expected, "reason": "unknown"},
+            {**expected, "extra": True},
+        ]
+        for response in invalid_responses:
+            self.assertFalse(rust_backend._valid_video_stream_response(response, request))
+
+    def test_audio_valid_dolby_result_and_strict_ordering(self):
+        request = audio_request(
+            [
+                {"original_index": 0, "quality_id": 30232, "bandwidth": 999},
+                {"original_index": 1, "quality_id": 30280, "bandwidth": 0},
+            ],
+            flac_available=True,
+            dolby_available=True,
+        )
+        validated = rust_backend._audio_stream_request(request)
+        expected = rust_backend._expected_audio_stream_selection(validated)
+        self.assertEqual(expected["preferred_source"], "dolby")
+        self.assertEqual(expected["ranked_regular_indices"], [1, 0])
+        self._mock_response("select_audio_stream", "rust_select_audio_stream", expected)
+        self.assertEqual(rust_backend.try_select_audio_stream(request), (True, expected))
+
+        for invalid in (
+            {**expected, "preferred_source": "unknown"},
+            {**expected, "selected_regular_index": 99},
+            {**expected, "ranked_regular_indices": [0, 1]},
+            {**expected, "ranked_regular_indices": [1, 1]},
+            {**expected, "regular_reason": "unknown"},
+            {**expected, "extra": True},
+        ):
+            self.assertFalse(rust_backend._valid_audio_stream_response(invalid, validated))
+
+    def test_audio_rejects_invalid_types_indices_and_excessive_requests(self):
+        stream = {"original_index": 0, "quality_id": 30280, "bandwidth": 0}
+        invalid = [
+            audio_request([stream], audio_hires=1),
+            audio_request([{**stream, "quality_id": True}]),
+            audio_request([{**stream, "original_index": True}]),
+            audio_request([stream, stream]),
+            audio_request([stream] * (rust_backend.MAX_STREAM_RANKING_INPUTS + 1)),
+            {**audio_request([stream]), "extra": True},
+        ]
+        for request in invalid:
+            self.assertIsNone(rust_backend._audio_stream_request(request))
+
+    def test_missing_library_symbol_malformed_json_null_and_capability_isolation(self):
+        calls = (
+            (rust_backend.try_decide_quality_policy, quality_request()),
+            (rust_backend.try_select_video_stream, video_request()),
+            (rust_backend.try_select_audio_stream, audio_request()),
+        )
+        with patch.object(rust_backend, "_rust_lib", None):
+            for function, request in calls:
+                self.assertEqual(function(request), (False, None))
+
+        for capability, function, request in (
+            ("decide_quality_policy", rust_backend.try_decide_quality_policy, quality_request()),
+            ("select_video_stream", rust_backend.try_select_video_stream, video_request()),
+            ("select_audio_stream", rust_backend.try_select_audio_stream, audio_request()),
+        ):
+            with patch.object(rust_backend, "_rust_lib", object()), patch.dict(
+                rust_backend._CAPABILITIES, {capability: False}
+            ):
+                self.assertEqual(function(request), (False, None))
+
+        self._mock_response(
+            "select_video_stream", "rust_select_video_stream", "not json"
+        )
+        self.assertEqual(rust_backend.try_select_video_stream(video_request()), (False, None))
+        with patch.object(rust_backend, "_rust_lib", object()), patch.dict(
+            rust_backend._CAPABILITIES, {"select_audio_stream": True}
+        ), patch.object(rust_backend, "_read_rust_string", return_value=None):
+            self.assertEqual(
+                rust_backend.try_select_audio_stream(audio_request()), (False, None)
+            )
+        self.assertEqual(
+            len(
+                {
+                    rust_backend._SYMBOLS["decide_quality_policy"][0],
+                    rust_backend._SYMBOLS["select_video_stream"][0],
+                    rust_backend._SYMBOLS["select_audio_stream"][0],
+                }
+            ),
+            3,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quality_stream_ranking_policy.py
+++ b/tests/test_quality_stream_ranking_policy.py
@@ -1,0 +1,266 @@
+import itertools
+import os
+import unittest
+from unittest.mock import patch
+
+from bilikara import rust_backend
+from bilikara.cache import CacheManager, VIDEO_QUALITY_CHOICES
+
+
+class QualityPolicyReferenceTest(unittest.TestCase):
+    def test_python_quality_reference_covers_labels_indices_caps_and_boundaries(self):
+        for index, quality in enumerate(VIDEO_QUALITY_CHOICES):
+            with self.subTest(index=index, quality=quality):
+                self.assertEqual(CacheManager._py_quality_from_choice_index(index), quality)
+                self.assertEqual(CacheManager._py_quality_from_choice_index(str(index)), quality)
+                self.assertEqual(CacheManager._py_optional_video_quality(f" {quality} "), quality)
+                self.assertEqual(CacheManager._py_normalize_video_quality(f" {quality} "), quality)
+
+        self.assertEqual(CacheManager._py_quality_from_choice_index(True), VIDEO_QUALITY_CHOICES[1])
+        self.assertEqual(CacheManager._py_quality_from_choice_index(2.9), VIDEO_QUALITY_CHOICES[2])
+        self.assertIsNone(CacheManager._py_quality_from_choice_index("invalid"))
+        self.assertIsNone(CacheManager._py_optional_video_quality("4K 超清"))
+        self.assertEqual(CacheManager._py_normalize_video_quality("invalid"), VIDEO_QUALITY_CHOICES[0])
+
+        dash_ids = {
+            "360P 流畅": 16,
+            "480P 清晰": 32,
+            "720P 高清": 64,
+            "720P 60帧": 74,
+            "1080P 高清": 80,
+            "1080P 高码率": 112,
+            "1080P 高帧率": 116,
+            "4K 超清": 120,
+            "HDR 真彩": 125,
+            "杜比视界": 126,
+            "8K 超高清": 127,
+        }
+        for label, quality_id in dash_ids.items():
+            self.assertEqual(CacheManager._py_dash_max_quality_id(label), quality_id)
+        self.assertEqual(CacheManager._py_dash_max_quality_id(" 4K 超清 "), 80)
+
+        heights = [1080, 1080, 720, 480, 360]
+        for quality, height in zip(VIDEO_QUALITY_CHOICES, heights):
+            self.assertEqual(CacheManager._py_ytdlp_max_height(quality), height)
+        self.assertEqual(
+            CacheManager._py_ytdlp_max_height("1080P 高帧率", "720P 高清"),
+            720,
+        )
+        self.assertEqual(
+            CacheManager._py_video_quality_priority("480P 清晰", "720P 高清"),
+            "480P 清晰,360P 流畅",
+        )
+
+    def test_public_quality_wrappers_fall_back_to_independent_python(self):
+        with patch.object(
+            rust_backend, "try_decide_quality_policy", return_value=(False, None)
+        ), patch.object(
+            CacheManager,
+            "_py_normalize_video_quality",
+            wraps=CacheManager._py_normalize_video_quality,
+        ) as fallback:
+            self.assertEqual(CacheManager._normalize_video_quality(" 720P 高清 "), "720P 高清")
+            fallback.assert_called_once()
+
+
+class StreamRankingReferenceTest(unittest.TestCase):
+    def test_python_video_reference_preserves_three_stage_ranking(self):
+        streams = [
+            {"quality_id": 80, "bandwidth": 100, "codec_name": "hevc"},
+            {"quality_id": 64, "bandwidth": 200, "codec_name": "avc"},
+            {"quality_id": 64, "bandwidth": 200, "codec_name": "avc"},
+        ]
+        self.assertIs(
+            CacheManager._py_select_dash_video_stream(
+                streams,
+                max_quality_id=80,
+                codec_filter="avc",
+                avc_quality_cap="720P 高清",
+            ),
+            streams[1],
+        )
+        self.assertIs(
+            CacheManager._py_select_dash_video_stream(
+                streams, max_quality_id=80, codec_filter="av1"
+            ),
+            streams[0],
+        )
+        self.assertEqual(
+            CacheManager._py_select_dash_video_stream(
+                [{"quality_id": 116, "bandwidth": 1, "codec_name": "avc"}],
+                max_quality_id=64,
+            )["codec_name"],
+            "avc",
+        )
+        self.assertIsNone(
+            CacheManager._py_select_dash_video_stream([], max_quality_id=80)
+        )
+
+    def test_python_audio_reference_preserves_quality_and_ignores_bandwidth(self):
+        streams = [
+            {"quality_id": 30280, "bandwidth": 0},
+            {"quality_id": 30280, "bandwidth": 999999},
+            {"quality_id": 30232, "bandwidth": 999999},
+        ]
+        self.assertIs(
+            CacheManager._py_select_dash_audio_stream(streams, audio_hires=True),
+            streams[0],
+        )
+        high_only = [
+            {"quality_id": 30251, "bandwidth": 2},
+            {"quality_id": 30250, "bandwidth": 1},
+        ]
+        self.assertIs(
+            CacheManager._py_select_dash_audio_stream(high_only, audio_hires=False),
+            high_only[1],
+        )
+
+    def test_python_preferred_audio_reference_is_dolby_flac_regular(self):
+        regular = {"quality_id": 30280}
+        flac = {"quality_id": 30251}
+        dolby = {"quality_id": 30250}
+        self.assertIs(
+            CacheManager._py_select_preferred_dash_audio(
+                [regular], flac, dolby, audio_hires=True
+            ),
+            dolby,
+        )
+        self.assertIs(
+            CacheManager._py_select_preferred_dash_audio(
+                [regular], flac, None, audio_hires=True
+            ),
+            flac,
+        )
+        self.assertIs(
+            CacheManager._py_select_preferred_dash_audio(
+                [regular], flac, dolby, audio_hires=False
+            ),
+            regular,
+        )
+
+    def test_public_stream_wrappers_fall_back_completely(self):
+        video = [{"quality_id": 80, "bandwidth": 1, "codec_name": "avc"}]
+        audio = [{"quality_id": 30280, "bandwidth": 1}]
+        with patch.object(
+            rust_backend, "try_select_video_stream", return_value=(False, None)
+        ), patch.object(
+            rust_backend, "try_select_audio_stream", return_value=(False, None)
+        ), patch.object(
+            CacheManager,
+            "_py_select_dash_video_stream",
+            wraps=CacheManager._py_select_dash_video_stream,
+        ) as video_fallback, patch.object(
+            CacheManager,
+            "_py_select_dash_audio_stream",
+            wraps=CacheManager._py_select_dash_audio_stream,
+        ) as audio_fallback:
+            self.assertIs(
+                CacheManager._select_dash_video_stream(video, max_quality_id=80),
+                video[0],
+            )
+            self.assertIs(
+                CacheManager._select_dash_audio_stream(audio, audio_hires=True),
+                audio[0],
+            )
+            video_fallback.assert_called_once()
+            audio_fallback.assert_called_once()
+
+
+class NativeQualityStreamEquivalenceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        status = rust_backend.backend_status()
+        capabilities = status["capabilities"]
+        required = {
+            "decide_quality_policy",
+            "select_video_stream",
+            "select_audio_stream",
+        }
+        if not status["loaded"] or not all(capabilities.get(name) for name in required):
+            if os.environ.get("BILIKARA_REQUIRE_RUST_LIB") == "1":
+                raise AssertionError("strict-native quality/stream capabilities are unavailable")
+            raise unittest.SkipTest("quality/stream native capabilities are unavailable")
+
+    def test_quality_native_matches_reference_generated_inputs(self):
+        values = ["", "invalid", " 720P 高清 ", "4K 超清", "歌曲"]
+        caps = ["", "720P 高清", " 480P 清晰 ", "invalid"]
+        for value, cap in itertools.product(values, caps):
+            self.assertEqual(
+                CacheManager._normalize_video_quality(value),
+                CacheManager._py_normalize_video_quality(value),
+            )
+            self.assertEqual(
+                CacheManager._optional_video_quality(value),
+                CacheManager._py_optional_video_quality(value),
+            )
+            self.assertEqual(
+                CacheManager._dash_max_quality_id(value),
+                CacheManager._py_dash_max_quality_id(value),
+            )
+            self.assertEqual(
+                CacheManager._ytdlp_max_height(value, cap),
+                CacheManager._py_ytdlp_max_height(value, cap),
+            )
+            self.assertEqual(
+                CacheManager._video_quality_priority(value, cap),
+                CacheManager._py_video_quality_priority(value, cap),
+            )
+
+    def test_video_native_matches_reference_across_permutations(self):
+        base = [
+            {"quality_id": 116, "bandwidth": 0, "codec_name": "hevc"},
+            {"quality_id": 80, "bandwidth": 100, "codec_name": "avc"},
+            {"quality_id": 64, "bandwidth": 100, "codec_name": "av1"},
+        ]
+        for streams in itertools.permutations(base):
+            streams = list(streams)
+            for max_id, codec, cap in itertools.product(
+                (64, 80, 116), (None, "", "avc", "hevc", "unknown"), ("", "720P 高清")
+            ):
+                native = CacheManager._select_dash_video_stream(
+                    streams,
+                    max_quality_id=max_id,
+                    codec_filter=codec,
+                    avc_quality_cap=cap,
+                )
+                reference = CacheManager._py_select_dash_video_stream(
+                    streams,
+                    max_quality_id=max_id,
+                    codec_filter=codec,
+                    avc_quality_cap=cap,
+                )
+                self.assertIs(native, reference)
+
+    def test_audio_native_matches_reference_for_hires_and_ties(self):
+        base = [
+            {"quality_id": 30250, "bandwidth": 1},
+            {"quality_id": 30251, "bandwidth": 999},
+            {"quality_id": 30280, "bandwidth": 0},
+            {"quality_id": 30280, "bandwidth": 999999},
+            {"quality_id": 0, "bandwidth": 1},
+        ]
+        for streams in ([], base, list(reversed(base)), base[2:]):
+            for hires in (False, True):
+                self.assertIs(
+                    CacheManager._select_dash_audio_stream(streams, audio_hires=hires),
+                    CacheManager._py_select_dash_audio_stream(streams, audio_hires=hires),
+                )
+
+        regular = {"quality_id": 30280, "bandwidth": 0}
+        flac = {"quality_id": 30251, "bandwidth": 1}
+        dolby = {"quality_id": 30250, "bandwidth": 1}
+        for hires, flac_value, dolby_value in itertools.product(
+            (False, True), (None, flac), (None, dolby)
+        ):
+            self.assertIs(
+                CacheManager._select_preferred_dash_audio(
+                    [regular], flac_value, dolby_value, audio_hires=hires
+                ),
+                CacheManager._py_select_preferred_dash_audio(
+                    [regular], flac_value, dolby_value, audio_hires=hires
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quality_stream_ranking_policy.py
+++ b/tests/test_quality_stream_ranking_policy.py
@@ -115,36 +115,86 @@ class StreamRankingReferenceTest(unittest.TestCase):
             high_only[1],
         )
 
-    def test_python_preferred_audio_reference_is_dolby_flac_regular(self):
-        regular = {"quality_id": 30280}
+    def test_python_preferred_audio_reference_preserves_first_regular(self):
+        regular = [
+            {"quality_id": 30216, "bandwidth": 1, "url": "first"},
+            {"quality_id": 30280, "bandwidth": 999, "url": "second"},
+        ]
         flac = {"quality_id": 30251}
         dolby = {"quality_id": 30250}
+        for hires in (False, True):
+            self.assertIs(
+                CacheManager._py_select_preferred_dash_audio(
+                    regular, None, None, audio_hires=hires
+                ),
+                regular[0],
+            )
         self.assertIs(
             CacheManager._py_select_preferred_dash_audio(
-                [regular], flac, dolby, audio_hires=True
-            ),
-            dolby,
-        )
-        self.assertIs(
-            CacheManager._py_select_preferred_dash_audio(
-                [regular], flac, None, audio_hires=True
+                regular, flac, None, audio_hires=True
             ),
             flac,
         )
         self.assertIs(
             CacheManager._py_select_preferred_dash_audio(
-                [regular], flac, dolby, audio_hires=False
+                regular, flac, None, audio_hires=False
             ),
-            regular,
+            regular[0],
+        )
+        self.assertIs(
+            CacheManager._py_select_preferred_dash_audio(
+                regular, flac, dolby, audio_hires=True
+            ),
+            dolby,
+        )
+        self.assertIs(
+            CacheManager._py_select_preferred_dash_audio(
+                regular, flac, dolby, audio_hires=False
+            ),
+            regular[0],
+        )
+
+    def test_python_preferred_audio_reference_handles_empty_regular(self):
+        flac = {"quality_id": 30251}
+        dolby = {"quality_id": 30250}
+        self.assertIs(
+            CacheManager._py_select_preferred_dash_audio(
+                [], flac, None, audio_hires=True
+            ),
+            flac,
+        )
+        self.assertIs(
+            CacheManager._py_select_preferred_dash_audio(
+                [], None, dolby, audio_hires=True
+            ),
+            dolby,
+        )
+        self.assertIsNone(
+            CacheManager._py_select_preferred_dash_audio(
+                [], flac, dolby, audio_hires=False
+            )
+        )
+        self.assertIsNone(
+            CacheManager._py_select_preferred_dash_audio(
+                [], None, None, audio_hires=True
+            )
         )
 
     def test_public_stream_wrappers_fall_back_completely(self):
         video = [{"quality_id": 80, "bandwidth": 1, "codec_name": "avc"}]
         audio = [{"quality_id": 30280, "bandwidth": 1}]
+        unsorted_audio = [
+            {"quality_id": 30216, "bandwidth": 1, "url": "first"},
+            {"quality_id": 30280, "bandwidth": 999, "url": "second"},
+        ]
         with patch.object(
             rust_backend, "try_select_video_stream", return_value=(False, None)
         ), patch.object(
             rust_backend, "try_select_audio_stream", return_value=(False, None)
+        ), patch.object(
+            rust_backend,
+            "try_select_preferred_audio_source",
+            return_value=(False, None),
         ), patch.object(
             CacheManager,
             "_py_select_dash_video_stream",
@@ -153,7 +203,11 @@ class StreamRankingReferenceTest(unittest.TestCase):
             CacheManager,
             "_py_select_dash_audio_stream",
             wraps=CacheManager._py_select_dash_audio_stream,
-        ) as audio_fallback:
+        ) as audio_fallback, patch.object(
+            CacheManager,
+            "_py_select_preferred_dash_audio",
+            wraps=CacheManager._py_select_preferred_dash_audio,
+        ) as preferred_fallback:
             self.assertIs(
                 CacheManager._select_dash_video_stream(video, max_quality_id=80),
                 video[0],
@@ -162,8 +216,15 @@ class StreamRankingReferenceTest(unittest.TestCase):
                 CacheManager._select_dash_audio_stream(audio, audio_hires=True),
                 audio[0],
             )
+            self.assertIs(
+                CacheManager._select_preferred_dash_audio(
+                    unsorted_audio, None, None, audio_hires=False
+                ),
+                unsorted_audio[0],
+            )
             video_fallback.assert_called_once()
             audio_fallback.assert_called_once()
+            preferred_fallback.assert_called_once()
 
 
 class NativeQualityStreamEquivalenceTest(unittest.TestCase):
@@ -175,6 +236,7 @@ class NativeQualityStreamEquivalenceTest(unittest.TestCase):
             "decide_quality_policy",
             "select_video_stream",
             "select_audio_stream",
+            "select_preferred_audio_source",
         }
         if not status["loaded"] or not all(capabilities.get(name) for name in required):
             if os.environ.get("BILIKARA_REQUIRE_RUST_LIB") == "1":
@@ -246,7 +308,10 @@ class NativeQualityStreamEquivalenceTest(unittest.TestCase):
                     CacheManager._py_select_dash_audio_stream(streams, audio_hires=hires),
                 )
 
-        regular = {"quality_id": 30280, "bandwidth": 0}
+        regular = [
+            {"quality_id": 30216, "bandwidth": 1, "url": "first"},
+            {"quality_id": 30280, "bandwidth": 999, "url": "second"},
+        ]
         flac = {"quality_id": 30251, "bandwidth": 1}
         dolby = {"quality_id": 30250, "bandwidth": 1}
         for hires, flac_value, dolby_value in itertools.product(
@@ -254,10 +319,10 @@ class NativeQualityStreamEquivalenceTest(unittest.TestCase):
         ):
             self.assertIs(
                 CacheManager._select_preferred_dash_audio(
-                    [regular], flac_value, dolby_value, audio_hires=hires
+                    regular, flac_value, dolby_value, audio_hires=hires
                 ),
                 CacheManager._py_select_preferred_dash_audio(
-                    [regular], flac_value, dolby_value, audio_hires=hires
+                    regular, flac_value, dolby_value, audio_hires=hires
                 ),
             )
 


### PR DESCRIPTION
## Summary
- Completes Phase 2 Item 6 by migrating deterministic quality and media-stream ranking into typed Rust domains.
- Retains complete Python reference fallbacks.
- Keeps metadata fetching, downloader commands, downloads, cache state and subprocess execution in Python.

## Migrated scope
- `_quality_from_choice_index`, `_optional_video_quality`, `_normalize_video_quality`, `_dash_max_quality_id`, `_video_quality_priority`, and `_ytdlp_max_height` policy decisions.
- Video quality, exact codec, AVC-cap, bandwidth and stable fallback ranking.
- Regular DASH audio quality ranking with the existing bandwidth-independent stable tie and Hi-Res filtering/fallback rules.
- Preferred-audio source binding as a separate policy: first regular input, then FLAC override, then Dolby override when Hi-Res is enabled.
- BBDown ordered-quality and yt-dlp maximum-height policy decisions, excluding command syntax and execution.

## Excluded scope
- Network requests.
- Downloader command execution.
- DASH metadata fetching.
- Download candidate planning.
- Cache scheduling and mutation.
- Filesystem operations.
- Playlist ordering.

## Safety model
- Typed Rust APIs independent from FFI and runtime state.
- Additive ABI-v1 JSON exports: `rust_decide_quality_policy`, `rust_select_video_stream`, `rust_select_audio_stream`, and `rust_select_preferred_audio_source`.
- Regular audio ranking and preferred-source binding use separate request/response invariants; preferred binding receives no quality or bandwidth data and cannot re-rank regular inputs.
- Strict native-response reconstruction and exact equality validation with bounded requests.
- Complete independent Python `_py_*` fallbacks.
- Valid `no_match` distinguished from backend failure.

## Validation
- `cd rust && cargo fmt --check` — passed.
- `cd rust && cargo clippy --all-targets --locked -- -D warnings` — passed.
- `cd rust && cargo test --locked` — passed, 164 tests.
- `cd rust && cargo build --release --locked` — passed.
- `BILIKARA_REQUIRE_RUST_LIB=1 python -m unittest discover -s tests -v` — passed, 599 tests with the real release library.
- `python -m compileall -q bilikara` — passed.
- `python -m py_compile start_bilikara.py build_bundle.py` — passed.
- `cd src-tauri && cargo fmt --check` — passed.
- `cd src-tauri && cargo clippy --all-targets --locked -- -D warnings` — passed.
- `cd src-tauri && cargo test --locked` — passed, 0 tests.
- `cd src-tauri && cargo build --release --locked` — passed.
- System `node --version` reported `v12.22.9`, below the repository requirement.
- `npx --yes --package node@20 --package npm@10 --call node --version && npm ci && npm run build` — passed with Node `v20.20.2`; produced deb, rpm and AppImage bundles.
- `git diff --check` — passed.
- `git status --short` — clean after commit.

## Migration status
Phase 2 progress: 6/8.
Item 6: completed.