### PR TITLE
fix(runtime): correct PR #101 post-merge lifecycle issues

### DIFF
--- a/bilikara/cache.py
+++ b/bilikara/cache.py
@@ -331,6 +331,7 @@ class CacheManager:
         self.item_activity_at: dict[str, float] = {}
         self.item_stage_progress_signatures: dict[str, str] = {}
         self.item_download_progress: dict[str, dict[str, dict[str, object]]] = {}
+        self.python_worker_download_sources: dict[str, str] = {}
         self.retry_requested_ids: set[str] = set()
         self.cache_interrupted_messages: dict[str, str] = {}
         self.log_dir = LOG_DIR
@@ -340,6 +341,7 @@ class CacheManager:
         self.native_cache_event_stop = threading.Event()
         self.native_cache_event_worker: threading.Thread | None = None
         self.native_cache_generations: dict[str, int] = {}
+        self.native_cache_terminal_sequences: dict[str, int] = {}
         self.native_cache_snapshot: dict[str, Any] = {}
         self.native_cache_error = ""
         self.native_cache_call_lock = threading.Lock()
@@ -384,15 +386,15 @@ class CacheManager:
 
     def _drain_native_cache_events(self) -> None:
         result = self._native_cache_request("drain_events", max_events=128)
-        snapshot = result.get("snapshot")
-        if isinstance(snapshot, dict):
-            self._apply_native_cache_snapshot(snapshot)
         events = result.get("events")
         if not isinstance(events, list):
             raise RuntimeError("Rust cache runtime returned invalid events")
         for event in events:
             if isinstance(event, dict):
                 self._apply_native_cache_event(event)
+        snapshot = result.get("snapshot")
+        if isinstance(snapshot, dict):
+            self._apply_native_cache_snapshot(snapshot)
         with self.lock:
             self.native_cache_error = ""
 
@@ -413,12 +415,19 @@ class CacheManager:
             if str(item_id).strip()
         }
         primary_id = str(snapshot.get("primary_active_item_id") or "").strip()
+        terminal_events = [
+            dict(event)
+            for event in snapshot.get("terminal_events", [])
+            if isinstance(event, dict)
+        ]
         with self.lock:
             self.native_cache_snapshot = dict(snapshot)
             if self.download_source == DOWNLOAD_SOURCE_NATIVE:
                 self.active_item_id = primary_id or None
                 self.pending_ids = pending_ids | active_ids
                 self.urgent_cache_ids = urgent_ids
+        for event in terminal_events:
+            self._apply_native_cache_event(event)
 
     def _apply_native_cache_event(self, event: dict[str, Any]) -> None:
         item_id = str(event.get("item_id") or "").strip()
@@ -429,7 +438,18 @@ class CacheManager:
             generation = int(event.get("generation") or 0)
         except (TypeError, ValueError):
             return
+        try:
+            sequence = int(event.get("sequence") or 0)
+        except (TypeError, ValueError):
+            return
+        terminal = kind in {"ready", "failed", "cancelled", "evicted"}
         with self.lock:
+            if (
+                terminal
+                and sequence > 0
+                and sequence <= self.native_cache_terminal_sequences.get(item_id, 0)
+            ):
+                return
             expected_generation = self.native_cache_generations.get(item_id)
             if generation > 0:
                 if expected_generation and generation < expected_generation:
@@ -488,6 +508,9 @@ class CacheManager:
             variants = payload.get("audio_variants")
             if not isinstance(variants, list) or not variants:
                 self._mark_native_cache_failed(item_id, "Rust 缓存结果缺少音轨")
+                if sequence > 0:
+                    with self.lock:
+                        self.native_cache_terminal_sequences[item_id] = sequence
                 return
             self._clear_item_download_progress(item_id)
             self.store.update_item(
@@ -522,6 +545,12 @@ class CacheManager:
             )
         else:
             return
+        if terminal and sequence > 0:
+            with self.lock:
+                self.native_cache_terminal_sequences[item_id] = max(
+                    sequence,
+                    self.native_cache_terminal_sequences.get(item_id, 0),
+                )
         self._record_item_activity(item_id)
 
     def _mark_native_cache_failed(self, item_id: str, message: str) -> None:
@@ -1419,6 +1448,7 @@ class CacheManager:
             self.item_activity_at.clear()
             self.item_stage_progress_signatures.clear()
             self.item_download_progress.clear()
+            getattr(self, "python_worker_download_sources", {}).clear()
             self.retry_requested_ids.clear()
             self.cache_interrupted_messages.clear()
             self.pending_ids.clear()
@@ -1482,6 +1512,7 @@ class CacheManager:
             self.item_activity_at.clear()
             self.item_stage_progress_signatures.clear()
             self.item_download_progress.clear()
+            getattr(self, "python_worker_download_sources", {}).clear()
             self.retry_requested_ids.clear()
             self.cache_interrupted_messages.clear()
             self.urgent_cache_ids.clear()
@@ -1490,6 +1521,7 @@ class CacheManager:
             self.native_cache_started = False
             self.native_cache_event_worker = None
             self.native_cache_generations.clear()
+            self.native_cache_terminal_sequences.clear()
             self.native_cache_snapshot.clear()
         for item in self.store.list_items():
             self.store.update_item(
@@ -1528,6 +1560,7 @@ class CacheManager:
             self.item_activity_at.clear()
             self.item_stage_progress_signatures.clear()
             self.item_download_progress.clear()
+            getattr(self, "python_worker_download_sources", {}).clear()
             self.active_process = None
             self.active_processes.clear()
             self.active_process_item_ids.clear()
@@ -1783,9 +1816,17 @@ class CacheManager:
     def _sync_native_with_playlist(self, items: list[Any], plan: CachePlan) -> None:
         desired_ids = set(plan.desired_ids)
         retained_ids = set(plan.retained_ids)
+        with self.lock:
+            python_owned_ids = set(
+                getattr(self, "python_worker_download_sources", {})
+            )
         jobs: list[dict[str, Any]] = []
         for item in items:
-            if item.id not in desired_ids or item.cache_status == "failed":
+            if (
+                item.id not in desired_ids
+                or item.cache_status == "failed"
+                or item.id in python_owned_ids
+            ):
                 continue
             try:
                 jobs.append(self._native_cache_job(item))
@@ -1806,8 +1847,6 @@ class CacheManager:
         except Exception as exc:  # noqa: BLE001
             with self.lock:
                 self.native_cache_error = str(exc)
-            for job in jobs:
-                self._mark_native_cache_failed(str(job["item_id"]), str(exc))
             return
 
         generations = result.get("generations")
@@ -1912,6 +1951,11 @@ class CacheManager:
         with self.lock:
             if self.stop_event.is_set() or item_id in self.urgent_cache_ids:
                 return
+            worker_sources = getattr(self, "python_worker_download_sources", None)
+            if worker_sources is None:
+                worker_sources = {}
+                self.python_worker_download_sources = worker_sources
+            worker_sources.setdefault(item_id, self._current_download_source())
             self.urgent_cache_ids.add(item_id)
             self.pending_ids.add(item_id)
             worker = threading.Thread(
@@ -1949,6 +1993,7 @@ class CacheManager:
                 self.urgent_cache_ids.discard(item_id)
                 self.urgent_workers.pop(item_id, None)
                 self.pending_ids.discard(item_id)
+                getattr(self, "python_worker_download_sources", {}).pop(item_id, None)
         if should_resync and not self.stop_event.is_set():
             self.sync_with_playlist()
 
@@ -2062,6 +2107,13 @@ class CacheManager:
                 try:
                     with self.lock:
                         self.active_item_id = item_id
+                        worker_sources = getattr(
+                            self, "python_worker_download_sources", None
+                        )
+                        if worker_sources is None:
+                            worker_sources = {}
+                            self.python_worker_download_sources = worker_sources
+                        worker_sources.setdefault(item_id, self._current_download_source())
                     should_resync = self._cache_item(item_id)
                 except Exception as exc:  # noqa: BLE001
                     _debug_print(f"[bilikara-cache] Unexpected error caching item {item_id}: {exc}")
@@ -2100,6 +2152,7 @@ class CacheManager:
                         self.requeued_active_ids.discard(item_id)
                     else:
                         self.pending_ids.discard(item_id)
+                    getattr(self, "python_worker_download_sources", {}).pop(item_id, None)
                 self.tasks.task_done()
             if should_resync and not self.stop_event.is_set():
                 self.sync_with_playlist()
@@ -2143,7 +2196,14 @@ class CacheManager:
 
         item_dir = CACHE_DIR / item_id
         item_dir.mkdir(parents=True, exist_ok=True)
-        download_source = self._current_download_source()
+        with self.lock:
+            worker_sources = getattr(self, "python_worker_download_sources", None)
+            if worker_sources is None:
+                worker_sources = {}
+                self.python_worker_download_sources = worker_sources
+            download_source = worker_sources.setdefault(
+                item_id, self._current_download_source()
+            )
         if download_source in (DOWNLOAD_SOURCE_DOWNKYI, DOWNLOAD_SOURCE_NATIVE):
             self._cleanup_attempt_dirs(item_dir)
         log_path = self._item_log_path(item_id, download_source)

--- a/rust-runtime/src/cache_runtime.rs
+++ b/rust-runtime/src/cache_runtime.rs
@@ -204,6 +204,7 @@ struct RuntimeState {
     primary_active_item_id: Option<String>,
     cancel_reasons: HashMap<(String, u64), String>,
     completed: HashMap<String, CompletedJob>,
+    terminal_events: HashMap<String, CacheEvent>,
     events: VecDeque<CacheEvent>,
 }
 
@@ -459,6 +460,7 @@ impl CacheRuntime {
             }
             remove_queued_locked(&mut state, &item_id);
         }
+        state.terminal_events.remove(&item_id);
         state.next_generation = state.next_generation.saturating_add(1).max(1);
         let generation = state.next_generation;
         state.jobs.insert(
@@ -513,12 +515,14 @@ impl CacheRuntime {
             .into_iter()
             .filter(|value| current.contains(value))
             .collect();
-        cleanup_orphan_directories(cache_root, &current)?;
-
         let desired: HashSet<String> = jobs.iter().map(|job| job.item_id.clone()).collect();
         let mut evict_now = Vec::new();
+        let active_ids_for_cleanup;
         {
             let mut state = lock_state(&self.shared);
+            state
+                .terminal_events
+                .retain(|item_id, _| current.contains(item_id));
             state.completed.retain(|item_id, completed| {
                 current.contains(item_id)
                     && completed_artifacts_ready(cache_root, &completed.result)
@@ -553,6 +557,7 @@ impl CacheRuntime {
                     .cancel_reasons
                     .insert((item_id, generation), "outside cache window".to_owned());
             }
+            active_ids_for_cleanup = state.active.keys().cloned().collect();
             for item_id in current.difference(&retained) {
                 if state.active.contains_key(item_id) {
                     continue;
@@ -578,6 +583,7 @@ impl CacheRuntime {
                 }
             }
         }
+        cleanup_orphan_directories(cache_root, &current, &active_ids_for_cleanup)?;
         for item_id in evict_now {
             remove_item_directory(cache_root, &item_id)?;
         }
@@ -674,6 +680,7 @@ impl CacheRuntime {
         state.urgent_queue.clear();
         state.queued_priorities.clear();
         state.completed.clear();
+        state.terminal_events.clear();
         for job in queued {
             if !state.active.contains_key(&job.spec.item_id) {
                 push_event_locked(
@@ -1473,6 +1480,10 @@ fn priority_name(priority: CacheJobPriority) -> &'static str {
     }
 }
 
+fn terminal_event(kind: &str) -> bool {
+    matches!(kind, "ready" | "failed" | "cancelled" | "evicted")
+}
+
 fn push_event_locked(
     state: &mut RuntimeState,
     generation: u64,
@@ -1481,16 +1492,22 @@ fn push_event_locked(
     payload: Value,
 ) {
     state.next_event_sequence = state.next_event_sequence.saturating_add(1).max(1);
-    if state.events.len() >= MAX_EVENTS {
-        state.events.pop_front();
-    }
-    state.events.push_back(CacheEvent {
+    let event = CacheEvent {
         sequence: state.next_event_sequence,
         generation,
         item_id: item_id.to_owned(),
         kind: kind.to_owned(),
         payload,
-    });
+    };
+    if terminal_event(kind) {
+        state
+            .terminal_events
+            .insert(item_id.to_owned(), event.clone());
+    }
+    if state.events.len() >= MAX_EVENTS {
+        state.events.pop_front();
+    }
+    state.events.push_back(event);
 }
 
 fn emit_track_progress(
@@ -1535,12 +1552,15 @@ fn snapshot_locked(state: &RuntimeState) -> Value {
         .map(|(item_id, _)| item_id.clone())
         .collect();
     urgent_ids.sort();
+    let mut terminal_events: Vec<CacheEvent> = state.terminal_events.values().cloned().collect();
+    terminal_events.sort_by_key(|event| event.sequence);
     json!({
         "stopping": state.stopping,
         "primary_active_item_id": state.primary_active_item_id,
         "active_item_ids": active_ids,
         "urgent_item_ids": urgent_ids,
         "pending_ids": state.normal_queue.iter().chain(state.urgent_queue.iter()).cloned().collect::<Vec<_>>(),
+        "terminal_events": terminal_events,
         "event_count": state.events.len(),
         "last_event_sequence": state.next_event_sequence,
     })
@@ -1653,13 +1673,14 @@ fn remove_item_directory(cache_root: &Path, item_id: &str) -> Result<(), CacheRu
 fn cleanup_orphan_directories(
     cache_root: &Path,
     current_ids: &HashSet<String>,
+    active_ids: &HashSet<String>,
 ) -> Result<(), CacheRuntimeError> {
     let entries = fs::read_dir(cache_root)
         .map_err(|error| CacheRuntimeError::new("io", error.to_string()))?;
     for entry in entries {
         let entry = entry.map_err(|error| CacheRuntimeError::new("io", error.to_string()))?;
         let name = entry.file_name().to_string_lossy().to_string();
-        if current_ids.contains(&name) {
+        if current_ids.contains(&name) || active_ids.contains(&name) {
             continue;
         }
         let path = entry.path();
@@ -1941,6 +1962,102 @@ mod tests {
         assert_eq!(result["snapshot"]["pending_ids"], json!([]));
         runtime.shutdown();
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn sync_defers_orphan_cleanup_while_the_item_is_active() {
+        let root = std::env::temp_dir().join(format!(
+            "bilikara-cache-runtime-active-orphan-{}-{}",
+            std::process::id(),
+            ATTEMPT_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let item_dir = root.join("song-a");
+        fs::create_dir_all(&item_dir).expect("create active cache fixture");
+        fs::write(item_dir.join("worker-owned.tmp"), b"active").expect("write active fixture");
+        let runtime = CacheRuntime::new().expect("start cache runtime");
+        let cancel = Arc::new(AtomicBool::new(false));
+        {
+            let mut state = lock_state(&runtime.shared);
+            state.active.insert(
+                "song-a".to_owned(),
+                ActiveJob {
+                    generation: 1,
+                    cancel: Arc::clone(&cancel),
+                    urgent: false,
+                },
+            );
+            state.primary_active_item_id = Some("song-a".to_owned());
+        }
+
+        runtime
+            .sync(&root, Vec::new(), Vec::new(), Vec::new(), Vec::new(), "")
+            .expect("sync active orphan");
+
+        assert!(cancel.load(Ordering::Acquire));
+        assert!(item_dir.exists());
+        {
+            let mut state = lock_state(&runtime.shared);
+            state.active.remove("song-a");
+            state.primary_active_item_id = None;
+        }
+        runtime
+            .sync(&root, Vec::new(), Vec::new(), Vec::new(), Vec::new(), "")
+            .expect("cleanup terminal orphan");
+        assert!(!item_dir.exists());
+        runtime.shutdown();
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn terminal_event_remains_recoverable_after_progress_overflow() {
+        let runtime = CacheRuntime::new().expect("start cache runtime");
+        {
+            let mut state = lock_state(&runtime.shared);
+            push_event_locked(
+                &mut state,
+                1,
+                "song-a",
+                "ready",
+                json!({
+                    "video_relative_path": "song-a/video-p1.mp4",
+                    "video_media_url": "/media/song-a/video-p1.mp4",
+                    "audio_variants": [{
+                        "id": "p1_track_1",
+                        "label": "P1",
+                        "page": 1,
+                        "audio_url": "/media/song-a/audio-p1.m4a"
+                    }],
+                    "selected_audio_variant_id": "p1_track_1"
+                }),
+            );
+            for index in 0..MAX_EVENTS {
+                push_event_locked(
+                    &mut state,
+                    2,
+                    "song-b",
+                    "progress",
+                    json!({"track": {"key": "video-p1", "current_bytes": index}}),
+                );
+            }
+        }
+
+        let drained = runtime.drain_events(MAX_DRAIN_EVENTS);
+        assert!(
+            drained["events"]
+                .as_array()
+                .is_some_and(|events| events.iter().all(|event| event["item_id"] != "song-a"))
+        );
+        let recovered = drained["snapshot"]["terminal_events"]
+            .as_array()
+            .expect("terminal recovery snapshot");
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0]["item_id"], "song-a");
+        assert_eq!(recovered[0]["kind"], "ready");
+        assert_eq!(
+            recovered[0]["payload"]["selected_audio_variant_id"],
+            "p1_track_1"
+        );
+        runtime.shutdown();
     }
 
     #[test]

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -464,6 +464,237 @@ class CacheManagerPolicyTest(unittest.TestCase):
         self.assertEqual(sync_request["jobs"][0]["item_id"], item.id)
         self.assertEqual(sync_request["ordered_ids"], [item.id])
 
+    def test_native_sync_excludes_active_python_owner_and_includes_future_item(self):
+        active = self.make_item("song-external-active")
+        future = self.make_item("song-native-future")
+        for item in (active, future):
+            item.selected_pages = [1]
+            item.selected_cids = [456]
+            item.selected_durations = [120]
+            self.store.add_item(item, requester_name="cache-test-user")
+        self.store.update_item(
+            active.id,
+            cache_status="downloading",
+            cache_progress=42.0,
+            cache_message="BBDown 下载中",
+            persist_backup=False,
+        )
+        plan = CachePlan(
+            desired_ids=(active.id, future.id),
+            pending_order=(active.id, future.id),
+            retained_ids=(active.id, future.id),
+            preempt_ids=(),
+        )
+        calls = []
+
+        def runtime_request(command, **fields):
+            calls.append((command, fields))
+            if command == "sync":
+                return {
+                    "generations": {future.id: 1},
+                    "snapshot": {
+                        "primary_active_item_id": None,
+                        "active_item_ids": [],
+                        "urgent_item_ids": [],
+                        "pending_ids": [future.id],
+                    },
+                }
+            return {"events": [], "snapshot": {}}
+
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir), patch(
+            "bilikara.cache.effective_bilibili_cookie", return_value=""
+        ), patch.object(CacheManager, "_worker_loop", lambda self: None):
+            manager = CacheManager(self.store, max_cache_items=2)
+            try:
+                manager.download_source = DOWNLOAD_SOURCE_BBDOWN
+                manager.active_item_id = active.id
+                manager.pending_ids.add(active.id)
+                manager.python_worker_download_sources[active.id] = DOWNLOAD_SOURCE_BBDOWN
+                manager.set_cache_policy(download_source=DOWNLOAD_SOURCE_NATIVE)
+                with patch.object(
+                    manager,
+                    "_stable_cache_plan_snapshot",
+                    return_value=(plan, manager._cache_priority_state()),
+                ), patch.object(manager, "_ensure_native_cache_runtime"), patch.object(
+                    manager, "_native_cache_request", side_effect=runtime_request
+                ):
+                    manager.sync_with_playlist()
+            finally:
+                manager.native_cache_started = False
+                manager.shutdown()
+
+        sync_request = next(fields for command, fields in calls if command == "sync")
+        self.assertEqual(
+            [job["item_id"] for job in sync_request["jobs"]],
+            [future.id],
+        )
+
+    def test_native_sync_service_failure_does_not_fan_out_to_valid_jobs(self):
+        ready = self.make_item("song-ready")
+        pending = self.make_item("song-pending")
+        malformed = self.make_item("song-malformed")
+        for item in (ready, pending, malformed):
+            item.selected_pages = [1]
+            item.selected_cids = [456]
+            item.selected_durations = [120]
+            self.store.add_item(item, requester_name="cache-test-user")
+        self.mark_item_ready_with_files(ready.id)
+        plan = CachePlan(
+            desired_ids=(ready.id, pending.id, malformed.id),
+            pending_order=(pending.id, malformed.id),
+            retained_ids=(ready.id, pending.id, malformed.id),
+            preempt_ids=(),
+        )
+
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir), patch(
+            "bilikara.cache.effective_bilibili_cookie", return_value=""
+        ), patch.object(CacheManager, "_worker_loop", lambda self: None):
+            manager = CacheManager(self.store, max_cache_items=3)
+            try:
+                manager.download_source = DOWNLOAD_SOURCE_NATIVE
+                original_job = manager._native_cache_job
+
+                def build_job(item):
+                    if item.id == malformed.id:
+                        raise ValueError("malformed fixture")
+                    return original_job(item)
+
+                with patch.object(
+                    manager,
+                    "_stable_cache_plan_snapshot",
+                    return_value=(plan, manager._cache_priority_state()),
+                ), patch.object(
+                    manager, "_native_cache_job", side_effect=build_job
+                ), patch.object(manager, "_ensure_native_cache_runtime"), patch.object(
+                    manager,
+                    "_native_cache_request",
+                    side_effect=RuntimeError("simulated service failure"),
+                ):
+                    manager.sync_with_playlist()
+
+                ready_after = self.store.get_item(ready.id)
+                pending_after = self.store.get_item(pending.id)
+                malformed_after = self.store.get_item(malformed.id)
+                self.assertEqual(ready_after.cache_status, "ready")
+                self.assertEqual(ready_after.video_relative_path, f"{ready.id}/video.mp4")
+                self.assertEqual(len(ready_after.audio_variants), 1)
+                self.assertEqual(pending_after.cache_status, "pending")
+                self.assertEqual(malformed_after.cache_status, "failed")
+                self.assertEqual(manager.native_cache_error, "simulated service failure")
+            finally:
+                manager.native_cache_started = False
+                manager.shutdown()
+
+    def test_native_snapshot_recovers_lost_terminal_event_once(self):
+        item = self.make_item("song-terminal-recovery")
+        self.store.add_item(item, requester_name="cache-test-user")
+        terminal = {
+            "sequence": 9,
+            "generation": 3,
+            "item_id": item.id,
+            "kind": "ready",
+            "payload": {
+                "video_relative_path": f"{item.id}/video-p1.mp4",
+                "video_media_url": f"/media/{item.id}/video-p1.mp4",
+                "audio_variants": [
+                    {
+                        "id": "p1-vocal",
+                        "label": "Vocal",
+                        "page": 1,
+                        "audio_url": f"/media/{item.id}/audio-p1-vocal.m4a",
+                    },
+                    {
+                        "id": "p1-off-vocal",
+                        "label": "Off Vocal",
+                        "page": 1,
+                        "audio_url": f"/media/{item.id}/audio-p1-off-vocal.m4a",
+                    },
+                ],
+                "selected_audio_variant_id": "p1-vocal",
+            },
+        }
+        snapshot = {
+            "primary_active_item_id": None,
+            "active_item_ids": [],
+            "urgent_item_ids": [],
+            "pending_ids": [],
+            "terminal_events": [terminal],
+        }
+
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir), patch.object(
+            CacheManager, "_worker_loop", lambda self: None
+        ):
+            manager = CacheManager(self.store, max_cache_items=1)
+            try:
+                manager.download_source = DOWNLOAD_SOURCE_NATIVE
+                manager._apply_native_cache_snapshot(snapshot)
+                self.store.update_item(
+                    item.id,
+                    selected_audio_variant_id="p1-off-vocal",
+                    persist_backup=False,
+                )
+                manager._apply_native_cache_snapshot(snapshot)
+                cached = self.store.get_item(item.id)
+                self.assertEqual(cached.cache_status, "ready")
+                self.assertEqual(cached.selected_audio_variant_id, "p1-off-vocal")
+                self.assertEqual(manager.native_cache_terminal_sequences[item.id], 9)
+            finally:
+                manager.shutdown()
+
+    def test_native_drain_applies_events_before_terminal_snapshot_recovery(self):
+        item = self.make_item("song-terminal-order")
+        self.store.add_item(item, requester_name="cache-test-user")
+        ready = {
+            "sequence": 9,
+            "generation": 3,
+            "item_id": item.id,
+            "kind": "ready",
+            "payload": {
+                "video_relative_path": f"{item.id}/video-p1.mp4",
+                "video_media_url": f"/media/{item.id}/video-p1.mp4",
+                "audio_variants": [
+                    {
+                        "id": "p1",
+                        "label": "P1",
+                        "page": 1,
+                        "audio_url": f"/media/{item.id}/audio-p1.m4a",
+                    }
+                ],
+                "selected_audio_variant_id": "p1",
+            },
+        }
+        result = {
+            "events": [
+                {
+                    "sequence": 8,
+                    "generation": 3,
+                    "item_id": item.id,
+                    "kind": "queued",
+                    "payload": {"priority": "normal"},
+                },
+                ready,
+            ],
+            "snapshot": {
+                "primary_active_item_id": None,
+                "active_item_ids": [],
+                "urgent_item_ids": [],
+                "pending_ids": [],
+                "terminal_events": [ready],
+            },
+        }
+
+        with patch("bilikara.cache.CACHE_DIR", self.cache_dir), patch.object(
+            CacheManager, "_worker_loop", lambda self: None
+        ):
+            manager = CacheManager(self.store, max_cache_items=1)
+            try:
+                manager.download_source = DOWNLOAD_SOURCE_NATIVE
+                with patch.object(manager, "_native_cache_request", return_value=result):
+                    manager._drain_native_cache_events()
+                self.assertEqual(self.store.get_item(item.id).cache_status, "ready")
+            finally:
+                manager.shutdown()
+
     def test_cache_metrics_reports_usage_by_item(self):
         first = self.cache_dir / "song-a"
         second = self.cache_dir / "song-b"


### PR DESCRIPTION
Post-merge corrections for contributor PR #101 after an independent hypothesis-driven audit.

Confirmed and corrected:
- preserve external worker ownership across download-source preference changes;
- isolate runtime-wide native sync failures from per-item cache state;
- cancel active native workers before orphan-directory cleanup and defer their directory removal;
- recover bounded-queue terminal events from the authoritative native snapshot.

Rejected by code trace and unchanged:
- H5 bounded desktop shutdown contract;
- H6 Rust/Python authority boundaries.

The original eight contributor commits remain unchanged under the PR #101 merge commit. Local Rust Core, Rust Runtime, Python, Tauri, frontend, and diff gates pass. This PR remains draft until the exact-head workflow_dispatch matrix and artifact audit pass.

## Summary by Sourcery

Correct cache lifecycle handling across Python and native workers, synchronization failures, cleanup, and terminal-event recovery.

Bug Fixes:
- Preserve ownership of active Python download workers when download-source preferences change.
- Prevent native runtime synchronization failures from incorrectly marking valid cache items as failed.
- Defer orphan cache-directory cleanup until active native workers have been cancelled.
- Recover terminal native cache events from snapshots when bounded event queues overflow.

Tests:
- Add coverage for worker ownership preservation, isolated native sync failures, terminal-event recovery, and event ordering.