### PR TITLE
perf: cache previous session summary

### DIFF
--- a/bilikara/store.py
+++ b/bilikara/store.py
@@ -59,7 +59,10 @@ class PlaylistStore:
             self.session_started_at
         )
         self.session_played: list[SessionPlayedEntry] = []
-        self._previous_session_file = self._latest_previous_session_file_unlocked()
+        (
+            self._previous_session_file,
+            self._previous_session_count,
+        ) = self._latest_previous_session_file_unlocked()
         self.updated_at = time.time()
         self._restore_persistent_state()
         self._save_session()
@@ -115,7 +118,7 @@ class PlaylistStore:
             item.requester_name = normalized_requester
             item.queue_slot_type = "priority" if position == "next" else "cycle"
             if self.current_item is None:
-                self._previous_session_file = None
+                self._clear_previous_session_unlocked()
                 self.current_item = item
                 self.current_item_started = False
                 self._record_session_played_unlocked(item)
@@ -468,7 +471,7 @@ class PlaylistStore:
             ]
             self.current_item_started = False
             self._restore_session_played_from_backup_unlocked(payload)
-            self._previous_session_file = None
+            self._clear_previous_session_unlocked()
             self._rebuild_cycle_items_unlocked()
             self._touch(persist_backup=False)
             return True
@@ -480,7 +483,7 @@ class PlaylistStore:
             self.playlist = []
             if existed:
                 self._start_new_session_played_unlocked()
-            self._previous_session_file = None
+            self._clear_previous_session_unlocked()
             self.backup_file.unlink(missing_ok=True)
             self._touch(persist_backup=False)
             return existed
@@ -499,7 +502,7 @@ class PlaylistStore:
             self.history = []
             self.session_history = []
             self.session_users = []
-            self._previous_session_file = None
+            self._clear_previous_session_unlocked()
             self.updated_at = time.time()
             self._delete_runtime_json_files_unlocked()
         self._notify_change()
@@ -529,12 +532,12 @@ class PlaylistStore:
             payload = self._read_json_payload_unlocked(candidate)
             entries = self._session_played_entries_from_payload(payload)
             if not payload or not entries:
-                self._previous_session_file = None
+                self._clear_previous_session_unlocked()
                 return False
             self.session_played_file = candidate
             self.session_started_at = self._session_started_at_from_payload(payload, {})
             self.session_played = entries
-            self._previous_session_file = None
+            self._clear_previous_session_unlocked()
             self._touch(persist_backup=False)
             return True
 
@@ -886,9 +889,9 @@ class PlaylistStore:
             / f"played-{self._session_file_label(timestamp)}.json"
         )
 
-    def _latest_previous_session_file_unlocked(self) -> Path | None:
+    def _latest_previous_session_file_unlocked(self) -> tuple[Path | None, int]:
         if not self.session_archive_dir.exists():
-            return None
+            return None, 0
         try:
             candidates = sorted(
                 self.session_archive_dir.glob("played-*.json"),
@@ -896,14 +899,19 @@ class PlaylistStore:
                 reverse=True,
             )
         except OSError:
-            return None
+            return None, 0
         for candidate in candidates:
             if candidate == self.session_played_file:
                 continue
             payload = self._read_json_payload_unlocked(candidate)
-            if self._session_played_entries_from_payload(payload):
-                return candidate
-        return None
+            entries = self._session_played_entries_from_payload(payload)
+            if entries:
+                return candidate, len(entries)
+        return None, 0
+
+    def _clear_previous_session_unlocked(self) -> None:
+        self._previous_session_file = None
+        self._previous_session_count = 0
 
     @staticmethod
     def _session_started_at_from_payload(
@@ -1234,17 +1242,11 @@ class PlaylistStore:
         }
 
     def _previous_session_summary_unlocked(self) -> dict[str, Any]:
-        candidate = self._previous_session_file
-        if candidate is None:
-            return {"available": False}
-        payload = self._read_json_payload_unlocked(candidate)
-        entries = self._session_played_entries_from_payload(payload)
-        if not payload or not entries:
-            self._previous_session_file = None
+        if self._previous_session_file is None:
             return {"available": False}
         return {
             "available": True,
-            "item_count": len(entries),
+            "item_count": self._previous_session_count,
         }
 
     def _validate_requester_name_unlocked(self, requester_name: str) -> str:

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -232,6 +232,10 @@ class PlaylistStoreTest(unittest.TestCase):
     def mark_started(self, item_id: str) -> None:
         self.assertTrue(self.store.mark_item_playback_started(item_id))
 
+    def assert_previous_session_cleared(self, store: PlaylistStore) -> None:
+        self.assertIsNone(store._previous_session_file)
+        self.assertEqual(store._previous_session_count, 0)
+
     def test_add_tail_and_next(self):
         self.add_item("a", requester_name="A")
         self.add_item("b", requester_name="B")
@@ -501,6 +505,8 @@ class PlaylistStoreTest(unittest.TestCase):
         self.assertFalse(snapshot["backup"]["available"])
         self.assertTrue(snapshot["previous_session"]["available"])
         self.assertEqual(snapshot["previous_session"]["item_count"], 1)
+        self.assertEqual(restored_store._previous_session_file, original_played_file)
+        self.assertEqual(restored_store._previous_session_count, 1)
         self.assertEqual(restored_store.session_played, [])
 
         self.assertTrue(restored_store.continue_previous_session())
@@ -508,7 +514,10 @@ class PlaylistStoreTest(unittest.TestCase):
         self.assertEqual(
             [entry.item_id for entry in restored_store.session_played], ["a"]
         )
+        self.assert_previous_session_cleared(restored_store)
         self.assertFalse(restored_store.snapshot()["previous_session"]["available"])
+        self.assertIsNone(restored_store.current_item)
+        self.assertEqual(restored_store.playlist, [])
 
         restored_store.add_item(
             self.make_item("b", song_key="song-b"), requester_name="B"
@@ -526,15 +535,118 @@ class PlaylistStoreTest(unittest.TestCase):
             backup_file=self.backup_file,
             session_archive_dir=self.session_archive_dir,
         )
+        self.assertEqual(restored_store._previous_session_count, 1)
         restored_store.add_item(
             self.make_item("b", song_key="song-b"), requester_name="B"
         )
 
         self.assertFalse(restored_store.continue_previous_session())
+        self.assert_previous_session_cleared(restored_store)
         self.assertFalse(restored_store.snapshot()["previous_session"]["available"])
         self.assertEqual(
             [entry.item_id for entry in restored_store.session_played], ["b"]
         )
+
+    def test_previous_session_summary_is_cached_without_polling_disk_reads(self):
+        self.add_item("a", requester_name="A", song_key="song-a")
+        self.add_item("b", requester_name="B", song_key="song-b")
+        self.mark_started("a")
+        self.assertTrue(self.store.advance_to_next())
+        self.mark_started("b")
+        original_played_file = self.store.session_played_file
+        self.assertTrue(self.store.advance_to_next())
+
+        restored_store = PlaylistStore(
+            state_file=self.state_file,
+            backup_file=self.backup_file,
+            session_archive_dir=self.session_archive_dir,
+        )
+        self.assertEqual(restored_store._previous_session_file, original_played_file)
+        self.assertEqual(restored_store._previous_session_count, 2)
+
+        with patch.object(
+            restored_store,
+            "_read_json_payload_unlocked",
+            wraps=restored_store._read_json_payload_unlocked,
+        ) as read_payload:
+            summaries = [restored_store.snapshot()["previous_session"] for _ in range(3)]
+
+        self.assertEqual(
+            summaries,
+            [{"available": True, "item_count": 2}] * 3,
+        )
+        self.assertFalse(
+            any(
+                invocation.args == (original_played_file,)
+                for invocation in read_payload.call_args_list
+            )
+        )
+
+    def test_previous_session_cache_clears_across_backup_lifecycle(self):
+        self.add_item("a", requester_name="A", song_key="song-a")
+        self.add_item("b", requester_name="B", song_key="song-b")
+
+        restored_store = PlaylistStore(
+            state_file=self.state_file,
+            backup_file=self.backup_file,
+            session_archive_dir=self.session_archive_dir,
+        )
+        self.assertEqual(restored_store._previous_session_count, 1)
+        self.assertTrue(restored_store.restore_backup())
+        self.assert_previous_session_cleared(restored_store)
+
+        discarded_store = PlaylistStore(
+            state_file=self.state_file,
+            backup_file=self.backup_file,
+            session_archive_dir=self.session_archive_dir,
+        )
+        self.assertEqual(discarded_store._previous_session_count, 1)
+        self.assertTrue(discarded_store.discard_backup())
+        self.assert_previous_session_cleared(discarded_store)
+
+        reset_store = PlaylistStore(
+            state_file=self.state_file,
+            backup_file=self.backup_file,
+            session_archive_dir=self.session_archive_dir,
+        )
+        self.assertEqual(reset_store._previous_session_count, 1)
+        reset_store.reset_runtime_data()
+        self.assert_previous_session_cleared(reset_store)
+
+    def test_continue_previous_session_revalidates_cached_archive(self):
+        self.add_item("a", requester_name="A", song_key="song-a")
+        self.mark_started("a")
+        original_played_file = self.store.session_played_file
+        self.assertTrue(self.store.advance_to_next())
+        valid_payload = original_played_file.read_text(encoding="utf-8")
+        empty_payload = json.loads(valid_payload)
+        empty_payload["items"] = []
+
+        mutations = {
+            "deleted": lambda: original_played_file.unlink(),
+            "malformed": lambda: original_played_file.write_text("{", encoding="utf-8"),
+            "empty": lambda: original_played_file.write_text(
+                json.dumps(empty_payload),
+                encoding="utf-8",
+            ),
+        }
+        for name, mutate in mutations.items():
+            with self.subTest(name=name):
+                original_played_file.write_text(valid_payload, encoding="utf-8")
+                restored_store = PlaylistStore(
+                    state_file=self.state_file,
+                    backup_file=self.backup_file,
+                    session_archive_dir=self.session_archive_dir,
+                )
+                self.assertEqual(restored_store._previous_session_count, 1)
+
+                mutate()
+
+                self.assertFalse(restored_store.continue_previous_session())
+                self.assert_previous_session_cleared(restored_store)
+                self.assertFalse(
+                    restored_store.snapshot()["previous_session"]["available"]
+                )
 
     def test_restore_backup_continues_existing_played_session_archive(self):
         self.add_item("a", requester_name="A", song_key="song-a")
@@ -549,9 +661,11 @@ class PlaylistStoreTest(unittest.TestCase):
             session_archive_dir=self.session_archive_dir,
         )
 
+        self.assertEqual(restored_store._previous_session_count, 1)
         self.assertTrue(restored_store.restore_backup())
         self.assertEqual(restored_store.session_played_file, original_played_file)
         self.assertEqual([entry.item_id for entry in restored_store.session_played], ["a"])
+        self.assert_previous_session_cleared(restored_store)
         self.assertFalse(restored_store.snapshot()["previous_session"]["available"])
 
         restored_store.mark_item_playback_started("a")


### PR DESCRIPTION
## Summary
- Caches the previous-session archive path and item count during startup discovery.
- Removes previous-session filesystem reads and JSON parsing from the high-frequency snapshot polling path.
- Preserves action-time archive re-reading and validation before continuing a session.

## Root cause
`PlaylistStore.snapshot()` called `_previous_session_summary_unlocked()` on every state poll, and that summary re-read and parsed the candidate archive while holding the store lock.

## Safety
- Maintains the invariant that a missing candidate path always has a cached count of zero.
- Centralizes all lifecycle invalidation through one unlocked helper.
- Keeps candidate ordering, archive validity checks, and user-visible behavior unchanged.
- Does not modify Rust migration status or begin Phase 2 Items 7 or 8.

## Tests
- Verifies startup caches the selected archive path and exact item count.
- Spies on three consecutive snapshots and proves the previous-session archive is never read.
- Covers new-queue, restore, discard, reset, successful continue, deleted file, malformed JSON, and empty-entry invalidation.
- Confirms successful continuation still restores the original archive without re-queueing old songs and appends later played items to that archive.

## Validation
- `python -m unittest discover -s tests -v` — passed, 607 tests.
- `BILIKARA_REQUIRE_RUST_LIB=1 python -m unittest discover -s tests -v` — passed, 607 tests with the real release native library.
- `python -m compileall -q bilikara` — passed.
- `python -m py_compile start_bilikara.py build_bundle.py` — passed.
- `cd rust && cargo fmt --check && cargo clippy --all-targets --locked -- -D warnings && cargo test --locked && cargo build --release --locked` — passed, 164 tests.
- `cd src-tauri && cargo fmt --check && cargo clippy --all-targets --locked -- -D warnings && cargo test --locked && cargo build --release --locked` — passed.
- `npx --yes --package=node@20 --package=npm@10 --call='node --version && npm --version && npm ci && npm run build'` — passed with Node v20.20.2 and npm 10.9.8.
- `git diff --check` — passed.