### PR TITLE
chore(release): prepare v0.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bilikara-tauri",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bilikara-tauri",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "engines": {
         "node": ">=24"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bilikara-tauri",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "author": "VZRXS",
   "engines": {
     "node": ">=24"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "bilikara_rust"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "regex",
  "serde",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bilikara_rust"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 rust-version = "1.85"
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -117,7 +117,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bilikara"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "objc2",
  "objc2-web-kit",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bilikara"
-version = "0.7.1"
+version = "0.7.2"
 description = "Bilikara Tauri MVP"
 authors = ["VZRXS"]
 edition = "2024"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "bilikara",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "com.bilikara.app",
   "build": {
     "beforeDevCommand": "",

--- a/tests/test_release_version_consistency.py
+++ b/tests/test_release_version_consistency.py
@@ -11,7 +11,7 @@ import build_bundle
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "0.7.1"
+EXPECTED_VERSION = "0.7.2"
 
 
 class ReleaseVersionConsistencyTest(unittest.TestCase):
@@ -36,9 +36,9 @@ class ReleaseVersionConsistencyTest(unittest.TestCase):
         self.assertEqual(package_lock["packages"][""]["version"], EXPECTED_VERSION)
 
     def test_bundle_and_windows_versions_use_release_representation(self):
-        with patch.dict(os.environ, {"BILIKARA_VERSION": "v0.7.1"}, clear=False):
-            self.assertEqual(build_bundle._bundle_version(), "v0.7.1")
-        self.assertEqual(build_bundle._windows_version_tuple("v0.7.1"), (0, 7, 1, 0))
+        with patch.dict(os.environ, {"BILIKARA_VERSION": "v0.7.2"}, clear=False):
+            self.assertEqual(build_bundle._bundle_version(), "v0.7.2")
+        self.assertEqual(build_bundle._windows_version_tuple("v0.7.2"), (0, 7, 2, 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Prepare the stable v0.7.2 release from the accepted PR #95 export fixes.

- bump application, Rust Core, Tauri, and npm metadata from 0.7.1 to 0.7.2
- update the release-version consistency expectations
- add no behavioral changes

## Validation

- Rust Core: formatting, warning-free clippy, 205 tests, locked release build
- Python: 1,050 tests passed with 6 environment-specific skips; compile checks passed with the native library required
- Tauri: formatting, warning-free clippy, 28 tests, locked release build
- Frontend/assets: `npm ci` and `npm run build` passed; Linux deb, rpm, and AppImage bundles produced
- `git diff --check` passed

The Windows x64, Windows ARM64, macOS ARM64, and macOS Intel workflow bundle matrix will be required on this exact head before merge.

## Summary by Sourcery

Prepare the project metadata and release checks for the stable v0.7.2 release.

Build:
- Bump application, Rust Core, Tauri, npm, and bundle metadata to version 0.7.2.

Tests:
- Update release-version consistency tests for v0.7.2.