### PR TITLE
fix(runtime): audit original PR #94 merge

### DIFF
--- a/.github/workflows/ci-bundle.yml
+++ b/.github/workflows/ci-bundle.yml
@@ -130,17 +130,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          for ($attempt = 1; $attempt -le 3; $attempt++) {
-            choco install ffmpeg -y --no-progress
-            if ((Get-Command ffmpeg -ErrorAction SilentlyContinue) -and
-                (Get-Command ffprobe -ErrorAction SilentlyContinue)) {
-              break
-            }
-            if ($attempt -eq 3) {
-              throw "Chocolatey did not install ffmpeg and ffprobe after $attempt attempts"
-            }
-            Start-Sleep -Seconds (5 * $attempt)
-          }
+          choco install ffmpeg -y --no-progress
           ffmpeg -version
           ffprobe -version
 

--- a/.github/workflows/ci-bundle.yml
+++ b/.github/workflows/ci-bundle.yml
@@ -387,8 +387,28 @@ jobs:
           file "$embedded_backend/Contents/MacOS/bilikara"
           test "$(lipo -archs dist_release/Bilikara-Desktop.app/Contents/MacOS/bilikara)" = "$(lipo -archs "$embedded_backend/Contents/MacOS/bilikara")"
 
+          echo "=== Locked aria2c metadata-only checks ==="
+          aria2_metadata="$embedded_backend/Contents/Resources/vendor/aria2-macos.json"
+          test -f "$aria2_metadata"
+          expected_arch="$(python -c "import platform; m=platform.machine().lower(); print('x64' if m in ('amd64','x86_64','x64') else 'arm64')")"
+          python -c 'import json,sys; data=json.load(open(sys.argv[1], encoding="utf-8")); assert data["schema_version"] == 2; assert data["arch"] == sys.argv[2]; assert data["url"].startswith("https://"); assert len(data["sha256"]) == 64; print("locked aria2c metadata: arch={} sha256={}".format(data["arch"], data["sha256"]))' "$aria2_metadata" "$expected_arch"
+          unexpected_aria2="$(find dist_release -type f \( -name aria2c -o -name aria2c.exe \) -print)"
+          if [ -n "$unexpected_aria2" ]; then
+            echo "Unexpected bundled aria2c executable candidate(s):" >&2
+            printf '%s\n' "$unexpected_aria2" >&2
+            exit 1
+          fi
+
+          echo "=== Packaged portable FFmpeg checks ==="
+          for binary_name in ffmpeg ffprobe; do
+            packaged_tool="dist_release/bilikara.app/Contents/Frameworks/vendor/$binary_name"
+            test -x "$packaged_tool"
+            "$packaged_tool" -version
+            /usr/bin/otool -L "$packaged_tool"
+          done
+
           echo "=== Running Python backend smoke test ==="
-          BILIKARA_REQUIRE_BACKEND_SMOKE=1 BILIKARA_TEST_BACKEND_EXE="$(pwd)/dist_release/bilikara.app/Contents/MacOS/bilikara" python -m unittest tests.test_macos_backend_smoke.MacOSBackendSmokeTest -v
+          BILIKARA_REQUIRE_ARIA2_TOOL_SMOKE=1 BILIKARA_REQUIRE_BACKEND_SMOKE=1 BILIKARA_TEST_BACKEND_EXE="$(pwd)/dist_release/bilikara.app/Contents/MacOS/bilikara" python -m unittest tests.test_macos_backend_smoke.MacOSBackendSmokeTest -v
 
           echo "=== Running Tauri/backend shell and Finder-like environment smoke tests ==="
           BILIKARA_TAURI_SMOKE_TIMEOUT_SECONDS=120 BILIKARA_REQUIRE_TAURI_SMOKE=1 BILIKARA_TEST_TAURI_EXE="$(pwd)/dist_release/Bilikara-Desktop.app/Contents/MacOS/bilikara" python -m unittest tests.test_macos_tauri_smoke.MacOSTauriSmokeTest -v
@@ -424,6 +444,25 @@ jobs:
           codesign --verify --deep --strict --verbose=4 test_extract/dist_release/Bilikara-Desktop.app
           codesign -dv --verbose=4 test_extract/dist_release/Bilikara-Desktop.app
           test "$(lipo -archs test_extract/dist_release/Bilikara-Desktop.app/Contents/MacOS/bilikara)" = "$(lipo -archs "$extracted_embedded_backend/Contents/MacOS/bilikara")"
+
+          extracted_aria2_metadata="$extracted_embedded_backend/Contents/Resources/vendor/aria2-macos.json"
+          test -f "$extracted_aria2_metadata"
+          python -c 'import json,sys; data=json.load(open(sys.argv[1], encoding="utf-8")); assert data["schema_version"] == 2; assert data["arch"] == sys.argv[2]; assert data["url"].startswith("https://"); assert len(data["sha256"]) == 64' "$extracted_aria2_metadata" "$(python -c "import platform; m=platform.machine().lower(); print('x64' if m in ('amd64','x86_64','x64') else 'arm64')")"
+          unexpected_aria2="$(find test_extract/dist_release -type f \( -name aria2c -o -name aria2c.exe \) -print)"
+          if [ -n "$unexpected_aria2" ]; then
+            echo "Unexpected archived aria2c executable candidate(s):" >&2
+            printf '%s\n' "$unexpected_aria2" >&2
+            exit 1
+          fi
+
+          echo "=== Running extracted portable FFmpeg checks ==="
+          for binary_name in ffmpeg ffprobe; do
+            packaged_tool="test_extract/dist_release/bilikara.app/Contents/Frameworks/vendor/$binary_name"
+            test -x "$packaged_tool"
+            "$packaged_tool" -version
+            /usr/bin/otool -L "$packaged_tool"
+          done
+
           echo "=== Running round-trip extracted shell and Finder-like smoke tests ==="
           BILIKARA_REQUIRE_BACKEND_SMOKE=1 BILIKARA_TEST_BACKEND_EXE="$(pwd)/test_extract/dist_release/bilikara.app/Contents/MacOS/bilikara" python -m unittest tests.test_macos_backend_smoke.MacOSBackendSmokeTest -v
           BILIKARA_TAURI_SMOKE_TIMEOUT_SECONDS=120 BILIKARA_REQUIRE_TAURI_SMOKE=1 BILIKARA_TEST_TAURI_EXE="$(pwd)/test_extract/dist_release/Bilikara-Desktop.app/Contents/MacOS/bilikara" python -m unittest tests.test_macos_tauri_smoke.MacOSTauriSmokeTest -v

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 ### 核心播放与缓存
 
 - 通过 B 站视频链接或 BV 号加入点歌列表（支持链接指定分 p），后台自动进入本地缓存流程
-- 本地播放由 Rust Native 下载与媒体后端缓存媒体，浏览器端使用分离视频 / 音频播放器同步播放
+- 默认由 BBDown 下载并交给 FFmpeg 处理缓存媒体；DownKyi / aria2c 与 Rust Native 是相互独立的可选下载源，浏览器端使用分离视频 / 音频播放器同步播放
 - 支持毫秒级音画延迟补偿、独立音量控制、静音，以及 -6 ~ +6 key 的音调调整（切歌时自动复位）
 - 音量、音画延迟、切歌延迟等播放器设置会本地记忆并在重新打开后恢复
 - 可设置 1 ~ 5 秒切歌延迟；切歌时显示过渡画面，包含即将播放、倒计时和后续点歌列表
@@ -229,7 +229,7 @@ CI 的正式打包流程会先构建 Python 后端包，再构建 Tauri 桌面�
 - 发布包元数据中的发布者 / CompanyName 设置为 `VZRXS`；Windows 安全提示中的“已验证发布者”仍需要代码签名证书
 - Tauri 桌面壳 `bilikara-desktop.exe` 会通过 `scripts/sign_windows.ps1` 签名；CI 可配置 `WINDOWS_SIGN_CERTIFICATE_BASE64` + `WINDOWS_SIGN_CERTIFICATE_PASSWORD`，也可改用 `WINDOWS_SIGN_CERTIFICATE_PATH` 或 `WINDOWS_SIGN_CERTIFICATE_THUMBPRINT`，未配置证书时会跳过签名并继续显示未知发布者
 - 打包后的 `data/`、日志、缓存和工具文件默认都会写到可写运行目录；macOS 使用 `~/Library/Application Support/bilikara/`，Windows 使用包内 `runtime/`；可通过 `BILIKARA_HOME` 指定其他目录
-- 打包脚本会构建并嵌入 `bilikara_rust` 与 `bilikara_runtime`；正式包不再包含 BBDown、FFmpeg、ffprobe 或 aria2c 可执行文件
+- 打包脚本会构建并嵌入 `bilikara_rust` 与 `bilikara_runtime`，并把经过验证的 `ffmpeg` / `ffprobe` 和按目标架构固定为 1.6.3 的 `BBDown` 放进不可变 vendor；正式包不内置 `aria2c`
 - Tauri 桌面壳启动后会拉起同目录或相邻目录里的 Python 后端包；开发模式下会回退到 `python start_bilikara.py`
 - 当前 Tauri 桌面版采用类似 sidecar 的 Python 后端进程方案；长期规划中，会考虑逐步将更适合桌面集成、进程管理和跨平台适配的能力迁移到 Rust / Tauri 侧
 - Windows 和 macOS 的最终包通常需要在各自系统上分别构建；也就是说，Windows 包最好在 Windows 上打，macOS 包最好在 macOS 上打
@@ -250,6 +250,9 @@ CI 的正式打包流程会先构建 Python 后端包，再构建 Tauri 桌面�
 - `BILIKARA_HOME`：自定义应用数据目录；不设置时，打包版默认写入应用目录内的 `runtime/`
 - `BILIKARA_MAX_CACHE_ITEMS`：自动缓存窗口大小，默认 `3`
 - `BILIKARA_BILIBILI_COOKIE`：用于获取会员清晰度或受限内容播放地址的 cookie
+- `BB_DOWN_PATH`：自定义本地 `BBDown` 可执行文件路径
+- `FFMPEG_PATH`：自定义本地 `ffmpeg` 可执行文件路径
+- `ARIA2C_PATH`：自定义实验性 DownKyi 下载源使用的 `aria2c` 可执行文件路径
 - `BILIKARA_STARTUP_LOG`：设为 `1` 时，启动日志会写入 `runtime/data/logs/startup.log`，用于排查打包版启动问题
 - `BILIKARA_RUST_STRICT_EQUIVALENCE`：设为 `1` 时，对已迁移能力同时运行 Rust 与 Python 参考实现并比较规范结果；仅建议用于测试、CI 和开发诊断
 - `BILIKARA_RUST_TIMING_DIAGNOSTICS`：设为 `1` 时，在后端状态中聚合 Rust FFI、JSON、Python 回退和严格等价检查耗时；默认关闭且不会逐调用打印日志
@@ -262,14 +265,14 @@ CI 的正式打包流程会先构建 Python 后端包，再构建 Tauri 桌面�
 - 桌面版使用 Tauri v2 / Rust 作为窗口壳，负责启动后端、承载本地 WebView，并在窗口关闭时请求后端退出
 - 当前桌面壳不是纯 Rust 后端：它会启动一个类似 sidecar 的 Python 后端进程，后端仍负责 HTTP API、缓存、下载和状态管理
 - Tauri 开发配置指向 `http://127.0.0.1:8080`，实际启动时会以 `--no-browser --headless --port 0` 拉起后端，并在收到 `bilikara.ready` 事件后跳转到真实本地地址
-- 播放流程以本地缓存和本地媒体播放为主，缓存媒体由 `bilikara_runtime` 直接下载、校验并重封装
-- Rust Native 以临时文件下载和完整 sample 校验后原子发布，视频输出使用 fast-start MP4
-- 当前原生媒体链路选择 AVC/H.264 视频和常规 AAC 音轨，以兼容 Windows WebView 与 macOS Safari；高解析音频设置不会让正式缓存链路回退到外部工具
-- 正式包不启动外部下载器或媒体工具进程
+- 播放流程以本地缓存和本地媒体播放为主；BBDown 是默认下载源，DownKyi / aria2c 与 Rust Native 是独立的可选下载源
+- Rust Native 由 `bilikara_runtime` 直接下载、校验并重封装媒体，以临时文件和完整 sample 校验后原子发布，视频输出使用 fast-start MP4
+- 当前原生媒体链路选择 AVC/H.264 视频以及常规 AAC 或可用的 Hi-Res FLAC 音轨；高解析音频处理失败时不会静默回退到外部工具
+- BBDown 源调用独立的 BBDown 与 FFmpeg / ffprobe 进程；DownKyi 源只在用户明确选择并准备 aria2c 后调用它；Rust Native 不会静默回退到 aria2c 或 Python 媒体实现
 - 手机访问 URL 的首选地址来自系统路由决定的源 IPv4；其他活动物理网卡地址可作为备用，虚拟和隧道地址会被降级
-- Rust Native 下载日志会写到应用数据目录下的 `data/logs/`
+- BBDown 与 Rust Native 下载日志会写到应用数据目录下的 `data/logs/`
 - 本次已唱记录会单独写入 `data/played_sessions/played-YYYY-MM-DD_HH-MM-SS-ffffff.json`
-- 旧 DownKyi / aria2c、BBDown 与 yt-dlp 入口仅保留为不可从设置选择的兼容代码，不参与正式缓存链路或打包
+- BBDown 保持默认支持；DownKyi / aria2c 和 Rust Native 可从 Host 设置中独立选择，Rust Native 不可用时会明确失败
 - 如果当前歌曲已经缓存完成，前端会使用浏览器里的分离视频 / 音频播放器播放本地文件
 - 本地播放时，视频与音频流会分开同步，用来支持独立的音画延迟补偿、音量控制、静音和升降 key
 - Host 页面和手机端控制台会共享同一套播放器设置，包括音画延迟、音量、静音状态和音调调整
@@ -278,7 +281,7 @@ CI 的正式打包流程会先构建 Python 后端包，再构建 Tauri 桌面�
 
 ## 注意
 
-- 本地缓存依赖运行环境能访问 B 站；Rust Native 后端随应用打包，不需要首次下载工具
+- 本地缓存依赖运行环境能访问 B 站；打包版首次使用默认 BBDown 不需要联网准备工具，用户选择 DownKyi 时自动准备 aria2c 需要访问项目工具镜像，Rust Runtime 随应用打包
 - 音画延迟补偿、音量控制、静音、远程暂停 / 跳转 / 切换音轨、升降 key 等能力依赖本地缓存媒体和浏览器媒体能力
 - 图片导出需要 Pillow；打包依赖中已包含 Pillow，脚本运行环境如果缺失则只能导出 CSV
 - Rust 下载与媒体后端状态会显示在右上角服务设置面板中

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -23,8 +23,9 @@ It does not apply to third-party tools, platform content, downloaded media, cach
 - License: MIT License, according to the upstream repository at the time this notice was written
 - Notes:
   - BBDown is an independent third-party project.
-  - Current packaged builds do not bundle or execute BBDown. Legacy compatibility and tooling files remain in the source tree.
-  - `BBDown.data` remains the compatibility filename for locally stored Bilibili cookies.
+  - Packaged builds bundle the architecture-matched BBDown 1.6.3 release asset from upstream tag `1.6.3` / commit `45622f79cd766e0fc6f5cbd49fcf4960340f35c3`.
+  - Release builds verify a pinned SHA-256 for each supported Windows and macOS asset and retain the selected URL, hash, version output, and MIT license in packaged compliance material.
+  - Packaged runtime repair copies the immutable vendor executable to the writable tool directory and does not poll GitHub for a newer BBDown release.
   - Non-packaged development environments may still use the legacy online acquisition path when no local binary is available.
   - BBDown's README includes its own usage notice. Users and redistributors should review the upstream repository before use or redistribution.
   - Account data such as `BBDown.data`, cookies, or tokens may contain sensitive user information and must not be shared, committed, uploaded, or published.
@@ -42,7 +43,11 @@ Important notes:
 - FFmpeg is generally licensed under LGPL when built with LGPL-compatible options.
 - Some optional components and build flags may cause a distributed FFmpeg binary to be licensed under GPL.
 - Builds using nonfree components may have additional redistribution restrictions.
-- Current packaged builds do not bundle or execute FFmpeg or FFprobe. Legacy compatibility and tooling files remain in the source tree.
+- Windows release bundles may include `ffmpeg` and `ffprobe` binaries from the build environment. The exact binary and license obligations depend on that build.
+- macOS release bundles build FFmpeg and FFprobe from a versioned, SHA-256-pinned official FFmpeg source archive with external-library autodetection disabled. The exact source archive, applicable FFmpeg license text, source URL/hash, and generated `-version` configuration output are retained in the packaged compliance material.
+- The bilikara build script rejects FFmpeg / FFprobe binaries whose version output contains `--enable-nonfree`.
+- If the version output contains `--enable-gpl`, the build script prints a notice so the release maintainer can verify GPL redistribution obligations.
+- The macOS build also rejects non-system Mach-O dependencies, including Homebrew Cellar paths and unresolved `@rpath` dependencies, before PyInstaller packaging.
 
 If you bundle or redistribute FFmpeg / FFprobe with bilikara, you must verify the exact binaries you ship.
 
@@ -66,13 +71,13 @@ Recommended release notes:
 - Description: Experimental, opt-in transfer engine used by the DownKyi download source
 - License: GPL-2.0-or-later
 
-Current packaged builds do not include or execute aria2c. The legacy manual Tool Assets workflow
-builds an HTTP/HTTPS-focused portable executable from the SHA-256-pinned official aria2
-1.37.0 source archive using AppleTLS and system libraries only. Application bundles consume
-checked-in architecture-specific URL and SHA-256 locks; ordinary application CI does not
-rebuild or republish the tool. The project-controlled mirror archive includes the upstream
-license and provenance. It is downloaded only after the user selects DownKyi and confirms
-preparation. Homebrew is an optional fallback, not a prerequisite.
+Current packaged builds do not include aria2c. The manual Tool Assets workflow builds an
+HTTP/HTTPS-focused portable executable from the SHA-256-pinned official aria2 1.37.0 source
+archive using AppleTLS and system libraries only. The DownKyi source consumes checked-in
+architecture-specific URL and SHA-256 locks when the user selects it and confirms preparation;
+ordinary application CI does not rebuild or republish the tool. The project-controlled mirror
+archive includes the upstream license and provenance. Homebrew is an optional fallback, not a
+prerequisite.
 
 ## 5. Reqwest
 

--- a/bilikara/launcher.py
+++ b/bilikara/launcher.py
@@ -149,7 +149,7 @@ def run_with_startup_logging() -> None:
     parser.add_argument("--https-smoke", action="store_true", help=argparse.SUPPRESS)
     parser.add_argument(
         "--tool-smoke",
-        choices=("native", "bbdown"),
+        choices=("native", "bbdown", "aria2c"),
         help=argparse.SUPPRESS,
     )
     args = parser.parse_args()

--- a/bilikara/tool_smoke.py
+++ b/bilikara/tool_smoke.py
@@ -6,10 +6,10 @@ from pathlib import Path
 
 def packaged_tool_smoke_json(tool: str) -> str:
     normalized = str(tool or "").strip().lower()
-    if normalized not in {"native", "bbdown"}:
+    if normalized not in {"native", "bbdown", "aria2c"}:
         raise ValueError(f"unsupported packaged tool smoke target: {tool}")
 
-    if normalized == "bbdown":
+    if normalized in {"bbdown", "aria2c"}:
         from .cache import CacheManager
         from .config import BACKUP_FILE, CACHE_DIR, PLAYED_SESSION_DIR, STATE_FILE
         from .store import PlaylistStore
@@ -18,10 +18,20 @@ def packaged_tool_smoke_json(tool: str) -> str:
         store = PlaylistStore(STATE_FILE, BACKUP_FILE, PLAYED_SESSION_DIR)
         manager = CacheManager(store, max_cache_items=0)
         try:
-            path = manager._ensure_bbdown()  # noqa: SLF001
-            version = manager._read_bbdown_version(path)  # noqa: SLF001
+            if normalized == "bbdown":
+                path = manager._ensure_bbdown()  # noqa: SLF001
+                version = manager._read_bbdown_version(path)  # noqa: SLF001
+            else:
+                path = manager._local_aria2c_binary_path()  # noqa: SLF001
+                manager._install_aria2c(  # noqa: SLF001
+                    path,
+                    allow_brew_fallback=False,
+                )
+                version = manager._read_aria2c_version(path)  # noqa: SLF001
             if not version:
-                raise RuntimeError(f"bbdown runtime version validation failed: {path}")
+                raise RuntimeError(
+                    f"{normalized} runtime version validation failed: {path}"
+                )
             payload = {
                 "event": "bilikara.tool_smoke",
                 "tool": normalized,

--- a/build_bundle.py
+++ b/build_bundle.py
@@ -93,6 +93,7 @@ def main() -> None:
     command.extend(
         _bundled_binary_args(data_separator, verbose=True, validate=True)
     )
+    command.extend(_macos_aria2_metadata_args(data_separator, verbose=True))
     command.extend(_rust_library_args(data_separator, verbose=True))
 
     if platform.system() == "Windows":

--- a/build_bundle.py
+++ b/build_bundle.py
@@ -576,6 +576,33 @@ def _write_release_compliance_files() -> None:
         if source.exists():
             shutil.copy2(source, target_dir / document_name)
 
+    licenses_dir = target_dir / "THIRD_PARTY_LICENSES"
+    licenses_dir.mkdir(parents=True, exist_ok=True)
+    bundled_paths, missing_tools = _resolved_bundle_binary_paths()
+    _write_text(
+        licenses_dir / "ffmpeg-source.txt",
+        _ffmpeg_source_notice(bundled_paths, missing_tools),
+    )
+    _write_text(
+        licenses_dir / "bbdown-source.txt",
+        _bbdown_source_notice(bundled_paths),
+    )
+    _copy_ffmpeg_source_material(target_dir, licenses_dir)
+    _copy_bbdown_license(licenses_dir)
+    for binary_name in ("ffmpeg", "ffprobe"):
+        binary_path = bundled_paths.get(binary_name)
+        if binary_path:
+            _write_text(
+                licenses_dir / f"{binary_name}-version.txt",
+                _tool_version_output(binary_path),
+            )
+    bbdown_path = bundled_paths.get("BBDown")
+    if bbdown_path:
+        _write_text(
+            licenses_dir / "bbdown-version.txt",
+            _tool_output(bbdown_path, "--help"),
+        )
+
 
 
 def _release_compliance_dir() -> Path | None:

--- a/rust-runtime/Cargo.lock
+++ b/rust-runtime/Cargo.lock
@@ -72,6 +72,7 @@ name = "bilikara_runtime"
 version = "0.7.0"
 dependencies = [
  "base64",
+ "claxon",
  "fs2",
  "if-addrs",
  "libc",
@@ -141,6 +142,12 @@ dependencies = [
  "cpufeatures",
  "rand_core",
 ]
+
+[[package]]
+name = "claxon"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bfbf56724aa9eca8afa4fcfadeb479e722935bb2a0900c2d37e0cc477af0688"
 
 [[package]]
 name = "cmake"

--- a/rust-runtime/Cargo.toml
+++ b/rust-runtime/Cargo.toml
@@ -18,3 +18,6 @@ reqwest = { version = "0.13", features = ["blocking", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 zip = { version = "2.4", default-features = false, features = ["deflate"] }
+
+[dev-dependencies]
+claxon = "0.4"

--- a/rust-runtime/src/media_backend.rs
+++ b/rust-runtime/src/media_backend.rs
@@ -1246,7 +1246,13 @@ fn temporary_path(destination: &Path, stage: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64::Engine as _;
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use claxon::FlacReader;
     use mp4::{AudioObjectType, ChannelConfig, Mp4Sample, SampleFreqIndex};
+
+    const REAL_FLAC_FIXTURE_BASE64: &str =
+        "ZkxhQ4AAACISABIAAAANAAANC7gA8AAAA8A9oVgtoi71SQek9M1tXRpg//h6CAADv8wAAAADsg==";
 
     fn test_dir(label: &str) -> PathBuf {
         let sequence = TEMP_SEQUENCE.fetch_add(1, Ordering::Relaxed);
@@ -1258,7 +1264,7 @@ mod tests {
         path
     }
 
-    fn write_aac_fixture(path: &Path) {
+    fn write_audio_fixture(path: &Path, samples: &[Vec<u8>]) {
         let file = File::create(path).expect("create fixture");
         let config = Mp4Config {
             major_brand: "isom".parse().unwrap(),
@@ -1280,16 +1286,16 @@ mod tests {
                 }),
             })
             .expect("add track");
-        for index in 0..4 {
+        for (index, sample) in samples.iter().enumerate() {
             writer
                 .write_sample(
                     1,
                     &Mp4Sample {
-                        start_time: index * 1024,
+                        start_time: index as u64 * 1024,
                         duration: 1024,
                         rendering_offset: 0,
                         is_sync: true,
-                        bytes: vec![index as u8 + 1; 16].into(),
+                        bytes: sample.clone().into(),
                     },
                 )
                 .expect("write sample");
@@ -1298,9 +1304,31 @@ mod tests {
         writer.into_writer().sync_all().expect("flush fixture");
     }
 
+    fn write_aac_fixture(path: &Path) {
+        let samples = (0..4)
+            .map(|index| vec![index as u8 + 1; 16])
+            .collect::<Vec<_>>();
+        write_audio_fixture(path, &samples);
+    }
+
+    fn real_flac_parts() -> ([u8; 34], Vec<u8>) {
+        let bytes = BASE64
+            .decode(REAL_FLAC_FIXTURE_BASE64)
+            .expect("decode real FLAC fixture");
+        assert_eq!(&bytes[..4], b"fLaC");
+        assert_eq!(bytes[4] & 0x7f, 0);
+        assert_ne!(bytes[4] & 0x80, 0);
+        let metadata_size =
+            ((bytes[5] as usize) << 16) | ((bytes[6] as usize) << 8) | bytes[7] as usize;
+        assert_eq!(metadata_size, 34);
+        let stream_info = bytes[8..42].try_into().expect("FLAC STREAMINFO");
+        (stream_info, bytes[42..].to_vec())
+    }
+
     fn write_flac_mp4_fixture(path: &Path) {
+        let (stream_info, flac_frame) = real_flac_parts();
         let raw_path = path.with_file_name("source-before-faststart.m4a");
-        write_aac_fixture(&raw_path);
+        write_audio_fixture(&raw_path, &[flac_frame]);
         normalize_media(&MediaNormalizeRequest {
             schema_version: 1,
             source: raw_path.clone(),
@@ -1324,11 +1352,6 @@ mod tests {
         let config_start = codec_config - 4;
         let config_size =
             u32::from_be_bytes(bytes[config_start..config_start + 4].try_into().unwrap()) as usize;
-        let stream_info = [
-            0x12, 0x00, 0x12, 0x00, 0x00, 0x00, 0x12, 0x00, 0x5f, 0x48, 0x0b, 0xb8, 0x03, 0x70,
-            0x00, 0xb3, 0x3f, 0x80, 0x43, 0x56, 0x86, 0x59, 0xbc, 0x22, 0xb1, 0x90, 0x1e, 0x4f,
-            0xd9, 0x4c, 0xe4, 0x28, 0x13, 0xc7,
-        ];
         let mut config_payload = vec![0_u8; 4];
         config_payload.extend_from_slice(&[0x80, 0x00, 0x00, 0x22]);
         config_payload.extend_from_slice(&stream_info);
@@ -1402,9 +1425,19 @@ mod tests {
         assert_eq!(result.source.sample_bytes, result.output.sample_bytes);
         assert!(result.output.fast_start);
         assert!(!result.output.fragmented);
-        let output = fs::read(destination).expect("read output");
+        let output = fs::read(&destination).expect("read output");
         assert_eq!(&output[..4], b"fLaC");
         assert_eq!(output.len() as u64, result.output.sample_bytes + 42);
+
+        let mut decoder = FlacReader::open(destination).expect("open normalized FLAC in decoder");
+        assert_eq!(decoder.streaminfo().sample_rate, 48_000);
+        assert_eq!(decoder.streaminfo().channels, 1);
+        let samples = decoder
+            .samples()
+            .collect::<Result<Vec<_>, _>>()
+            .expect("decode normalized FLAC samples");
+        assert_eq!(samples.len(), 960);
+        assert!(samples.iter().all(|sample| *sample == 0));
     }
 
     #[test]

--- a/tests/test_build_bundle.py
+++ b/tests/test_build_bundle.py
@@ -282,7 +282,7 @@ class BuildBundleTest(unittest.TestCase):
         ):
             build_bundle._validate_macos_tool_portability(ffmpeg)
 
-    def test_write_release_compliance_files_copies_only_application_notices(self):
+    def test_write_release_compliance_files_copies_notices_and_tool_versions(self):
         with TemporaryDirectory() as temp_dir:
             root_dir = Path(temp_dir)
             dist_dir = root_dir / "dist" / build_bundle.APP_NAME
@@ -334,8 +334,41 @@ class BuildBundleTest(unittest.TestCase):
             self.assertTrue((dist_dir / "LICENSE").exists())
             self.assertTrue((dist_dir / "LEGAL.md").exists())
             self.assertTrue((dist_dir / "THIRD_PARTY_NOTICES.md").exists())
-            self.assertFalse((dist_dir / "THIRD_PARTY_LICENSES").exists())
-            self.assertFalse((dist_dir / "THIRD_PARTY_SOURCES").exists())
+            licenses_dir = dist_dir / "THIRD_PARTY_LICENSES"
+            self.assertIn(
+                "FFmpeg / FFprobe redistribution notes",
+                (licenses_dir / "ffmpeg-source.txt").read_text(encoding="utf-8"),
+            )
+            self.assertEqual(
+                (licenses_dir / "ffmpeg-version.txt").read_text(encoding="utf-8"),
+                "tool version\n",
+            )
+            self.assertEqual(
+                (licenses_dir / "ffprobe-version.txt").read_text(encoding="utf-8"),
+                "tool version\n",
+            )
+            self.assertEqual(
+                (licenses_dir / "FFmpeg-COPYING.LGPLv2.1.txt").read_text(
+                    encoding="utf-8"
+                ),
+                "LGPL text\n",
+            )
+            self.assertIn(
+                "pinned BBDown vendor executable",
+                (licenses_dir / "bbdown-source.txt").read_text(encoding="utf-8"),
+            )
+            self.assertEqual(
+                (licenses_dir / "BBDown-LICENSE.txt").read_text(encoding="utf-8"),
+                "BBDown MIT text\n",
+            )
+            self.assertEqual(
+                (licenses_dir / "bbdown-version.txt").read_text(encoding="utf-8"),
+                "tool version\n",
+            )
+            self.assertEqual(
+                (dist_dir / "THIRD_PARTY_SOURCES" / source_archive.name).read_bytes(),
+                source_archive.read_bytes(),
+            )
 
     def test_macos_aria2_metadata_is_validated_and_bundled_as_data(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_build_bundle.py
+++ b/tests/test_build_bundle.py
@@ -38,7 +38,7 @@ class BuildBundleTest(unittest.TestCase):
         source = inspect.getsource(build_bundle.main)
         self.assertIn("_rust_library_args", source)
         self.assertIn("_bundled_binary_args", source)
-        self.assertNotIn("_macos_aria2_metadata_args", source)
+        self.assertIn("_macos_aria2_metadata_args", source)
 
     def test_rust_library_args_includes_release_library(self):
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_macos_backend_smoke.py
+++ b/tests/test_macos_backend_smoke.py
@@ -271,13 +271,100 @@ class MacOSBackendSmokeTest(unittest.TestCase):
             raise AssertionError(f"Backend binary is not executable: {executable}")
         return executable
 
-    def _run_packaged_tool_smoke(self, tool_name: str) -> tuple[dict, Path]:
+    @staticmethod
+    def _assert_tool_version(
+        binary_path: Path,
+        tool_name: str,
+        *,
+        cwd: Path,
+        env: dict[str, str],
+    ) -> None:
+        process = subprocess.run(
+            [str(binary_path), "-version"],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=30,
+            check=False,
+        )
+        output = (process.stdout or "") + (process.stderr or "")
+        if process.returncode != 0 or f"{tool_name} version" not in output.lower():
+            raise AssertionError(
+                f"{tool_name} -version failed for {binary_path}\n"
+                f"exit_code={process.returncode}\noutput={output}"
+            )
+
+    def test_packaged_ffmpeg_and_runtime_copy_execute(self):
+        if platform.system() != "Darwin":
+            if os.getenv("BILIKARA_REQUIRE_BACKEND_SMOKE") == "1":
+                self.fail("Required packaged FFmpeg smoke test must run on macOS")
+            raise unittest.SkipTest("Packaged FFmpeg smoke test requires macOS")
+
+        executable = self._require_packaged_backend_executable()
+        contents_dir = executable.parent.parent
+        vendor_dir = contents_dir / "Frameworks" / "vendor"
+
+        with tempfile.TemporaryDirectory(prefix="bilikara-ffmpeg-smoke-") as temp_dir_value:
+            temp_dir = Path(temp_dir_value)
+            runtime_dir = (
+                temp_dir
+                / "Library"
+                / "Application Support"
+                / "bilikara"
+                / "tools"
+                / "bbdown"
+            )
+            runtime_dir.mkdir(parents=True)
+            minimal_env = {
+                "HOME": str(temp_dir),
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "TMPDIR": str(temp_dir),
+            }
+
+            from bilikara.cache import CacheManager
+
+            for tool_name in ("ffmpeg", "ffprobe"):
+                packaged_tool = vendor_dir / tool_name
+                if not packaged_tool.is_file():
+                    self.fail(f"Packaged {tool_name} not found: {packaged_tool}")
+                if not os.access(packaged_tool, os.X_OK):
+                    self.fail(f"Packaged {tool_name} is not executable: {packaged_tool}")
+                self._assert_tool_version(
+                    packaged_tool,
+                    tool_name,
+                    cwd=temp_dir,
+                    env=minimal_env,
+                )
+
+                runtime_tool = runtime_dir / tool_name
+                CacheManager._sync_runtime_tool(
+                    packaged_tool,
+                    runtime_tool,
+                    force_refresh=True,
+                )
+                self.assertTrue(os.access(runtime_tool, os.X_OK))
+                self._assert_tool_version(
+                    runtime_tool,
+                    tool_name,
+                    cwd=temp_dir,
+                    env=minimal_env,
+                )
+
+    def _run_packaged_tool_smoke(
+        self, tool_name: str
+    ) -> tuple[dict, Path, Path, dict[str, str]]:
         executable = self._require_packaged_backend_executable()
         home = os.getenv("HOME", "").strip()
         if not home:
             self.fail("Packaged tool smoke requires HOME")
         smoke_root = self._tool_smoke_root.resolve()
+        app_home = (smoke_root / f"{tool_name}-app-home").resolve()
+        app_home.mkdir(parents=True, exist_ok=True)
         minimal_env = {
+            "BILIKARA_HOME": str(app_home),
             "HOME": home,
             "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
             "PYTHONUNBUFFERED": "1",
@@ -310,10 +397,8 @@ class MacOSBackendSmokeTest(unittest.TestCase):
             )
         self.assertEqual(marker.get("tool"), tool_name)
         runtime_path = Path(str(marker.get("path") or "")).resolve()
-        self.assertTrue(runtime_path.is_file(), f"Native runtime is missing: {runtime_path}")
-        rust_dir = executable.parent.parent / "Frameworks" / "rust"
-        self.assertTrue(runtime_path.is_relative_to(rust_dir.resolve()))
-        return marker, runtime_path
+        self.assertTrue(runtime_path.is_file(), f"Runtime path is missing: {runtime_path}")
+        return marker, runtime_path, app_home, minimal_env
 
     def test_packaged_native_runtime_loads_from_bundle(self):
         if platform.system() != "Darwin":
@@ -322,11 +407,69 @@ class MacOSBackendSmokeTest(unittest.TestCase):
             raise unittest.SkipTest("Packaged native smoke test requires macOS")
         with tempfile.TemporaryDirectory(prefix="bilikara-native-smoke-") as temp_dir:
             self._tool_smoke_root = Path(temp_dir)
-            marker, runtime = self._run_packaged_tool_smoke("native")
+            marker, runtime, _app_home, _env = self._run_packaged_tool_smoke("native")
             self.assertEqual(marker.get("version"), "ABI 1")
             self.assertTrue(marker.get("capabilities", {}).get("http_download"))
             self.assertTrue(marker.get("capabilities", {}).get("media_backend"))
             self.assertEqual(runtime.name, "libbilikara_runtime.dylib")
+            executable = self._require_packaged_backend_executable()
+            rust_dir = executable.parent.parent / "Frameworks" / "rust"
+            self.assertTrue(runtime.is_relative_to(rust_dir.resolve()))
+
+    def test_packaged_bbdown_restores_offline_vendor_to_clean_runtime(self):
+        if platform.system() != "Darwin":
+            if os.getenv("BILIKARA_REQUIRE_BACKEND_SMOKE") == "1":
+                self.fail("Required packaged BBDown smoke test must run on macOS")
+            raise unittest.SkipTest("Packaged BBDown smoke test requires macOS")
+        executable = self._require_packaged_backend_executable()
+        vendor = executable.parent.parent / "Frameworks" / "vendor" / "BBDown"
+        self.assertTrue(vendor.is_file(), f"Packaged BBDown vendor is missing: {vendor}")
+        with tempfile.TemporaryDirectory(prefix="bilikara-bbdown-smoke-") as temp_dir:
+            self._tool_smoke_root = Path(temp_dir)
+            marker, runtime, app_home, env = self._run_packaged_tool_smoke("bbdown")
+            self.assertTrue(os.access(runtime, os.X_OK))
+            self.assertTrue(runtime.is_relative_to(app_home))
+            process = subprocess.run(
+                [str(runtime), "--help"],
+                cwd=temp_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+                check=False,
+            )
+            self.assertEqual(process.returncode, 0, process.stdout + process.stderr)
+            self.assertEqual(marker.get("version"), "1.6.3")
+
+    def test_packaged_macos_aria2_prepares_on_demand_with_minimal_path(self):
+        if os.getenv("BILIKARA_REQUIRE_ARIA2_TOOL_SMOKE") != "1":
+            raise unittest.SkipTest(
+                "Full aria2c download is reserved for the package validation gate"
+            )
+        if platform.system() != "Darwin":
+            self.fail("Required packaged aria2c smoke test must run on macOS")
+        with tempfile.TemporaryDirectory(prefix="bilikara-aria2-smoke-") as temp_dir:
+            self._tool_smoke_root = Path(temp_dir)
+            marker, runtime, app_home, env = self._run_packaged_tool_smoke("aria2c")
+            self.assertTrue(os.access(runtime, os.X_OK))
+            self.assertTrue(runtime.is_relative_to(app_home))
+            process = subprocess.run(
+                [str(runtime), "--version"],
+                cwd=temp_dir,
+                env=env,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+                check=False,
+            )
+            output = (process.stdout or "") + (process.stderr or "")
+            self.assertEqual(process.returncode, 0, output)
+            self.assertIn("aria2 version 1.37.0", output)
+            self.assertEqual(marker.get("version"), "1.37.0")
 
     def test_packaged_https_uses_macos_system_trust(self):
         if platform.system() != "Darwin":

--- a/tests/test_tool_asset_workflows.py
+++ b/tests/test_tool_asset_workflows.py
@@ -96,6 +96,8 @@ class ToolAssetWorkflowTest(unittest.TestCase):
     def test_normal_bundle_embeds_required_media_tools(self):
         self.assertIn("Install FFmpeg on Windows", self.bundle_workflow)
         self.assertIn("choco install ffmpeg -y --no-progress", self.bundle_workflow)
+        self.assertNotIn("for ($attempt", self.bundle_workflow)
+        self.assertNotIn("Start-Sleep", self.bundle_workflow)
         self.assertIn("Prepare pinned portable FFmpeg asset", self.bundle_workflow)
         self.assertIn("Prepare pinned BBDown vendor", self.bundle_workflow)
         self.assertIn("scripts/prepare_bbdown_vendor.py", self.bundle_workflow)

--- a/tests/test_tool_asset_workflows.py
+++ b/tests/test_tool_asset_workflows.py
@@ -108,6 +108,10 @@ class ToolAssetWorkflowTest(unittest.TestCase):
             self.bundle_workflow,
         )
         self.assertIn("Verify clean BBDown runtime restore on Windows", self.bundle_workflow)
+        self.assertIn("Locked aria2c metadata-only checks", self.bundle_workflow)
+        self.assertIn("BILIKARA_REQUIRE_ARIA2_TOOL_SMOKE=1", self.bundle_workflow)
+        self.assertIn("Packaged portable FFmpeg checks", self.bundle_workflow)
+        self.assertIn("Running extracted portable FFmpeg checks", self.bundle_workflow)
         for tool in ("BBDown", "ffmpeg", "ffprobe"):
             self.assertIn(tool, self.bundle_workflow)
         self.assertIn("bilikara_runtime.dll", self.bundle_workflow)

--- a/tests/test_tool_smoke.py
+++ b/tests/test_tool_smoke.py
@@ -1,15 +1,44 @@
 from __future__ import annotations
 
 import json
+import sys
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
+from bilikara import launcher
 from bilikara.tool_smoke import packaged_tool_smoke_json
 
 
 class PackagedToolSmokeTest(unittest.TestCase):
+    def test_launcher_accepts_aria2c_smoke_target(self):
+        marker = '{"event":"bilikara.tool_smoke","tool":"aria2c"}'
+        trust_status = SimpleNamespace(
+            backend="python-default",
+            verify_mode="CERT_REQUIRED",
+            check_hostname=True,
+        )
+
+        with patch.object(sys, "argv", ["bilikara", "--tool-smoke", "aria2c"]), patch(
+            "bilikara.launcher._ensure_std_streams"
+        ), patch("bilikara.launcher._install_debug_log_streams"), patch(
+            "bilikara.launcher._install_startup_exception_hooks"
+        ), patch(
+            "bilikara.launcher.startup_logging_enabled", return_value=False
+        ), patch(
+            "bilikara.https_trust.initialize_https_trust", return_value=trust_status
+        ), patch(
+            "bilikara.tool_smoke.packaged_tool_smoke_json", return_value=marker
+        ) as smoke, patch(
+            "builtins.print"
+        ) as print_mock:
+            launcher.run_with_startup_logging()
+
+        smoke.assert_called_once_with("aria2c")
+        print_mock.assert_called_once_with(marker, flush=True)
+
     def test_bbdown_smoke_exercises_runtime_restore(self):
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/test_tool_smoke.py
+++ b/tests/test_tool_smoke.py
@@ -87,6 +87,51 @@ class PackagedToolSmokeTest(unittest.TestCase):
         self.assertTrue(payload["capabilities"]["status_service"])
         self.assertTrue(payload["capabilities"]["diagnostics"])
 
+    def test_aria2c_smoke_exercises_on_demand_publication(self):
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            cache_dir = root / "data" / "cache"
+            runtime = root / "tools" / "aria2c" / "aria2c"
+            events: list[object] = []
+
+            class FakeCacheManager:
+                def __init__(self, _store, *, max_cache_items: int):
+                    if max_cache_items != 0:
+                        raise AssertionError("tool smoke must disable media caching")
+                    events.append("created")
+
+                @staticmethod
+                def _local_aria2c_binary_path() -> Path:
+                    return runtime
+
+                @staticmethod
+                def _install_aria2c(path: Path, *, allow_brew_fallback: bool) -> None:
+                    events.append((path, allow_brew_fallback))
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_bytes(b"aria2c")
+
+                @staticmethod
+                def _read_aria2c_version(_path: Path) -> str:
+                    return "1.37.0"
+
+                def shutdown(self) -> None:
+                    events.append("shutdown")
+
+            with patch("bilikara.config.CACHE_DIR", cache_dir), patch(
+                "bilikara.config.STATE_FILE", root / "data" / "state.json"
+            ), patch("bilikara.config.BACKUP_FILE", root / "data" / "backup.json"), patch(
+                "bilikara.config.PLAYED_SESSION_DIR", root / "data" / "played"
+            ), patch("bilikara.cache.CacheManager", FakeCacheManager), patch(
+                "bilikara.store.PlaylistStore", return_value=object()
+            ):
+                payload = json.loads(packaged_tool_smoke_json("aria2c"))
+
+        self.assertEqual(payload["event"], "bilikara.tool_smoke")
+        self.assertEqual(payload["tool"], "aria2c")
+        self.assertEqual(payload["version"], "1.37.0")
+        self.assertEqual(Path(payload["path"]), runtime.resolve())
+        self.assertEqual(events, ["created", (runtime, False), "shutdown"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Context

This PR contains maintainer corrections **after** the direct, non-squash merge of original PR #94. The contributor head `db274f108bb33df9e0e1dbb49bfa3363a3728a4b` and all 15 original commits remain unchanged ancestors of this branch; no contributor commit was amended, rebased, squashed, or recreated.

The branch starts at PR #94 merge commit `ae971ee8207f8681daede480f2aa7d44c3b174bb` and does not contain PR #89 presentation work.

## Audit classification

- `REQUIRED_BASELINE_RESOLUTION`: v0.7.2 metadata and PR #95 export/shutdown/stdout fixes were naturally retained by the direct merge.
- `CONTRIBUTOR_INTENT`: Rust Runtime ownership, distinct BBDown / DownKyi-aria2c / Rust Native sources, Python Host orchestration, and both Rust libraries are retained.
- `SUPERSEDED_INTERMEDIATE_STATE`: the contributor's D1 patch/revert pair is preserved in history and has no final-tree residue.
- `VALID_POST_MERGE_CORRECTION`: the focused commits below address defects proven by the post-merge audit.
- `UNNECESSARY_PR97_DIFFERENCE`: the reconstructed PR #97 import commit was not replayed; PR #97 was used only as review evidence.
- `UNRELATED`: no PR #89 or experimental C++ AV synchronization code is included.

## Maintainer corrections

- `7f2c8e5` — restore bundled BBDown / FFmpeg / ffprobe compliance material and align documentation with actual packaging.
- `9d9f468` — restore pinned macOS aria2 metadata staging for the explicit DownKyi source.
- `443e92a` — restore real macOS package smoke coverage for FFmpeg/ffprobe, clean-runtime BBDown, and explicit aria2 preparation while retaining Rust Runtime smoke.
- `2a97328` — remove the PR-added CI-only Chocolatey retry loop.
- `7955310` — validate normalized Hi-Res FLAC with an independent real decoder.

## Local validation completed

- Rust Core: fmt, clippy with warnings denied, 205 tests, locked release build.
- Rust Runtime: fmt, clippy with warnings denied, 24 tests, locked release build.
- Tauri: fmt, clippy with warnings denied, 28 tests, locked release build.
- Python compileall / py_compile passed.
- Focused Runtime/cache/media/diagnostics/update/export suite: 273 passed.
- Complete `BILIKARA_REQUIRE_RUST_LIB=1` suite: 1,074 passed, 7 platform-gated skips.
- `npm ci` passed; Node-backed harnesses passed through the complete Python suite.
- Linux Tauri executable, `.deb`, and `.rpm` built. Generic Linux AppImage packaging was unavailable because `appimagetool` could not download its runtime (HTTP status 0); Linux is not one of this task's bundle targets.
- `git diff --check`, clean worktree, and git object integrity check passed.

The required Windows x64, Windows ARM64, macOS ARM64, and macOS Intel package jobs and packaged runtime smokes will be run on this exact head before acceptance.

## Summary by Sourcery

Restore audited runtime packaging behavior and strengthen cross-platform bundle validation for media tools, download sources, and normalized audio output.

New Features:
- Add packaged macOS smoke coverage for FFmpeg, ffprobe, BBDown, aria2c, and runtime restoration.
- Support aria2c as a tool-smoke target and document the selectable download sources and tool paths.

Bug Fixes:
- Restore bundled compliance material and pinned macOS aria2 metadata staging.
- Remove the unnecessary Windows Chocolatey retry loop.
- Strengthen normalized Hi-Res FLAC validation using an independent decoder.

Enhancements:
- Reinstate validated FFmpeg/ffprobe and BBDown vendor assets in release packaging with licensing, provenance, and version information.
- Expand bundle validation to verify portable media tools, locked aria2c metadata, and extracted macOS application contents.

CI:
- Extend macOS bundle CI with packaged and extracted FFmpeg/ffprobe checks, aria2c metadata validation, and required aria2c smoke coverage.

Documentation:
- Update packaging, download-source, third-party compliance, and runtime configuration documentation to reflect bundled BBDown/media tools and optional aria2c and Rust Native sources.

Tests:
- Add launcher and packaged-tool tests for aria2c and improve macOS backend and FLAC media validation.