### PR TITLE
fix: validate audio duration against original track

### DIFF
--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -5,6 +5,7 @@ from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
 import ctypes
 from datetime import datetime
 import json
+import math
 import os
 import platform
 import queue
@@ -66,6 +67,7 @@ CACHE_RETENTION_BUFFER_ITEMS = 3
 MAX_PARALLEL_TRACK_DOWNLOADS = 4
 DOWNKYI_TRACK_MAX_ATTEMPTS = 10
 DOWNKYI_TRACK_RETRY_WAIT_SECONDS = 3.0
+SOURCE_AUDIO_DURATION_TOLERANCE_SECONDS = 2.0
 try:
     ARIA2_CONNECTIONS_PER_TRACK = max(
         1,
@@ -1855,7 +1857,6 @@ class CacheManager:
                     "stream_kind": "audio",
                     "page": page,
                     "cid": self._cid_for_validation(item, page),
-                    "expected_duration": self._duration_for_page(item, page),
                     "download_source": download_source,
                     "stream_metadata": next(
                         (track.get("stream_metadata") or {} for track in audio_tracks if int(track["page"]) == page),
@@ -2635,6 +2636,16 @@ class CacheManager:
                             attempt=attempt,
                             max_attempts=max_attempts,
                         )
+                        assert ffprobe_path is not None
+                        source_audio_duration = None
+                        if stream_kind == "audio":
+                            source_audio_duration = self._probe_original_audio_duration(
+                                ffprobe_path,
+                                ffmpeg_path,
+                                media_path,
+                                label=validation_label,
+                                log_path=log_path,
+                            )
                         self._normalize_downkyi_media_file(
                             ffmpeg_path,
                             media_path,
@@ -2642,7 +2653,6 @@ class CacheManager:
                             stream_kind=stream_kind,
                             log_path=log_path,
                         )
-                        assert ffprobe_path is not None
                         validation_entry: dict[str, object] = {
                             "label": validation_label,
                             "path": media_path,
@@ -2650,10 +2660,13 @@ class CacheManager:
                             "stream_kind": stream_kind,
                             "page": page,
                             "cid": cid,
-                            "expected_duration": self._duration_for_page(item, page),
                             "download_source": DOWNLOAD_SOURCE_DOWNKYI,
                             "stream_metadata": dict(stream_metadata),
                         }
+                        if stream_kind == "video":
+                            validation_entry["expected_duration"] = self._duration_for_page(item, page)
+                        if source_audio_duration is not None:
+                            validation_entry["source_audio_duration"] = source_audio_duration
                         metadata = self._validate_media_file(
                             ffprobe_path,
                             ffmpeg_path,
@@ -2669,6 +2682,9 @@ class CacheManager:
                             "stream_kind": stream_kind,
                             "expected_duration": self._optional_probe_float(
                                 validation_entry.get("expected_duration")
+                            ),
+                            "source_audio_duration": self._optional_probe_float(
+                                validation_entry.get("source_audio_duration")
                             ),
                         })
                         track["validation_metadata"] = metadata
@@ -3812,6 +3828,9 @@ class CacheManager:
                         "page": int(entry.get("page") or 0),
                         "stream_kind": str(entry.get("stream_kind") or ""),
                         "expected_duration": self._optional_probe_float(entry.get("expected_duration")),
+                        "source_audio_duration": self._optional_probe_float(
+                            entry.get("source_audio_duration")
+                        ),
                     }
                 )
                 validation_metadata.append(metadata)
@@ -3828,7 +3847,6 @@ class CacheManager:
                     f"[{self._log_timestamp()}] ffprobe validate {label}: failed: {message}",
                 )
 
-        validation_errors.extend(self._duration_pair_errors(validation_metadata))
         cache_result["validation_metadata"] = validation_metadata
         cache_result["validation_failure_count"] = len(validation_errors)
         if validation_errors:
@@ -3840,17 +3858,15 @@ class CacheManager:
             raise DownloadCommandError("；".join(validation_errors))
         self._append_log_line(log_path, f"[{self._log_timestamp()}] ffprobe validate: ok")
 
-    def _validate_media_file(
+    def _probe_media_payload(
         self,
         ffprobe_path: Path,
         ffmpeg_path: Path,
         media_path: Path,
         *,
         label: str,
-        required_streams: set[str],
         log_path: Path,
-        diagnostic_context: dict[str, object] | None = None,
-    ) -> dict[str, object]:
+    ) -> tuple[int, dict[str, object]]:
         if not media_path.exists():
             raise DownloadCommandError(f"缓存校验失败: {label} 文件不存在")
         size = media_path.stat().st_size
@@ -3892,7 +3908,49 @@ class CacheManager:
             payload = json.loads(process.stdout or "{}")
         except json.JSONDecodeError as exc:
             raise DownloadCommandError(f"缓存校验失败: {label}: ffprobe 输出无法解析") from exc
+        if not isinstance(payload, dict):
+            raise DownloadCommandError(f"缓存校验失败: {label}: ffprobe 输出结构无效")
+        return size, payload
 
+    def _probe_original_audio_duration(
+        self,
+        ffprobe_path: Path,
+        ffmpeg_path: Path,
+        media_path: Path,
+        *,
+        label: str,
+        log_path: Path,
+    ) -> float:
+        _size, payload = self._probe_media_payload(
+            ffprobe_path,
+            ffmpeg_path,
+            media_path,
+            label=f"{label} 原始音轨",
+            log_path=log_path,
+        )
+        duration = self._probe_stream_duration(payload, "audio")
+        if duration is None:
+            raise DownloadCommandError(f"缓存校验失败: {label} 原始音轨未报告有效时长")
+        self._append_log_line(
+            log_path,
+            f"[{self._log_timestamp()}] ffprobe source audio {label}: duration={duration:.6f}s",
+        )
+        return duration
+
+    def _validate_media_file(
+        self,
+        ffprobe_path: Path,
+        ffmpeg_path: Path,
+        media_path: Path,
+        *,
+        label: str,
+        required_streams: set[str],
+        log_path: Path,
+        diagnostic_context: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        size, payload = self._probe_media_payload(
+            ffprobe_path, ffmpeg_path, media_path, label=label, log_path=log_path
+        )
         streams = payload.get("streams")
         if not isinstance(streams, list) or not streams:
             raise DownloadCommandError(f"缓存校验失败: {label}: 未识别到媒体流")
@@ -3910,7 +3968,13 @@ class CacheManager:
                 f"缓存校验失败: {label}: 缺少 {missing_label} 流，实际为 {detected_label}"
             )
 
-        duration = self._probe_duration(payload)
+        primary_stream_kind = next(iter(required_streams)) if len(required_streams) == 1 else None
+        stream_duration = (
+            self._probe_stream_duration(payload, primary_stream_kind)
+            if primary_stream_kind is not None
+            else None
+        )
+        duration = stream_duration or self._probe_duration(payload)
         context = diagnostic_context or {}
         expected_duration = self._optional_probe_float(context.get("expected_duration"))
         if expected_duration is not None and expected_duration > 0 and duration is None:
@@ -3923,6 +3987,23 @@ class CacheManager:
                 raise DownloadCommandError(
                     f"缓存校验失败: {label} 时长异常，预期约 {expected_duration:.0f} 秒，"
                     f"实际 {duration:.0f} 秒"
+                )
+        if "source_audio_duration" in context:
+            source_audio_duration = self._optional_probe_float(context.get("source_audio_duration"))
+            if (
+                required_streams != {"audio"}
+                or source_audio_duration is None
+                or source_audio_duration <= 0
+            ):
+                raise DownloadCommandError(f"缓存校验失败: {label} 原始音轨时长上下文无效")
+            if stream_duration is None:
+                raise DownloadCommandError(f"缓存校验失败: {label} 未报告音频流时长")
+            difference = abs(stream_duration - source_audio_duration)
+            if difference > SOURCE_AUDIO_DURATION_TOLERANCE_SECONDS:
+                raise DownloadCommandError(
+                    f"缓存校验失败: {label} 与原始音轨时长不一致，"
+                    f"原始 {source_audio_duration:.3f} 秒，实际 {stream_duration:.3f} 秒，"
+                    f"相差 {difference:.3f} 秒"
                 )
         if str(context.get("download_source") or "") == DOWNLOAD_SOURCE_DOWNKYI:
             self._validate_demux_file(
@@ -3949,6 +4030,8 @@ class CacheManager:
                 "codec_tag_string": str(stream.get("codec_tag_string") or ""),
                 "duration": self._optional_probe_float(stream.get("duration")),
                 "start_time": self._optional_probe_float(stream.get("start_time")),
+                "duration_ts": stream.get("duration_ts"),
+                "time_base": str(stream.get("time_base") or ""),
             }
             for stream in streams
             if isinstance(stream, dict)
@@ -3976,6 +4059,7 @@ class CacheManager:
                 "expected_output": str(media_path),
                 "actual_output": str(media_path),
                 "file_size": size,
+                "source_audio_duration": self._optional_probe_float(context.get("source_audio_duration")),
                 "aria2_control_files": [
                     candidate.name
                     for candidate in media_path.parent.glob("*.aria2")
@@ -3993,41 +4077,6 @@ class CacheManager:
     @staticmethod
     def _duration_tolerance(expected_duration: float) -> float:
         return max(3.0, expected_duration * 0.02)
-
-    @classmethod
-    def _duration_pair_errors(cls, metadata: list[dict[str, object]]) -> list[str]:
-        videos = [entry for entry in metadata if entry.get("stream_kind") == "video"]
-        audios = [entry for entry in metadata if entry.get("stream_kind") == "audio"]
-        errors: list[str] = []
-        for audio in audios:
-            audio_duration = cls._optional_probe_float(audio.get("duration"))
-            if audio_duration is None:
-                continue
-            audio_page = int(audio.get("page") or 0)
-            audio_expected = cls._optional_probe_float(audio.get("expected_duration"))
-            for video in videos:
-                video_duration = cls._optional_probe_float(video.get("duration"))
-                if video_duration is None:
-                    continue
-                video_page = int(video.get("page") or 0)
-                video_expected = cls._optional_probe_float(video.get("expected_duration"))
-                expected_match = (
-                    audio_expected is not None
-                    and video_expected is not None
-                    and abs(audio_expected - video_expected)
-                    <= cls._duration_tolerance(max(audio_expected, video_expected))
-                )
-                if audio_page != video_page and not expected_match:
-                    continue
-                tolerance = cls._duration_tolerance(video_duration)
-                if audio_duration + tolerance < video_duration:
-                    label = str(audio.get("label") or f"音轨 P{audio_page}")
-                    errors.append(
-                        f"缓存校验失败: {label} 比视频轨明显更短，"
-                        f"视频 {video_duration:.0f} 秒，音频 {audio_duration:.0f} 秒"
-                    )
-                break
-        return errors
 
     @staticmethod
     def _discard_invalid_media(media_path: Path) -> None:
@@ -4091,31 +4140,68 @@ class CacheManager:
 
     @staticmethod
     def _optional_probe_float(value: object) -> float | None:
+        if isinstance(value, bool):
+            return None
         try:
             result = float(value)
         except (TypeError, ValueError):
             return None
-        return result if result == result else None
+        return result if math.isfinite(result) else None
 
-    @staticmethod
-    def _probe_duration(payload: dict[str, object]) -> float | None:
-        candidates: list[object] = []
-        file_format = payload.get("format")
-        if isinstance(file_format, dict):
-            candidates.append(file_format.get("duration"))
+    @classmethod
+    def _probe_stream_duration(
+        cls,
+        payload: dict[str, object],
+        stream_kind: str,
+    ) -> float | None:
+        streams = payload.get("streams")
+        if not isinstance(streams, list):
+            return None
+        for stream in streams:
+            if (
+                not isinstance(stream, dict)
+                or str(stream.get("codec_type") or "").strip() != stream_kind
+            ):
+                continue
+            duration = cls._optional_probe_float(stream.get("duration"))
+            if duration is not None and duration > 0:
+                return duration
+            duration_ts = cls._optional_probe_float(stream.get("duration_ts"))
+            time_base = str(stream.get("time_base") or "").strip()
+            if duration_ts is None or duration_ts <= 0 or "/" not in time_base:
+                continue
+            numerator_text, denominator_text = time_base.split("/", 1)
+            numerator = cls._optional_probe_float(numerator_text)
+            denominator = cls._optional_probe_float(denominator_text)
+            if (
+                numerator is None
+                or numerator <= 0
+                or denominator is None
+                or denominator <= 0
+            ):
+                continue
+            reconstructed = duration_ts * numerator / denominator
+            if math.isfinite(reconstructed) and reconstructed > 0:
+                return reconstructed
+        return None
+
+    @classmethod
+    def _probe_duration(cls, payload: dict[str, object]) -> float | None:
         streams = payload.get("streams")
         if isinstance(streams, list):
-            candidates.extend(
-                stream.get("duration")
+            stream_kinds = [
+                str(stream.get("codec_type") or "").strip()
                 for stream in streams
                 if isinstance(stream, dict)
-            )
-        for candidate in candidates:
-            try:
-                duration = float(candidate)
-            except (TypeError, ValueError):
-                continue
-            if duration > 0:
+            ]
+            for stream_kind in stream_kinds:
+                duration = cls._probe_stream_duration(payload, stream_kind)
+                if duration is not None:
+                    return duration
+        file_format = payload.get("format")
+        if isinstance(file_format, dict):
+            duration = cls._optional_probe_float(file_format.get("duration"))
+            if duration is not None and duration > 0:
                 return duration
         return None
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -15,7 +15,14 @@ from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from bilikara.cache import CacheManager, DOWNLOAD_SOURCE_DOWNKYI, DOWNLOAD_SOURCE_YTDLP, DownloadCommandError, VIDEO_QUALITY_CHOICES
+from bilikara.cache import (
+    CacheManager,
+    DOWNLOAD_SOURCE_DOWNKYI,
+    DOWNLOAD_SOURCE_YTDLP,
+    DownloadCommandError,
+    SOURCE_AUDIO_DURATION_TOLERANCE_SECONDS,
+    VIDEO_QUALITY_CHOICES,
+)
 from bilikara.models import PlaylistItem
 from bilikara.store import PlaylistStore
 
@@ -2098,6 +2105,9 @@ class CacheManagerPolicyTest(unittest.TestCase):
         self.assertNotIn("media_url", result["audio_variants"][0])
         validation_labels = [entry["label"] for entry in result["validation_files"]]
         self.assertEqual(validation_labels, ["视频轨 P1", "音轨 P1"])
+        video_validation, audio_validation = result["validation_files"]
+        self.assertIn("expected_duration", video_validation)
+        self.assertNotIn("expected_duration", audio_validation)
 
     def test_download_selected_streams_records_page_for_single_p2_audio_binding(self):
         item_dir = self.cache_dir / "song-a"
@@ -2304,10 +2314,12 @@ class CacheManagerMediaIntegrityEvidenceTest(unittest.TestCase):
             "codec_name": "h264" if kind == "video" else "aac",
             "codec_tag_string": "avc1" if kind == "video" else "mp4a",
             "start_time": "0.000000",
+            "time_base": "1/1000",
         }
         file_format = {"format_name": "mov,mp4,m4a", "start_time": "0.000000"}
         if duration is not None:
             stream["duration"] = duration
+            stream["duration_ts"] = str(round(float(duration) * 1000))
             file_format["duration"] = duration
         return {"streams": [stream], "format": file_format}
 
@@ -2376,6 +2388,94 @@ class CacheManagerMediaIntegrityEvidenceTest(unittest.TestCase):
         self.assertEqual(result["start_time"], 0.0)
         self.assertEqual(result["streams"][0]["codec_name"], "h264")
         self.assertEqual(result["streams"][0]["codec_tag_string"], "avc1")
+        self.assertEqual(result["streams"][0]["duration_ts"], "120500")
+        self.assertEqual(result["streams"][0]["time_base"], "1/1000")
+
+    def test_audio_stream_duration_does_not_use_video_or_container_duration(self):
+        payload = {
+            "streams": [
+                {"codec_type": "video", "duration": "243.0"},
+                {"codec_type": "audio", "duration": "87.0"},
+            ],
+            "format": {"duration": "243.0"},
+        }
+
+        self.assertEqual(CacheManager._probe_stream_duration(payload, "audio"), 87.0)
+        self.assertEqual(CacheManager._probe_stream_duration(payload, "video"), 243.0)
+
+    def test_original_audio_probe_uses_audio_stream_not_container_duration(self):
+        media = self.cache_dir / "song" / "raw-audio.m4a"
+        media.parent.mkdir(parents=True)
+        media.write_bytes(b"raw")
+        payload = {
+            "streams": [
+                {"codec_type": "video", "duration": "243.0"},
+                {"codec_type": "audio", "duration": "87.0"},
+            ],
+            "format": {"duration": "243.0"},
+        }
+        with patch.object(CacheManager, "_worker_loop", lambda self: None):
+            manager = self._manager()
+            try:
+                with patch(
+                    "bilikara.cache.subprocess.run",
+                    return_value=SimpleNamespace(
+                        returncode=0,
+                        stdout=json.dumps(payload),
+                        stderr="",
+                    ),
+                ):
+                    duration = manager._probe_original_audio_duration(
+                        Path("/tools/ffprobe"),
+                        Path("/tools/ffmpeg"),
+                        media,
+                        label="音轨 P1",
+                        log_path=self.log_path,
+                    )
+            finally:
+                manager.shutdown()
+
+        self.assertEqual(duration, 87.0)
+
+    def test_stream_duration_reconstructs_from_duration_ts_and_time_base(self):
+        payload = {
+            "streams": [{
+                "codec_type": "audio",
+                "duration_ts": "459020",
+                "time_base": "1/44100",
+            }],
+            "format": {"duration": "99.0"},
+        }
+
+        self.assertAlmostEqual(
+            CacheManager._probe_stream_duration(payload, "audio"),
+            459020 / 44100,
+            places=9,
+        )
+
+    def test_stream_duration_rejects_invalid_or_non_finite_values(self):
+        invalid_payloads = [
+            {"streams": [{"codec_type": "audio", "duration": "nan"}]},
+            {"streams": [{"codec_type": "audio", "duration": "inf"}]},
+            {
+                "streams": [{
+                    "codec_type": "audio",
+                    "duration_ts": "100",
+                    "time_base": "1/0",
+                }]
+            },
+            {
+                "streams": [{
+                    "codec_type": "audio",
+                    "duration_ts": True,
+                    "time_base": "1/1000",
+                }]
+            },
+        ]
+
+        for payload in invalid_payloads:
+            with self.subTest(payload=payload):
+                self.assertIsNone(CacheManager._probe_stream_duration(payload, "audio"))
 
     def test_validation_error_prevents_cache_result_acceptance(self):
         media = self.cache_dir / "song" / "audio.m4a"
@@ -2408,11 +2508,21 @@ class CacheManagerMediaIntegrityEvidenceTest(unittest.TestCase):
             finally:
                 manager.shutdown()
 
-    def test_ffprobe_missing_duration_is_rejected(self):
-        self._assert_duration_rejected("audio", None, expected=120)
+    def test_source_audio_missing_stream_duration_is_rejected(self):
+        with self.assertRaisesRegex(DownloadCommandError, "未报告音频流时长"):
+            self._validate_source_audio_duration(None, source_duration=120.0)
 
-    def test_audio_significantly_shorter_than_expected_is_rejected(self):
-        self._assert_duration_rejected("audio", "87", expected=243)
+    def test_source_audio_duration_accepts_observed_remux_delta(self):
+        result = self._validate_source_audio_duration("118.0", source_duration=120.0)
+        self.assertEqual(result["duration"], 118.0)
+
+    def test_source_audio_duration_rejects_shorter_output_beyond_tolerance(self):
+        with self.assertRaisesRegex(DownloadCommandError, "与原始音轨时长不一致"):
+            self._validate_source_audio_duration("117.999", source_duration=120.0)
+
+    def test_source_audio_duration_rejects_longer_output_beyond_tolerance(self):
+        with self.assertRaisesRegex(DownloadCommandError, "与原始音轨时长不一致"):
+            self._validate_source_audio_duration("122.001", source_duration=120.0)
 
     def test_video_significantly_shorter_than_expected_is_rejected(self):
         self._assert_duration_rejected("video", "87", expected=243)
@@ -2463,7 +2573,7 @@ class CacheManagerMediaIntegrityEvidenceTest(unittest.TestCase):
                             required_streams={"audio"},
                             log_path=self.log_path,
                             diagnostic_context={
-                                "expected_duration": 120,
+                                "source_audio_duration": 120,
                                 "download_source": DOWNLOAD_SOURCE_DOWNKYI,
                                 "stream_kind": "audio",
                             },
@@ -2524,6 +2634,56 @@ class CacheManagerMediaIntegrityEvidenceTest(unittest.TestCase):
         self.assertEqual(command[command.index("-map") + 1], "0:a:0")
         self.assertNotIn("-movflags", command)
 
+    def test_real_aac_remux_preserves_original_audio_duration_when_available(self):
+        ffmpeg = shutil.which("ffmpeg")
+        ffprobe = shutil.which("ffprobe")
+        if not ffmpeg or not ffprobe:
+            self.skipTest("ffmpeg/ffprobe unavailable")
+        media = self.cache_dir / "song" / ".attempt-test" / "audio-p1.m4a"
+        media.parent.mkdir(parents=True)
+        generated = subprocess.run([
+            ffmpeg, "-v", "error", "-y", "-f", "lavfi", "-i",
+            "sine=frequency=440:sample_rate=44100:duration=1.2",
+            "-vn", "-c:a", "aac", "-movflags", "frag_keyframe+empty_moov",
+            str(media),
+        ], capture_output=True, text=True, check=False)
+        if generated.returncode != 0:
+            self.skipTest(f"AAC fixture generation unavailable: {generated.stderr[:120]}")
+
+        with patch.object(CacheManager, "_worker_loop", lambda self: None):
+            manager = self._manager()
+            try:
+                source_duration = manager._probe_original_audio_duration(
+                    Path(ffprobe),
+                    Path(ffmpeg),
+                    media,
+                    label="音轨 P1",
+                    log_path=self.log_path,
+                )
+                manager._normalize_downkyi_media_file(
+                    Path(ffmpeg),
+                    media,
+                    label="音轨 P1",
+                    stream_kind="audio",
+                    log_path=self.log_path,
+                )
+                metadata = manager._validate_media_file(
+                    Path(ffprobe),
+                    Path(ffmpeg),
+                    media,
+                    label="音轨 P1",
+                    required_streams={"audio"},
+                    log_path=self.log_path,
+                    diagnostic_context={"source_audio_duration": source_duration},
+                )
+            finally:
+                manager.shutdown()
+
+        self.assertLessEqual(
+            abs(float(metadata["duration"]) - source_duration),
+            SOURCE_AUDIO_DURATION_TOLERANCE_SECONDS,
+        )
+
     def test_downkyi_remux_failure_keeps_raw_file_and_rejects_cache(self):
         media = self.cache_dir / "song" / ".attempt-test" / "audio-p1.m4a"
         media.parent.mkdir(parents=True)
@@ -2576,13 +2736,95 @@ class CacheManagerMediaIntegrityEvidenceTest(unittest.TestCase):
             finally:
                 manager.shutdown()
 
-    def test_matching_page_audio_shorter_than_video_is_rejected(self):
-        errors = CacheManager._duration_pair_errors([
-            {"label": "视频轨 P1", "stream_kind": "video", "page": 1, "duration": 243.0},
-            {"label": "音轨 P1", "stream_kind": "audio", "page": 1, "duration": 87.0},
-        ])
-        self.assertEqual(len(errors), 1)
-        self.assertIn("比视频轨明显更短", errors[0])
+    def test_audio_duration_is_not_compared_with_video_duration(self):
+        video = self.cache_dir / "song" / "video.mp4"
+        audio = self.cache_dir / "song" / "audio.m4a"
+        video.parent.mkdir(parents=True)
+        video.write_bytes(b"video")
+        audio.write_bytes(b"audio")
+        cache_result = {
+            "validation_files": [
+                {
+                    "path": video,
+                    "label": "视频轨 P1",
+                    "required_streams": {"video"},
+                    "stream_kind": "video",
+                    "page": 1,
+                    "expected_duration": 243,
+                },
+                {
+                    "path": audio,
+                    "label": "音轨 P1",
+                    "required_streams": {"audio"},
+                    "stream_kind": "audio",
+                    "page": 1,
+                },
+            ]
+        }
+        probes = [
+            SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(self._probe_payload("video", "243")),
+                stderr="",
+            ),
+            SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(self._probe_payload("audio", "87")),
+                stderr="",
+            ),
+        ]
+
+        with patch.object(CacheManager, "_worker_loop", lambda self: None):
+            manager = self._manager()
+            try:
+                with patch.object(
+                    manager,
+                    "_ffprobe_path_for_ffmpeg",
+                    return_value=Path("/tools/ffprobe"),
+                ), patch("bilikara.cache.subprocess.run", side_effect=probes):
+                    manager._validate_cache_result(
+                        "song", cache_result, Path("/tools/ffmpeg"), self.log_path
+                    )
+            finally:
+                manager.shutdown()
+
+        self.assertEqual(cache_result["validation_failure_count"], 0)
+        self.assertEqual(
+            [entry["duration"] for entry in cache_result["validation_metadata"]],
+            [243.0, 87.0],
+        )
+
+    def _validate_source_audio_duration(
+        self,
+        actual: str | None,
+        *,
+        source_duration: float,
+    ) -> dict[str, object]:
+        media = self.cache_dir / "song" / "source-audio.m4a"
+        media.parent.mkdir(parents=True, exist_ok=True)
+        media.write_bytes(b"media")
+        with patch.object(CacheManager, "_worker_loop", lambda self: None):
+            manager = self._manager()
+            try:
+                with patch(
+                    "bilikara.cache.subprocess.run",
+                    return_value=SimpleNamespace(
+                        returncode=0,
+                        stdout=json.dumps(self._probe_payload("audio", actual)),
+                        stderr="",
+                    ),
+                ):
+                    return manager._validate_media_file(
+                        Path("/tools/ffprobe"),
+                        Path("/tools/ffmpeg"),
+                        media,
+                        label="音轨 P1",
+                        required_streams={"audio"},
+                        log_path=self.log_path,
+                        diagnostic_context={"source_audio_duration": source_duration},
+                    )
+            finally:
+                manager.shutdown()
 
     def _assert_duration_rejected(self, kind: str, actual: str | None, *, expected: float) -> None:
         extension = ".mp4" if kind == "video" else ".m4a"
@@ -3087,6 +3329,7 @@ class CacheManagerDownkyiRegressionTest(unittest.TestCase):
         item = self._single_downkyi_item("async-validation")
         video_validated = threading.Event()
         download_counts = {"video": 0, "audio": 0}
+        audio_steps = []
 
         def fake_download(_item_id, _binary, _ffmpeg, target_dir, _log, **kwargs):
             kind = kwargs["stream_kind"]
@@ -3099,9 +3342,24 @@ class CacheManagerDownkyiRegressionTest(unittest.TestCase):
             path.write_bytes(kind.encode("ascii"))
             return path
 
+        def fake_probe_source(_ffprobe, _ffmpeg, media_path, **_kwargs):
+            self.assertEqual(media_path.read_bytes(), b"audio")
+            audio_steps.append("source-probe")
+            return 120.125
+
+        def fake_normalize(_ffmpeg, _media_path, **kwargs):
+            if kwargs["stream_kind"] == "audio":
+                audio_steps.append("normalize")
+
         def fake_validate(_ffprobe, _ffmpeg, media_path, **kwargs):
-            if kwargs["diagnostic_context"]["stream_kind"] == "video":
+            context = kwargs["diagnostic_context"]
+            if context["stream_kind"] == "video":
                 video_validated.set()
+                self.assertNotIn("source_audio_duration", context)
+            else:
+                audio_steps.append("validate")
+                self.assertEqual(context["source_audio_duration"], 120.125)
+                self.assertNotIn("expected_duration", context)
             return {
                 "path": str(media_path),
                 "size": media_path.stat().st_size,
@@ -3124,7 +3382,9 @@ class CacheManagerDownkyiRegressionTest(unittest.TestCase):
                 ), patch.object(
                     manager, "_download_stream_with_aria2c", side_effect=fake_download
                 ), patch.object(
-                    manager, "_normalize_downkyi_media_file"
+                    manager, "_probe_original_audio_duration", side_effect=fake_probe_source
+                ), patch.object(
+                    manager, "_normalize_downkyi_media_file", side_effect=fake_normalize
                 ), patch.object(
                     manager, "_validate_media_file", side_effect=fake_validate
                 ):
@@ -3147,6 +3407,7 @@ class CacheManagerDownkyiRegressionTest(unittest.TestCase):
         self.assertEqual(set(result), {"video-p1", "audio-p1"})
         self.assertEqual(download_counts, {"video": 1, "audio": 1})
         self.assertTrue(video_validated.is_set())
+        self.assertEqual(audio_steps, ["source-probe", "normalize", "validate"])
 
     def test_downkyi_retries_only_failed_track_and_caps_total_attempts_at_ten(self):
         item = self._single_downkyi_item("track-retry")
@@ -3190,6 +3451,8 @@ class CacheManagerDownkyiRegressionTest(unittest.TestCase):
                     manager, "_ffprobe_path_for_ffmpeg", return_value=Path("/tools/ffprobe")
                 ), patch.object(
                     manager, "_download_stream_with_aria2c", side_effect=fake_download
+                ), patch.object(
+                    manager, "_probe_original_audio_duration", return_value=120.0
                 ), patch.object(
                     manager, "_normalize_downkyi_media_file"
                 ), patch.object(


### PR DESCRIPTION
## Summary
- Validates normalized DownKyi audio against the duration of the original downloaded audio track.
- Uses the audio stream duration rather than video, page, or container duration.
- Applies a fixed 2-second absolute tolerance in both directions.

## Root cause
Audio duration validation previously reused page/video duration and also compared audio directly with the matching video track. Original audio tracks can legitimately have a different duration, so those comparisons could reject valid media.

## Behavior
- Probes the original audio stream before normalization.
- Uses `stream.duration`, with `duration_ts × time_base` as the fallback.
- Re-probes the normalized output and rejects differences greater than 2 seconds.
- Keeps the existing FFmpeg full-demux validation.
- Keeps existing coarse page-duration validation for video only.
- Does not invent an expected audio duration for BBDown or yt-dlp outputs where no separate original track is available.

## Validation
- `python -m unittest tests.test_cache.CacheManagerMediaIntegrityEvidenceTest -v` — 25 passed.
- `BILIKARA_REQUIRE_RUST_LIB=1 python -m unittest discover -s tests -v` — 614 passed.
- `python -m compileall -q bilikara` — passed.
- `python -m py_compile start_bilikara.py build_bundle.py` — passed.
- Rust domain fmt, Clippy, tests (164), and release build — passed.
- Tauri fmt, Clippy, tests, and release build — passed.
- Node.js 20/npm 10 `npm ci && npm run build` — passed; DEB, RPM, and AppImage generated.
- `git diff --check` — passed.
