### PR TITLE
fix(export): retain backend and keep stdout draining

### DIFF
--- a/bilikara/server.py
+++ b/bilikara/server.py
@@ -107,6 +107,7 @@ RATING_PROMPT_THRESHOLD = 0.5
 REMOTE_IDENTITY_COOKIE = "bilikara_remote_token"
 REMOTE_IDENTITY_COOKIE_MAX_AGE = 365 * 24 * 60 * 60
 CONTAINER_RUNTIME_MARKERS = ("docker", "containerd", "kubepods", "lxc")
+LOCAL_EXPORT_SHUTDOWN_GRACE_SECONDS = 10.0
 
 
 def _player_diagnostic_number(value: object) -> float | None:
@@ -324,6 +325,9 @@ class AppContext:
         self._client_seen_once = False
         self._no_clients_since: float | None = None
         self._shutdown_requested = False
+        self._active_local_exports = 0
+        self._local_export_idle = threading.Event()
+        self._local_export_idle.set()
         self._client_grace_seconds = 4.0
         self._client_stale_seconds = 120.0
         self._client_watchdog: threading.Thread | None = None
@@ -888,6 +892,8 @@ class AppContext:
             self._host_seen_once = False
             self._no_clients_since = None
             self._shutdown_requested = False
+            self._active_local_exports = 0
+            self._local_export_idle.set()
         with self._remote_access_lock:
             self._remote_access = self._build_remote_access_payload(self._host, self._port, [])
         self._start_background_tasks_once()
@@ -915,6 +921,9 @@ class AppContext:
             self._state_change_condition.notify_all()
 
     def _request_update_restart(self) -> None:
+        self._request_server_shutdown(delay_seconds=0.5, thread_name="bilikara-update-restart")
+
+    def _request_server_shutdown(self, *, delay_seconds: float = 0.0, thread_name: str) -> None:
         with self._client_lock:
             server = self._server
             self._shutdown_requested = True
@@ -922,26 +931,35 @@ class AppContext:
             return
 
         def shutdown_server() -> None:
-            time.sleep(0.5)
+            if delay_seconds:
+                time.sleep(delay_seconds)
+            self._local_export_idle.wait(timeout=LOCAL_EXPORT_SHUTDOWN_GRACE_SECONDS)
             server.shutdown()
 
         threading.Thread(
             target=shutdown_server,
             daemon=True,
-            name="bilikara-update-restart",
+            name=thread_name,
         ).start()
 
     def request_shutdown(self) -> None:
+        self._request_server_shutdown(thread_name="bilikara-api-shutdown")
+
+    def begin_local_export(self) -> bool:
         with self._client_lock:
-            server = self._server
-            self._shutdown_requested = True
-        if server is None:
-            return
-        threading.Thread(
-            target=server.shutdown,
-            daemon=True,
-            name="bilikara-api-shutdown",
-        ).start()
+            if self._closed or self._shutdown_requested:
+                return False
+            self._active_local_exports += 1
+            self._local_export_idle.clear()
+            return True
+
+    def finish_local_export(self) -> None:
+        with self._client_lock:
+            if self._active_local_exports <= 0:
+                return
+            self._active_local_exports -= 1
+            if not self._active_local_exports:
+                self._local_export_idle.set()
 
     def touch_client(self, client_id: str, is_host: bool = True) -> None:
         client_key = str(client_id or "").strip()
@@ -955,7 +973,6 @@ class AppContext:
                 self._host_seen_once = True
             self._client_seen_once = True
             self._no_clients_since = None
-            self._shutdown_requested = False
 
     def disconnect_client(self, client_id: str) -> None:
         client_key = str(client_id or "").strip()
@@ -974,6 +991,7 @@ class AppContext:
     def _client_watchdog_loop(self) -> None:
         while not self._closed:
             time.sleep(1.0)
+            should_shutdown = False
             with self._client_lock:
                 # 注意：这里改成了依赖 self._host_seen_once
                 if not self._shutdown_on_last_client or not self._host_seen_once or self._shutdown_requested:
@@ -989,11 +1007,12 @@ class AppContext:
                     continue
                 if now - self._no_clients_since < self._client_grace_seconds:
                     continue
-                server = self._server
-                if server is None:
+                if self._server is None:
                     continue
                 self._shutdown_requested = True
-            threading.Thread(target=server.shutdown, daemon=True).start()
+                should_shutdown = True
+            if should_shutdown:
+                self._request_server_shutdown(thread_name="bilikara-api-shutdown")
 
     def _prune_stale_clients(self, now: float) -> None:
         expired = [
@@ -1082,6 +1101,30 @@ atexit.register(CONTEXT.shutdown)
 
 class BilikaraHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
+
+    def handle_one_request(self) -> None:
+        self._local_export_lease_active = False
+        self._local_export_lease_rejected = False
+        try:
+            super().handle_one_request()
+        finally:
+            if self._local_export_lease_active:
+                self._local_export_lease_active = False
+                CONTEXT.finish_local_export()
+
+    def parse_request(self) -> bool:
+        if not super().parse_request():
+            return False
+        route = urlparse(self.path).path
+        is_local_export = (
+            self.command == "GET" and route == "/api/playlist/export"
+        ) or (
+            self.command == "POST" and route == "/api/diagnostics/package"
+        )
+        if is_local_export and self._is_local_client():
+            self._local_export_lease_active = CONTEXT.begin_local_export()
+            self._local_export_lease_rejected = not self._local_export_lease_active
+        return True
 
     def do_HEAD(self) -> None:  # noqa: N802
         route = urlparse(self.path).path
@@ -1323,6 +1366,12 @@ class BilikaraHandler(BaseHTTPRequestHandler):
                 "payload_size": 0,
             }
             self._log_export_stage("export_request_started", export_context)
+            if getattr(self, "_local_export_lease_rejected", False):
+                self._write_json(
+                    {"ok": False, "error": "服务正在关闭，无法开始导出"},
+                    status=HTTPStatus.SERVICE_UNAVAILABLE,
+                )
+                return
             source_settings = {
                 "history": {
                     "items": lambda: CONTEXT.history_snapshot(),
@@ -1447,6 +1496,12 @@ class BilikaraHandler(BaseHTTPRequestHandler):
                         error=PermissionError("remote client rejected"),
                     )
                     self._write_json({"ok": False, "error": "forbidden"}, status=HTTPStatus.FORBIDDEN)
+                    return
+                if getattr(self, "_local_export_lease_rejected", False):
+                    self._write_json(
+                        {"ok": False, "error": "服务正在关闭，无法开始导出"},
+                        status=HTTPStatus.SERVICE_UNAVAILABLE,
+                    )
                     return
                 self._log_diagnostics_stage("diagnostics_authorized", diagnostic_context)
                 try:

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1648,6 +1648,10 @@ fn write_and_flush_ready_marker<W: io::Write>(mut writer: W, base_url: &str) -> 
     writer.flush()
 }
 
+fn forward_backend_stdout_line<W: Write>(mut writer: W, line: &str) {
+    let _ = writeln!(writer, "Backend stdout: {line}");
+}
+
 fn drain_backend_stdout<R, FReady, FOutput>(
     reader: R,
     mut on_ready: FReady,
@@ -1964,7 +1968,7 @@ fn main() {
                     },
                     |line| {
                         push_backend_tail(&stdout_tail_for_reader, line.clone());
-                        println!("Backend stdout: {line}");
+                        forward_backend_stdout_line(io::stdout(), &line);
                     },
                 );
                 if let Err(error) = result {
@@ -2811,6 +2815,40 @@ mod tests {
             output[3].contains("9090"),
             "duplicate readiness is still drained"
         );
+    }
+
+    #[test]
+    fn stdout_reader_keeps_draining_after_desktop_stdout_breaks() {
+        struct BrokenPipeWriter {
+            writes: usize,
+        }
+
+        impl Write for BrokenPipeWriter {
+            fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
+                self.writes += 1;
+                Err(io::ErrorKind::BrokenPipe.into())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut writer = BrokenPipeWriter { writes: 0 };
+        let mut drained = Vec::new();
+
+        drain_backend_stdout(
+            Cursor::new(b"first\nsecond\n"),
+            |_| panic!("unexpected ready marker"),
+            |line| {
+                forward_backend_stdout_line(&mut writer, &line);
+                drained.push(line);
+            },
+        )
+        .expect("backend stdout reaches EOF");
+
+        assert_eq!(writer.writes, 2);
+        assert_eq!(drained, ["first", "second"]);
     }
 
     #[test]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -10,7 +10,7 @@ use std::io::{self, BufRead, BufReader, Read, Write};
 use std::net::{Shutdown, TcpStream};
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::Manager;
@@ -35,6 +35,7 @@ const MAX_BACKEND_OUTPUT_CHARS: usize = 2_048;
 const MAX_BACKEND_TAIL_LINES: usize = 40;
 const MAX_DESKTOP_STARTUP_LOG_BYTES: u64 = 512 * 1024;
 const BACKEND_READY_TIMEOUT: Duration = Duration::from_secs(90);
+const ACTIVE_BACKEND_DOWNLOAD_SHUTDOWN_GRACE: Duration = Duration::from_secs(10);
 const DESKTOP_STARTUP_LOG_NAME: &str = "desktop-startup.log";
 
 #[derive(Debug, PartialEq, Eq)]
@@ -137,6 +138,24 @@ struct BackendProcess {
     child: Arc<Mutex<Option<Child>>>,
     base_url: Arc<Mutex<Option<String>>>,
     shutdown_token: String,
+    active_downloads: Arc<AtomicUsize>,
+}
+
+struct ActiveBackendDownloadGuard {
+    active_downloads: Arc<AtomicUsize>,
+}
+
+impl ActiveBackendDownloadGuard {
+    fn acquire(active_downloads: Arc<AtomicUsize>) -> Self {
+        active_downloads.fetch_add(1, Ordering::AcqRel);
+        Self { active_downloads }
+    }
+}
+
+impl Drop for ActiveBackendDownloadGuard {
+    fn drop(&mut self) {
+        self.active_downloads.fetch_sub(1, Ordering::AcqRel);
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -1110,9 +1129,14 @@ async fn save_backend_download(
 
     let endpoint = validated.path.clone();
     let worker_endpoint = endpoint.clone();
+    // Acquire before scheduling the worker, then move the lease into it. This
+    // keeps WindowEvent::Destroyed from shutting down Python before the export
+    // request has reached its handler, even if the invoke future is cancelled.
+    let active_download_guard = ActiveBackendDownloadGuard::acquire(state.active_downloads.clone());
 
     // Stage 3 & 4: request_backend and validate_response
     let fetch_res = tauri::async_runtime::spawn_blocking(move || {
+        let _active_download_guard = active_download_guard;
         let mut worker_timings = Vec::new();
         // Stage 3: request_backend
         let t_req = Instant::now();
@@ -1478,6 +1502,16 @@ fn wait_for_child_exit(child: &mut Child, timeout: Duration) -> bool {
     }
 }
 
+fn wait_for_active_backend_downloads(active_downloads: &AtomicUsize, timeout: Duration) {
+    let deadline = Instant::now() + timeout;
+    while active_downloads.load(Ordering::Acquire) > 0 {
+        if Instant::now() >= deadline {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
 fn sanitized_diagnostic_line(line: &str) -> String {
     let mut sanitized = line
         .chars()
@@ -1812,6 +1846,7 @@ fn main() {
                 child: child_arc.clone(),
                 base_url: base_url.clone(),
                 shutdown_token: shutdown_token.clone(),
+                active_downloads: Arc::new(AtomicUsize::new(0)),
             });
 
             if let Some(stderr) = stderr {
@@ -2043,6 +2078,10 @@ fn main() {
             if let tauri::WindowEvent::Destroyed = event
                 && let Some(state) = window.try_state::<BackendProcess>()
             {
+                wait_for_active_backend_downloads(
+                    &state.active_downloads,
+                    ACTIVE_BACKEND_DOWNLOAD_SHUTDOWN_GRACE,
+                );
                 let shutdown_url = state
                     .base_url
                     .lock()
@@ -2660,6 +2699,46 @@ mod tests {
         let error = request_backend_download(&format!("http://127.0.0.1:{port}"), &request)
             .expect_err("closed port must fail");
         assert!(error.starts_with("无法连接本机后端："));
+    }
+
+    #[test]
+    fn window_shutdown_waits_for_the_in_flight_download_transport() {
+        let active_downloads = Arc::new(AtomicUsize::new(0));
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let downloads_for_worker = active_downloads.clone();
+        let worker = thread::spawn(move || {
+            let _guard = ActiveBackendDownloadGuard::acquire(downloads_for_worker);
+            started_tx.send(()).expect("notify worker start");
+            release_rx.recv().expect("wait for worker release");
+        });
+        started_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("worker must hold the download lease");
+
+        let (finished_tx, finished_rx) = std::sync::mpsc::channel();
+        let downloads_for_waiter = active_downloads.clone();
+        let waiter = thread::spawn(move || {
+            wait_for_active_backend_downloads(&downloads_for_waiter, Duration::from_secs(1));
+            finished_tx.send(()).expect("notify waiter completion");
+        });
+        assert!(finished_rx.recv_timeout(Duration::from_millis(50)).is_err());
+        release_tx.send(()).expect("release worker");
+        finished_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("waiter must proceed after the transport completes");
+        worker.join().expect("join worker");
+        waiter.join().expect("join waiter");
+    }
+
+    #[test]
+    fn window_shutdown_download_wait_is_bounded() {
+        let active_downloads = AtomicUsize::new(1);
+        let started = Instant::now();
+
+        wait_for_active_backend_downloads(&active_downloads, Duration::from_millis(40));
+
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
 
     #[test]

--- a/tests/test_native_export_shutdown.py
+++ b/tests/test_native_export_shutdown.py
@@ -1,0 +1,330 @@
+import json
+import multiprocessing
+import os
+import socket
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+
+def _run_native_export_shutdown_fixture(
+    runtime_home: str,
+    export_kind: str,
+    shutdown_token: str,
+    listener: socket.socket,
+    readiness,
+) -> None:
+    """Run the real handler in a spawned child without inheriting test threads."""
+
+    os.environ.update(
+        {
+            "BILIKARA_HOME": runtime_home,
+            "BILIKARA_LAUNCH_MODE": "tauri",
+            "BILIKARA_SHUTDOWN_TOKEN": shutdown_token,
+            # This child isolates HTTP lifecycle behavior; it does not exercise
+            # Rust policy loading and must remain portable across CI layouts.
+            "BILIKARA_REQUIRE_RUST_LIB": "0",
+            "BILIKARA_RUST_STRICT_EQUIVALENCE": "0",
+        }
+    )
+
+    def send_stage(stage: str) -> None:
+        readiness.send(("stage", stage))
+
+    try:
+        send_stage("BOOTSTRAP")
+        from http.server import ThreadingHTTPServer
+
+        send_stage("BEFORE_SERVER_IMPORT")
+        import bilikara.server as server_module
+        from bilikara.diagnostics import DiagnosticArtifact
+        send_stage("SERVER_IMPORTED")
+
+        context = server_module.CONTEXT
+        original_do_get = server_module.BilikaraHandler.do_GET
+        original_do_post = server_module.BilikaraHandler.do_POST
+        entered = threading.Event()
+        release = threading.Event()
+        fixture_state_path = "/__test_native_export_shutdown/state"
+        fixture_release_path = "/__test_native_export_shutdown/release"
+        send_stage("FIXTURE_STATE_READY")
+
+        server_module.BilikaraHandler._log_export_stage = lambda *args, **kwargs: None
+        server_module.BilikaraHandler._log_diagnostics_stage = lambda *args, **kwargs: None
+
+        def do_get(handler):
+            route = handler.path.split("?", 1)[0]
+            if route == fixture_state_path:
+                handler._write_json({"ok": True, "entered": entered.is_set()})
+                return
+            if route == "/api/playlist/export":
+                entered.set()
+                release.wait(timeout=30)
+            return original_do_get(handler)
+
+        def do_post(handler):
+            route = handler.path.split("?", 1)[0]
+            if route == fixture_release_path:
+                release.set()
+                handler._write_json({"ok": True})
+                return
+            if route == "/api/diagnostics/package":
+                entered.set()
+                release.wait(timeout=30)
+            return original_do_post(handler)
+        send_stage("HANDLERS_READY")
+
+        if export_kind == "png":
+            server_module.playlist_image_export = lambda *args, **kwargs: (
+                b"\\x89PNG\\r\\n\\x1a\\nfixture",
+                "image/png",
+                "playlist.png",
+            )
+        elif export_kind == "zip":
+            server_module.playlist_image_export = lambda *args, **kwargs: (
+                b"PK\\x03\\x04fixture",
+                "application/zip",
+                "playlist.zip",
+            )
+        send_stage("PAYLOAD_STUBBED")
+
+        context.history_snapshot = lambda: [{"title": "shutdown test", "requested_at": 1.0}]
+        context.session_played_snapshot = context.history_snapshot
+        context.build_diagnostics = lambda *args, **kwargs: DiagnosticArtifact(
+            markdown="# shutdown test",
+            files={"system.json": b"{}"},
+        )
+        server_module.BilikaraHandler.do_GET = do_get
+        server_module.BilikaraHandler.do_POST = do_post
+        # macOS CI can block indefinitely in the spawned child's HTTPServer
+        # bind path. The parent binds the disposable loopback port and
+        # multiprocessing transfers the listener to retain the real
+        # ThreadingHTTPServer request/daemon-thread/shutdown behavior.
+        send_stage("BEFORE_SERVER_BIND")
+        server = ThreadingHTTPServer(
+            listener.getsockname(),
+            server_module.BilikaraHandler,
+            bind_and_activate=False,
+        )
+        server.socket.close()
+        server.socket = listener
+        server.server_address = listener.getsockname()
+        server.server_name = "localhost"
+        server.server_port = server.server_address[1]
+        send_stage("SERVER_BOUND")
+        # The fixture initializes only the server ownership request_shutdown()
+        # consumes. bind_server() additionally launches unrelated UI startup
+        # work, outside this handler/shutdown race.
+        with context._client_lock:
+            context._server = server
+            context._shutdown_on_last_client = False
+            context._shutdown_requested = False
+            context._active_local_exports = 0
+            if hasattr(context, "_local_export_idle"):
+                context._local_export_idle.set()
+        readiness.send(("ready", server.server_address[1]))
+        readiness.close()
+        try:
+            server.serve_forever()
+        finally:
+            context.shutdown()
+            server.server_close()
+    except BaseException as exc:
+        try:
+            readiness.send(("error", type(exc).__name__))
+        except (BrokenPipeError, EOFError, OSError):
+            pass
+        readiness.close()
+        raise
+
+
+class NativeExportShutdownLeaseTest(unittest.TestCase):
+    """Exercise a real daemon handler paused after request parsing."""
+
+    ROOT = Path(__file__).resolve().parents[1]
+    FIXTURE_STATE_PATH = "/__test_native_export_shutdown/state"
+    FIXTURE_RELEASE_PATH = "/__test_native_export_shutdown/release"
+    SHUTDOWN_TOKEN = "native-export-shutdown-test-token"
+
+    @staticmethod
+    def _request(port: int, method: str, path: str, body: bytes = b"") -> bytes:
+        request = (
+            f"{method} {path} HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{port}\r\n"
+            "Connection: close\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            + ("Content-Type: application/json\r\n" if body else "")
+            + "\r\n"
+        ).encode("ascii") + body
+        with socket.create_connection(("127.0.0.1", port), timeout=10) as stream:
+            stream.sendall(request)
+            stream.shutdown(socket.SHUT_WR)
+            response = bytearray()
+            while chunk := stream.recv(64 * 1024):
+                response.extend(chunk)
+        return bytes(response)
+
+    @staticmethod
+    def _wait_for_fixture_ready(readiness, process) -> int:
+        deadline = time.monotonic() + 10
+        last_stage = "NONE"
+        while time.monotonic() < deadline:
+            if not readiness.poll(max(0.0, deadline - time.monotonic())):
+                break
+            try:
+                event, value = readiness.recv()
+            except EOFError as exc:
+                raise AssertionError(
+                    "fixture closed before becoming ready "
+                    f"(exit {process.exitcode}, stage={last_stage})"
+                ) from exc
+            if event == "stage":
+                last_stage = str(value)
+                continue
+            if event == "ready" and isinstance(value, int) and 1 <= value <= 65535:
+                return value
+            raise AssertionError(
+                "fixture failed before becoming ready "
+                f"(exit {process.exitcode}, event={event!r}, stage={last_stage})"
+            )
+        raise AssertionError(
+            "fixture did not become ready within 10 seconds "
+            f"(exit {process.exitcode}, stage={last_stage})"
+        )
+
+    @classmethod
+    def _wait_for_dispatch(cls, port: int) -> None:
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline:
+            try:
+                response = cls._request(port, "GET", cls.FIXTURE_STATE_PATH)
+            except OSError:
+                time.sleep(0.05)
+                continue
+            header_end = response.find(b"\r\n\r\n")
+            if response.startswith(b"HTTP/1.1 200 OK\r") and header_end >= 0:
+                state = json.loads(response[header_end + 4 :].decode("utf-8"))
+                if state.get("entered") is True:
+                    return
+            time.sleep(0.05)
+        raise AssertionError("export handler did not reach the post-parse barrier")
+
+    @classmethod
+    def _release_dispatch(cls, port: int) -> None:
+        response = cls._request(port, "POST", cls.FIXTURE_RELEASE_PATH, b"{}")
+        if not response.startswith(b"HTTP/1.1 200 OK\r"):
+            raise AssertionError("fixture did not release the paused export handler")
+
+    @staticmethod
+    def _read_export(port: int, method: str, path: str, body: bytes, result: dict[str, bytes]) -> None:
+        request = (
+            f"{method} {path} HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{port}\r\n"
+            "Connection: close\r\n"
+            "X-Bilikara-Client: native-export-shutdown-test\r\n"
+            f"Content-Length: {len(body)}\r\n"
+            + ("Content-Type: application/json\r\n" if method == "POST" else "")
+            + "\r\n"
+        ).encode("ascii") + body
+        with socket.create_connection(("127.0.0.1", port), timeout=10) as stream:
+            stream.sendall(request)
+            stream.shutdown(socket.SHUT_WR)
+            response = bytearray()
+            while chunk := stream.recv(64 * 1024):
+                response.extend(chunk)
+        result["response"] = bytes(response)
+
+    @classmethod
+    def _request_shutdown(cls, port: int) -> None:
+        request = (
+            "POST /api/app/shutdown HTTP/1.1\r\n"
+            f"Host: 127.0.0.1:{port}\r\n"
+            "Connection: close\r\n"
+            "Content-Type: application/json\r\n"
+            f"X-Bilikara-Shutdown-Token: {cls.SHUTDOWN_TOKEN}\r\n"
+            "Content-Length: 2\r\n\r\n{}"
+        ).encode("ascii")
+        with socket.create_connection(("127.0.0.1", port), timeout=10) as stream:
+            stream.sendall(request)
+            stream.shutdown(socket.SHUT_WR)
+            while stream.recv(64 * 1024):
+                pass
+
+    @staticmethod
+    def _content_length_matches(response: bytes) -> bool:
+        header_end = response.find(b"\r\n\r\n")
+        if header_end < 0:
+            return False
+        for line in response[:header_end].split(b"\r\n")[1:]:
+            if line.lower().startswith(b"content-length:"):
+                return len(response) - header_end - 4 == int(line.split(b":", 1)[1].strip())
+        return False
+
+    def _run_case(self, kind: str, method: str, path: str, body: bytes, content_type: bytes) -> None:
+        with tempfile.TemporaryDirectory(prefix="bilikara-native-export-shutdown-") as runtime_home:
+            context = multiprocessing.get_context("spawn")
+            readiness, child_readiness = context.Pipe(duplex=False)
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+                listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                listener.bind(("127.0.0.1", 0))
+                listener.listen()
+                process = context.Process(
+                    target=_run_native_export_shutdown_fixture,
+                    args=(runtime_home, kind, self.SHUTDOWN_TOKEN, listener, child_readiness),
+                )
+                process.start()
+                child_readiness.close()
+                try:
+                    port = self._wait_for_fixture_ready(readiness, process)
+                    received: dict[str, bytes] = {}
+                    client = threading.Thread(
+                        target=self._read_export,
+                        args=(port, method, path, body, received),
+                    )
+                    client.start()
+                    self._wait_for_dispatch(port)
+
+                    self._request_shutdown(port)
+                    # v0.7.1 exits while its daemon export handler is still paused,
+                    # producing a clean empty response. The lease must keep the
+                    # server alive until the admitted export completes.
+                    process.join(timeout=1)
+                    self.assertTrue(
+                        process.is_alive(),
+                        f"shutdown ended the admitted export (exit {process.exitcode})",
+                    )
+                    self._release_dispatch(port)
+                    client.join(10)
+                    self.assertFalse(client.is_alive())
+                    response = received.get("response", b"")
+                    self.assertEqual(response[:16], b"HTTP/1.1 200 OK\r")
+                    self.assertIn(content_type, response.split(b"\r\n\r\n", 1)[0])
+                    self.assertTrue(self._content_length_matches(response))
+                    process.join(timeout=10)
+                    self.assertFalse(process.is_alive())
+                    self.assertEqual(process.exitcode, 0)
+                finally:
+                    readiness.close()
+                    if process.is_alive():
+                        process.terminate()
+                        process.join(timeout=10)
+                    if process.is_alive():
+                        process.kill()
+                        process.join(timeout=10)
+
+    def test_shutdown_waits_for_each_native_export(self):
+        cases = (
+            ("csv", "GET", "/api/playlist/export?format=csv&source=history", b"", b"Content-Type: text/csv; charset=utf-8"),
+            ("png", "GET", "/api/playlist/export?format=image&source=history&page_size=80", b"", b"Content-Type: image/png"),
+            ("zip", "GET", "/api/playlist/export?format=image&source=history&page_size=80", b"", b"Content-Type: application/zip"),
+            ("diagnostics", "POST", "/api/diagnostics/package", b'{"browser":{}}', b"Content-Type: application/zip"),
+        )
+        for case in cases:
+            with self.subTest(kind=case[0]):
+                self._run_case(*case)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -852,6 +852,11 @@ class AppContextClientTrackingTest(unittest.TestCase):
         context._client_seen_once = False
         context._no_clients_since = None
         context._shutdown_requested = False
+        context._closed = False
+        context._active_local_exports = 0
+        context._local_export_idle = threading.Event()
+        context._local_export_idle.set()
+        context._server = None
         context._client_stale_seconds = 120.0
         return context
 
@@ -866,6 +871,40 @@ class AppContextClientTrackingTest(unittest.TestCase):
         self.assertIn("remote-client", context._client_last_seen)
         self.assertEqual(context._host_client_last_seen, {})
         self.assertIsNotNone(context._no_clients_since)
+
+    def test_shutdown_waits_for_the_active_local_export(self):
+        context = self.make_context()
+        shutdown_called = threading.Event()
+        context._server = SimpleNamespace(shutdown=shutdown_called.set)
+
+        self.assertTrue(context.begin_local_export())
+        context.request_shutdown()
+        self.assertFalse(shutdown_called.wait(0.05))
+
+        context.touch_client("host-client", is_host=True)
+        self.assertFalse(context.begin_local_export())
+
+        context.finish_local_export()
+        self.assertTrue(shutdown_called.wait(1))
+
+    def test_rejected_local_export_cannot_reopen_shutdown_admission(self):
+        context = self.make_context()
+        context.request_shutdown()
+
+        self.assertFalse(context.begin_local_export())
+        context.touch_client("host-client", is_host=True)
+
+        self.assertFalse(context.begin_local_export())
+
+    def test_shutdown_wait_is_bounded_when_an_export_stalls(self):
+        context = self.make_context()
+        shutdown_called = threading.Event()
+        context._server = SimpleNamespace(shutdown=shutdown_called.set)
+
+        self.assertTrue(context.begin_local_export())
+        with patch.object(server_module, "LOCAL_EXPORT_SHUTDOWN_GRACE_SECONDS", 0.05):
+            context.request_shutdown()
+            self.assertTrue(shutdown_called.wait(1))
 
 
 class RunDefaultsTest(unittest.TestCase):


### PR DESCRIPTION
## Status

This PR contains two narrowly separated export reliability fixes:

1. defensive shutdown/export lifecycle hardening; and
2. a minimal fix for a reproduced backend stdout-drain failure mechanism.

The stdout mechanism is reproduced and corrected, but the event that caused a real user's outer stdout consumer to disappear after hours of use remains unproven. The shutdown race and the field-visible error must therefore remain separate claims.

## What changed

- Tauri acquires a native-download lease before scheduling the blocking backend request and retains the backend while that transport is in flight.
- The Python Host admits local playlist and diagnostics exports through an export lease, rejects new local exports after shutdown is scheduled, and lets already-admitted exports finish during the grace period.
- Shutdown intent is monotonic once scheduled: later Host polling or a rejected export request cannot reopen export admission while the shutdown worker remains committed.
- Python and Tauri shutdown waits remain capped at 10 seconds, so a stalled export cannot block application exit indefinitely.
- Tauri now treats forwarding child output to its own stdout as best-effort. If the desktop stdout sink becomes unavailable, the reader continues draining the Python child pipe instead of panicking and closing it.
- Existing response validation remains strict.

## Reproduced stdout failure mechanism

Before the second fix, the following production chain was reproduced in the same live Tauri WebView without reload, window destruction, update, or application shutdown:

1. An outer stdout consumer disappeared while Tauri and the Python backend remained alive.
2. `println!("Backend stdout: ...")` received `BrokenPipe` and panicked in the backend stdout reader thread.
3. Dropping that reader closed the Python child's stdout pipe.
4. The next CSV or image export raised `BrokenPipeError` in its first stage log, before sending response headers.
5. Tauri received 0 response bytes and displayed `[validate_response] 后端返回了无效的 HTTP 响应`.
6. Immediate health and state requests still returned HTTP 200, while a second export failed again.

After the fix, closing the same outer consumer leaves the child pipe reader alive. CSV, image, and a second CSV export all return complete HTTP 200 responses and save successfully; health and state remain available.

## Proven defensive shutdown issues

- Explicit application shutdown could race an admitted export before response headers were emitted.
- Client activity could previously clear `_shutdown_requested` after shutdown was already scheduled, reopening admission without cancelling the committed shutdown worker.
- Focused regressions verify that existing exports can finish, new exports remain rejected after shutdown intent is committed, and all waits stay bounded.

## Still unproven

- Which terminal, launcher, log collector, or operating-system event caused the field user's stdout consumer to disappear naturally after hours of use.
- That normal Remote activity, recaching, player reset, language switching, or ordinary network fluctuation triggers the stdout failure.
- That the defensive shutdown race caused the field-visible error.

## Scope boundaries

- No retry or fallback.
- No alternate backend or transport.
- No browser-download fallback.
- No relaxed response validation.
- No new state, thread, timeout, or lifecycle abstraction for the stdout fix.
- No change to either 10-second shutdown grace period.
- No version bump, release, tag, or merge.

## Validation

Validated against tree `6cb23131df55b2844a454f6b07fa06415468a72b` and head `b0b4a747094e057d3e51361ef149ed30847ec773`:

- `cargo fmt --check` (`src-tauri`): passed.
- `cargo clippy --all-targets --locked -- -D warnings` (`src-tauri`): passed.
- `cargo test --locked` (`src-tauri`): 28 passed, 0 skipped.
- Focused BrokenPipe regression: 1 passed, 0 skipped.
- `cargo fmt --check`, clippy, tests, and release build (`rust`): passed; 205 tests passed.
- Python full suite with the native Rust library required: 1050 passed, 6 environment-specific skips.
- Focused export/shutdown/frontend/diagnostic Python suites: 130 passed, 0 skipped.
- Patched live Tauri production-chain test: CSV, PNG, and CSV retry all saved after the outer stdout consumer closed; no panic, BrokenPipe, reader exit, or invalid HTTP response.
- Local `npm run build`: passed and produced Linux deb, rpm, and AppImage bundles.
- `git diff --check`: passed.

- Automatic PR CI [run 32035150433](https://github.com/VZRXS/bilikara/actions/runs/32035150433): Ubuntu, Windows, and macOS tests passed.
- Manually dispatched CI and bundle [run 32035258696](https://github.com/VZRXS/bilikara/actions/runs/32035258696), attempt 2: all three test jobs and all four bundle jobs passed; Windows x64/ARM64 and macOS ARM64/Intel artifacts were uploaded.
- Release upload and R2 mirroring remained skipped because this is a branch run, not a release tag.

## Commit structure

1. `34441fa` — `fix(export): retain backend during native response`
2. `b0b4a74` — `fix(export): keep backend stdout draining`

## Summary by Sourcery

Harden export and shutdown lifecycle handling while keeping backend stdout draining resilient to a closed desktop output sink.

Bug Fixes:
- Prevent backend shutdown from interrupting admitted native, playlist, and diagnostics exports.
- Keep draining backend stdout when the desktop stdout sink closes, preventing child-pipe closure and subsequent export failures.

Enhancements:
- Make shutdown admission monotonic and ensure shutdown waits for active exports only within the existing bounded grace period.

Tests:
- Add regression coverage for bounded shutdown waits, export completion during shutdown, and continued stdout draining after BrokenPipe.