### PR TITLE
fix: make Gatcha refresh incremental and reduce D1 amplification

### DIFF
--- a/bilikara/bilibili.py
+++ b/bilikara/bilibili.py
@@ -1990,11 +1990,8 @@ def refresh_gatcha_cache_in_background(
                 task_status = "success"
                 message = "抽卡缓存格式重建完成。"
                 _set_gatcha_task_status(task_status, message=message, result=result, blocking=False)
-                rebuilt_cache = _load_gatcha_cache()
-                entries = _gatcha_cache_payload_entries(rebuilt_cache)
-                favlist_entries = _local_gatcha_favlist_candidates()
-                if entries or favlist_entries:
-                    _append_lark_pool_entries_async(entries + favlist_entries)
+                # A local schema rebuild does not discover new remote records. Uploading the
+                # rebuilt cache here would resend the entire library during process startup.
                 return
 
             cache_payload = refresh_gatcha_cache()
@@ -2020,7 +2017,7 @@ def refresh_gatcha_cache_in_background(
                 if on_done is not None:
                     on_done()
         if cache_payload is not None and task_status != "failed":
-            entries = _gatcha_cache_payload_entries(cache_payload)
+            entries = _gatcha_refresh_added_entries(cache_payload)
             if entries:
                 _append_lark_pool_entries_async(entries)
 
@@ -2262,6 +2259,39 @@ def _gatcha_cache_payload_entries(cache_payload: dict, *, exclude_uids: set[str]
                 payload.setdefault("owner_url", str(profile.get("space_url") or ""))
             entries.append(payload)
     return entries
+
+
+def _gatcha_refresh_added_entries(cache_payload: dict) -> list[dict]:
+    """Project only records added by the latest UID refresh for remote append."""
+    if not isinstance(cache_payload, dict):
+        return []
+    uid_entries = cache_payload.get("uids")
+    profiles = cache_payload.get("profiles")
+    summary = cache_payload.get("refresh_summary")
+    results = summary.get("uids") if isinstance(summary, dict) else None
+    if not isinstance(uid_entries, dict) or not isinstance(results, list):
+        return []
+
+    added_by_uid: dict[str, list[dict]] = {}
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        uid = str(result.get("uid") or "").strip()
+        try:
+            added_count = int(result.get("added_count") or 0)
+        except (TypeError, ValueError):
+            continue
+        raw_entries = uid_entries.get(uid)
+        if not uid or added_count <= 0 or not isinstance(raw_entries, list):
+            continue
+        added_by_uid[uid] = raw_entries[:added_count]
+
+    return _gatcha_cache_payload_entries(
+        {
+            "uids": added_by_uid,
+            "profiles": profiles if isinstance(profiles, dict) else {},
+        }
+    )
 
 
 def _append_lark_pool_entries_async(entries: list[dict]) -> None:

--- a/monthly_gatcha_d1_refresh.py
+++ b/monthly_gatcha_d1_refresh.py
@@ -16,7 +16,6 @@ from typing import Any
 import bilikara.bilibili as bilibili
 import bilikara.lark_pool_client as pool_client
 from bilikara.config import DATA_DIR
-from bilikara.lark_pool_client import append_cloudflare_pool_entries
 
 
 ROOT_DIR = Path(__file__).resolve().parent
@@ -79,7 +78,14 @@ def _load_configured_uids(path: Path) -> list[str]:
     return _dedupe_ordered(_load_uid_lines(path))
 
 
-def _request_json(url: str, *, secret: str = "", timeout: float = 60.0) -> Any:
+def _request_json(
+    url: str,
+    *,
+    method: str = "GET",
+    payload: object | None = None,
+    secret: str = "",
+    timeout: float = 60.0,
+) -> Any:
     headers = {
         "Accept": "application/json",
         "Cache-Control": "no-store",
@@ -91,7 +97,11 @@ def _request_json(url: str, *, secret: str = "", timeout: float = 60.0) -> Any:
     }
     if secret:
         headers["Authorization"] = f"Bearer {secret}"
-    request = urllib.request.Request(url, headers=headers, method="GET")
+    data = None
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    request = urllib.request.Request(url, headers=headers, data=data, method=method)
     with urllib.request.urlopen(request, timeout=timeout) as response:
         return json.loads(response.read().decode("utf-8"))
 
@@ -210,10 +220,40 @@ def _fetch_all_uid_entries(mid: str, *, retry_delay: float, max_retries: int) ->
     return entries
 
 
-def _upload_entries(entries: list[dict], *, dry_run: bool) -> dict[str, Any]:
+def _upload_entries(
+    entries: list[dict],
+    *,
+    api_url: str,
+    secret: str,
+    batch_size: int,
+    dry_run: bool,
+) -> dict[str, Any]:
     if dry_run:
         return {"attempted": len(entries), "added": 0, "updated_existing": 0, "dry_run": True}
-    return append_cloudflare_pool_entries(entries)
+    if not secret:
+        raise RuntimeError("BILIKARA_ADMIN_SECRET is required to upload D1 records.")
+    normalized_batch_size = max(1, min(2000, int(batch_size)))
+    result: dict[str, Any] = {
+        "attempted": 0,
+        "added": 0,
+        "updated_existing": 0,
+        "skipped_existing": 0,
+        "skipped_blacklisted": 0,
+    }
+    for index in range(0, len(entries), normalized_batch_size):
+        chunk = entries[index : index + normalized_batch_size]
+        response = _request_json(
+            f"{str(api_url or '').rstrip('/')}/batch-add?sync_google=1",
+            method="POST",
+            payload={"records": chunk},
+            secret=secret,
+            timeout=120.0,
+        )
+        if not isinstance(response, dict) or not response.get("success"):
+            raise RuntimeError(f"D1 batch upload returned an invalid payload: {response}")
+        for key in result:
+            result[key] += int(response.get(key) or 0)
+    return result
 
 
 def _combine_uids(local_uids: list[str], d1_mids: set[str], *, uid_mode: str) -> list[str]:
@@ -228,7 +268,7 @@ def main(argv: list[str] | None = None, *, secret_override: str = "") -> int:
     parser = argparse.ArgumentParser(
         description=(
             "Monthly full-UID D1 refresh: export D1 once, probe each UID's first Bilibili page, "
-            "and fully refresh only UIDs whose latest visible BV is missing from D1."
+            "and fully refresh only UIDs with a missing first-page BV in D1."
         ),
     )
     parser.add_argument("--uid-source", default=str(DEFAULT_UIDS_PATH), help="UID JSON/text file. Default: data/gatcha_uids.json")
@@ -247,6 +287,12 @@ def main(argv: list[str] | None = None, *, secret_override: str = "") -> int:
     parser.add_argument("--delay", type=float, default=2.0, help="Seconds to sleep after each UID. Default: 2.")
     parser.add_argument("--export-limit", type=int, default=5000, help="D1 export page size used by the Worker. Default: 5000.")
     parser.add_argument("--export-timeout", type=float, default=120.0, help="Seconds before D1 export times out. Default: 120.")
+    parser.add_argument(
+        "--upload-batch-size",
+        type=int,
+        default=500,
+        help="Missing D1 records per authenticated /batch-add request. Maximum: 2000. Default: 500.",
+    )
     parser.add_argument(
         "--max-visible-total",
         type=int,
@@ -268,8 +314,8 @@ def main(argv: list[str] | None = None, *, secret_override: str = "") -> int:
     parser.add_argument(
         "--probe-mode",
         choices=("latest", "page-any"),
-        default="latest",
-        help="latest checks only the newest visible BV; page-any refreshes if any first-page BV is missing.",
+        default="page-any",
+        help="page-any refreshes if any first-page BV is missing; latest checks only the newest visible BV. Default: page-any.",
     )
     parser.add_argument("--force", action="store_true", help="Refresh and upload every UID without first-page D1 comparison.")
     parser.add_argument("--dry-run", action="store_true", help="Fetch and decide, but do not upload to D1.")
@@ -372,13 +418,24 @@ def main(argv: list[str] | None = None, *, secret_override: str = "") -> int:
                 retry_delay=args.bili_retry_delay,
                 max_retries=args.bili_max_retries,
             )
-            upload = _upload_entries(entries, dry_run=args.dry_run)
-            for bvid in _entry_bvids(entries):
+            missing_entries = [
+                entry
+                for entry in entries
+                if str(entry.get("bvid") or "").strip() not in d1_bvids
+            ]
+            upload = _upload_entries(
+                missing_entries,
+                api_url=api_url,
+                secret=secret,
+                batch_size=args.upload_batch_size,
+                dry_run=args.dry_run,
+            )
+            for bvid in _entry_bvids(missing_entries):
                 d1_bvids.add(bvid)
             refreshed += 1
             print(
                 "  refreshed "
-                f"entries={len(entries)} "
+                f"entries={len(entries)} missing={len(missing_entries)} "
                 f"d1_attempted={upload.get('attempted', 0)} "
                 f"d1_added={upload.get('added', 0)} "
                 f"d1_updated={upload.get('updated_existing', 0)}",

--- a/rust-runtime/src/gatcha_repository.rs
+++ b/rust-runtime/src/gatcha_repository.rs
@@ -22,6 +22,12 @@ const FAVLIST_ITEMS_URL: &str = "https://api.bilibili.com/x/v3/fav/resource/list
 const GATCHA_REQUEST_DELAY: Duration = Duration::from_secs(5);
 const FAVLIST_REQUEST_DELAY: Duration = Duration::from_secs(3);
 
+#[derive(Debug)]
+struct UidFetchResult {
+    entries: Vec<Value>,
+    first_bvid: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct GatchaPaths {
@@ -362,6 +368,8 @@ fn load_cache(path: &Path) -> Value {
         "schema_version": CACHE_SCHEMA_VERSION,
         "uids": payload.get("uids").filter(|value| value.is_object()).cloned().unwrap_or_else(|| json!({})),
         "profiles": payload.get("profiles").filter(|value| value.is_object()).cloned().unwrap_or_else(|| json!({})),
+        "uid_checkpoints": payload.get("uid_checkpoints").filter(|value| value.is_object()).cloned().unwrap_or_else(|| json!({})),
+        "refresh_summary": payload.get("refresh_summary").filter(|value| value.is_object()).cloned().unwrap_or_else(|| json!({})),
         "updated_at": number_map(&payload, "updated_at"),
     })
 }
@@ -501,11 +509,14 @@ fn add_uid(
         .cloned()
         .unwrap_or_default();
     let incremental = !dedupe_entries(&existing).is_empty();
-    let fresh = fetch_uid_entries(client, &uid, keywords, incremental.then_some(1))?;
+    let checkpoint = incremental
+        .then(|| uid_refresh_checkpoint(&cache, &uid, &existing))
+        .flatten();
+    let fresh = fetch_uid_entries(client, &uid, keywords, checkpoint.as_deref())?;
     let (entries, added_count) = if incremental {
-        merge_incremental_entries(&existing, &fresh)
+        merge_incremental_entries(&existing, &fresh.entries)
     } else {
-        let entries = dedupe_entries(&fresh);
+        let entries = dedupe_entries(&fresh.entries);
         let count = entries.len();
         (entries, count)
     };
@@ -526,6 +537,7 @@ fn add_uid(
         .as_object_mut()
         .ok_or_else(|| error("state", "invalid Gacha profile cache"))?;
     cache_profiles.insert(uid.clone(), profile.clone());
+    persist_uid_checkpoint(cache_object, &uid, fresh.first_bvid.as_deref())?;
     atomic_write_json(&paths.cache_file, &cache)?;
     Ok(json!({
         "uid": uid,
@@ -549,15 +561,19 @@ fn refresh_all(
     keywords: &[String],
     client: &BilibiliHttpClient,
 ) -> Result<Value, GatchaRepositoryError> {
-    let (configured, legacy_cache) = {
+    let (configured, legacy_cache, initial_checkpoints) = {
         let _guard = repository_guard()?;
         let uid_payload = uid_snapshot(&paths.uid_file, &[])?;
         let raw_cache = read_object(&paths.cache_file).unwrap_or_default();
+        let configured = normalized_strings(uid_payload.get("uids"));
+        let initial_checkpoints =
+            uid_refresh_checkpoints(&load_cache(&paths.cache_file), &configured);
         (
-            normalized_strings(uid_payload.get("uids")),
+            configured,
             integer_value(raw_cache.get("schema_version")).unwrap_or(0)
                 < CACHE_SCHEMA_VERSION as i64
                 || !raw_cache.get("profiles").is_some_and(Value::is_object),
+            initial_checkpoints,
         )
     };
     let mut results = Vec::new();
@@ -569,16 +585,17 @@ fn refresh_all(
                 let _guard = repository_guard()?;
                 let uid_payload = uid_snapshot(&paths.uid_file, &[])?;
                 let cache = load_cache(&paths.cache_file);
+                let existing = cache
+                    .pointer(&format!("/uids/{uid}"))
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
                 (
                     uid_payload
                         .pointer(&format!("/profiles/{uid}"))
                         .filter(|value| valid_profile(value))
                         .cloned(),
-                    cache
-                        .pointer(&format!("/uids/{uid}"))
-                        .and_then(Value::as_array)
-                        .cloned()
-                        .unwrap_or_default(),
+                    existing,
                 )
             };
             let profile = known_profile
@@ -588,9 +605,19 @@ fn refresh_all(
                 .map(Ok)
                 .unwrap_or_else(|| fetch_profile(client, uid))?;
             let incremental = !legacy_cache && !dedupe_entries(&existing).is_empty();
-            let fresh = fetch_uid_entries(client, uid, keywords, incremental.then_some(1))?;
-            let (added_count, total_count) =
-                persist_refreshed_uid(paths, uid, &profile, &existing, &fresh, incremental)?;
+            let stop_bvid = incremental
+                .then(|| initial_checkpoints.get(uid).cloned().flatten())
+                .flatten();
+            let fresh = fetch_uid_entries(client, uid, keywords, stop_bvid.as_deref())?;
+            let (added_count, total_count) = persist_refreshed_uid(
+                paths,
+                uid,
+                &profile,
+                &existing,
+                &fresh.entries,
+                fresh.first_bvid.as_deref(),
+                incremental,
+            )?;
             Ok::<Value, GatchaRepositoryError>(json!({
                 "uid": uid,
                 "mode": if incremental { "incremental" } else { "full" },
@@ -629,6 +656,7 @@ fn persist_refreshed_uid(
     profile: &Value,
     baseline_entries: &[Value],
     fresh_entries: &[Value],
+    first_bvid: Option<&str>,
     incremental: bool,
 ) -> Result<(usize, usize), GatchaRepositoryError> {
     let _guard = repository_guard()?;
@@ -676,6 +704,7 @@ fn persist_refreshed_uid(
         .as_object_mut()
         .ok_or_else(|| error("state", "invalid Gacha profile cache"))?
         .insert(uid.to_owned(), profile.clone());
+    persist_uid_checkpoint(cache_object, uid, first_bvid)?;
     cache_object.insert("updated_at".to_owned(), json!(updated_at));
     atomic_write_json(&paths.cache_file, &cache)?;
     Ok((added_count, total_count))
@@ -923,14 +952,74 @@ fn fetch_profile(client: &BilibiliHttpClient, uid: &str) -> Result<Value, Gatcha
     Ok(profile)
 }
 
+fn uid_refresh_checkpoint(cache: &Value, uid: &str, existing: &[Value]) -> Option<String> {
+    if let Some(checkpoint) = cache
+        .pointer(&format!("/uid_checkpoints/{uid}"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Some(checkpoint.to_owned());
+    }
+
+    let added_count = cache
+        .pointer("/refresh_summary/uids")
+        .and_then(Value::as_array)
+        .and_then(|results| {
+            results.iter().find_map(|result| {
+                let object = result.as_object()?;
+                (first_text(object, &["uid"]).as_deref() == Some(uid)
+                    && first_text(object, &["mode"]).as_deref() == Some("incremental"))
+                .then(|| integer(object, &["added_count"]).unwrap_or(0).max(0) as usize)
+            })
+        })
+        .unwrap_or(0);
+
+    existing
+        .get(added_count)
+        .or_else(|| existing.first())
+        .and_then(Value::as_object)
+        .and_then(|entry| first_text(entry, &["bvid"]))
+}
+
+fn uid_refresh_checkpoints(cache: &Value, uids: &[String]) -> BTreeMap<String, Option<String>> {
+    uids.iter()
+        .map(|uid| {
+            let existing = cache
+                .pointer(&format!("/uids/{uid}"))
+                .and_then(Value::as_array)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            (uid.clone(), uid_refresh_checkpoint(cache, uid, existing))
+        })
+        .collect()
+}
+
+fn persist_uid_checkpoint(
+    cache: &mut Map<String, Value>,
+    uid: &str,
+    first_bvid: Option<&str>,
+) -> Result<(), GatchaRepositoryError> {
+    let checkpoints = cache
+        .entry("uid_checkpoints")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .ok_or_else(|| error("state", "invalid Gacha UID checkpoints"))?;
+    if let Some(first_bvid) = first_bvid.map(str::trim).filter(|value| !value.is_empty()) {
+        checkpoints.insert(uid.to_owned(), Value::String(first_bvid.to_owned()));
+    }
+    Ok(())
+}
+
 fn fetch_uid_entries(
     client: &BilibiliHttpClient,
     uid: &str,
     keywords: &[String],
-    max_pages: Option<usize>,
-) -> Result<Vec<Value>, GatchaRepositoryError> {
+    stop_bvid: Option<&str>,
+) -> Result<UidFetchResult, GatchaRepositoryError> {
     let mut output = Vec::new();
     let mut seen = HashSet::new();
+    let mut first_bvid = None;
     let page_size = 50usize;
     let mut page = 1usize;
     loop {
@@ -960,6 +1049,14 @@ fn fetch_uid_entries(
             .and_then(Value::as_array)
             .map(Vec::as_slice)
             .unwrap_or(&[]);
+        if page == 1 {
+            first_bvid = videos
+                .iter()
+                .filter_map(Value::as_object)
+                .find_map(|video| first_text(video, &["bvid"]));
+        }
+        let reached_checkpoint =
+            stop_bvid.is_some_and(|checkpoint| page_contains_bvid(videos, checkpoint));
         for video in videos.iter().filter_map(Value::as_object) {
             let bvid = first_text(video, &["bvid"]).unwrap_or_default();
             let title = first_text(video, &["title"]).unwrap_or_default();
@@ -991,12 +1088,23 @@ fn fetch_uid_entries(
             add_video_extras(object, video);
             output.push(entry);
         }
-        if max_pages.is_some_and(|limit| page >= limit) || videos.len() < page_size {
+        if reached_checkpoint || videos.len() < page_size {
             break;
         }
         page += 1;
     }
-    Ok(output)
+    Ok(UidFetchResult {
+        entries: output,
+        first_bvid,
+    })
+}
+
+fn page_contains_bvid(videos: &[Value], checkpoint: &str) -> bool {
+    videos
+        .iter()
+        .filter_map(Value::as_object)
+        .filter_map(|video| first_text(video, &["bvid"]))
+        .any(|bvid| bvid == checkpoint)
 }
 
 fn fetch_favlist_folders(
@@ -2132,6 +2240,7 @@ mod tests {
             &json!({"uid": "1", "name": "owner", "space_url": "https://space.bilibili.com/1"}),
             &[],
             &[json!({"bvid": "BVFRESH", "title": "fresh"})],
+            Some("BVFRESH"),
             false,
         )
         .expect("persist refreshed uid");
@@ -2143,7 +2252,88 @@ mod tests {
         assert_eq!(cache["uids"]["1"][1]["bvid"], "BVCONCURRENT");
         assert_eq!(cache["uids"]["2"][0]["bvid"], "BVOTHER");
         assert_eq!(cache["profiles"]["1"]["name"], "owner");
+        assert_eq!(cache["uid_checkpoints"]["1"], "BVFRESH");
         let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn legacy_checkpoint_uses_the_entry_before_the_last_incremental_additions() {
+        let cache = json!({
+            "uid_checkpoints": {},
+            "refresh_summary": {
+                "uids": [{
+                    "uid": "42",
+                    "mode": "incremental",
+                    "added_count": 1
+                }]
+            }
+        });
+        let existing = vec![
+            json!({"bvid": "BVNEW0000001", "title": "new"}),
+            json!({"bvid": "BVOLD0000001", "title": "old boundary"}),
+        ];
+
+        assert_eq!(
+            uid_refresh_checkpoint(&cache, "42", &existing).as_deref(),
+            Some("BVOLD0000001")
+        );
+    }
+
+    #[test]
+    fn persisted_checkpoint_takes_priority_over_legacy_refresh_summary() {
+        let cache = json!({
+            "uid_checkpoints": {"42": "BVRAW0000001"},
+            "refresh_summary": {
+                "uids": [{"uid": "42", "mode": "incremental", "added_count": 1}]
+            }
+        });
+        let existing = vec![
+            json!({"bvid": "BVNEW0000001", "title": "new"}),
+            json!({"bvid": "BVOLD0000001", "title": "old boundary"}),
+        ];
+
+        assert_eq!(
+            uid_refresh_checkpoint(&cache, "42", &existing).as_deref(),
+            Some("BVRAW0000001")
+        );
+    }
+
+    #[test]
+    fn refresh_checkpoints_are_frozen_before_progress_summary_is_replaced() {
+        let mut cache = json!({
+            "uids": {
+                "42": [
+                    {"bvid": "BVNEW0000001", "title": "new"},
+                    {"bvid": "BVOLD0000001", "title": "old boundary"}
+                ]
+            },
+            "uid_checkpoints": {},
+            "refresh_summary": {
+                "uids": [{"uid": "42", "mode": "incremental", "added_count": 1}]
+            }
+        });
+        let checkpoints = uid_refresh_checkpoints(&cache, &["42".to_owned()]);
+        cache["refresh_summary"] = json!({"uids": []});
+
+        assert_eq!(
+            checkpoints.get("42").and_then(Option::as_deref),
+            Some("BVOLD0000001")
+        );
+        assert_eq!(
+            uid_refresh_checkpoint(&cache, "42", cache["uids"]["42"].as_array().unwrap())
+                .as_deref(),
+            Some("BVNEW0000001")
+        );
+    }
+
+    #[test]
+    fn checkpoint_detection_uses_raw_posts_before_keyword_filtering() {
+        let videos = vec![
+            json!({"bvid": "BVNEW0000001", "title": "karaoke new"}),
+            json!({"bvid": "BVRAW0000001", "title": "ordinary upload"}),
+        ];
+
+        assert!(page_contains_bvid(&videos, "BVRAW0000001"));
     }
 
     #[test]

--- a/tests/test_monthly_gatcha_d1_refresh.py
+++ b/tests/test_monthly_gatcha_d1_refresh.py
@@ -49,6 +49,51 @@ class MonthlyGatchaD1RefreshTest(unittest.TestCase):
         self.assertIn("already running locally", duplicate["error"])
         self.assertEqual(calls, [([], "worker-secret")])
 
+    def test_upload_entries_uses_authenticated_bounded_batches(self):
+        entries = [
+            {"bvid": f"BV{index:010d}", "title": f"song {index}"}
+            for index in range(1_201)
+        ]
+        requests = []
+
+        def fake_request(url, *, method="GET", payload=None, secret="", timeout=60.0):
+            requests.append((url, method, payload, secret, timeout))
+            count = len(payload["records"])
+            return {"success": True, "attempted": count, "added": count}
+
+        with patch.object(monthly_refresh, "_request_json", side_effect=fake_request):
+            result = monthly_refresh._upload_entries(
+                entries,
+                api_url="https://api.example.test",
+                secret="worker-secret",
+                batch_size=500,
+                dry_run=False,
+            )
+
+        self.assertEqual([len(request[2]["records"]) for request in requests], [500, 500, 201])
+        self.assertTrue(all(request[0].endswith("/batch-add?sync_google=1") for request in requests))
+        self.assertTrue(all(request[1] == "POST" for request in requests))
+        self.assertTrue(all(request[3] == "worker-secret" for request in requests))
+        self.assertEqual(result["attempted"], 1_201)
+        self.assertEqual(result["added"], 1_201)
+
+    def test_page_any_probe_detects_a_missing_middle_video(self):
+        first_page = [
+            {"bvid": "BVNEW0000001"},
+            {"bvid": "BVMID0000001"},
+            {"bvid": "BVOLD0000001"},
+        ]
+        d1_bvids = {"BVNEW0000001", "BVOLD0000001"}
+
+        should_refresh, reason = monthly_refresh._needs_refresh(
+            first_page,
+            d1_bvids,
+            probe_mode="page-any",
+        )
+
+        self.assertTrue(should_refresh)
+        self.assertIn("BVMID0000001", reason)
+
     def test_default_uid_source_uses_runtime_data_directory(self):
         self.assertEqual(monthly_refresh.DEFAULT_UIDS_PATH, config.DATA_DIR / "gatcha_uids.json")
 

--- a/tests/test_store_and_bilibili.py
+++ b/tests/test_store_and_bilibili.py
@@ -2468,7 +2468,7 @@ class BilibiliParserTest(unittest.TestCase):
         self.assertEqual([item["uid"] for item in summary["uids"]], ["2"])
         self.assertEqual(summary["errors"], [{"uid": "1", "error": "uid failed"}])
 
-    def test_startup_gatcha_refresh_uploads_default_uids_to_cloudflare_append_path(self):
+    def test_startup_gatcha_refresh_does_not_upload_when_no_uid_added_entries(self):
         class FakeThread:
             def __init__(self, *, target, daemon=None, name=None):
                 self.target = target
@@ -2482,6 +2482,52 @@ class BilibiliParserTest(unittest.TestCase):
                 "2": [{"bvid": "BVUSER", "title": "user", "url": "https://www.bilibili.com/video/BVUSER"}],
             },
             "profiles": {},
+            "refresh_summary": {
+                "uids": [
+                    {"uid": "1", "mode": "incremental", "added_count": 0, "total_count": 1},
+                    {"uid": "2", "mode": "incremental", "added_count": 0, "total_count": 1},
+                ]
+            },
+        }
+
+        with (
+            patch.object(bilibili_module, "refresh_gatcha_cache", return_value=cache_payload),
+            patch.object(bilibili_module, "_default_gatcha_uids", return_value=["1"]),
+            patch.object(bilibili_module, "_append_lark_pool_entries_async") as append_lark,
+            patch.object(bilibili_module.threading, "Thread", FakeThread),
+        ):
+            self.assertTrue(
+                bilibili_module.refresh_gatcha_cache_in_background(
+                    use_global_lock=False,
+                    upload_default_uids_to_lark=False,
+                )
+            )
+
+        append_lark.assert_not_called()
+
+    def test_startup_gatcha_refresh_uploads_only_new_uid_entries(self):
+        class FakeThread:
+            def __init__(self, *, target, daemon=None, name=None):
+                self.target = target
+
+            def start(self):
+                self.target()
+
+        cache_payload = {
+            "uids": {
+                "1": [
+                    {"bvid": "BVNEW", "title": "new", "url": "https://www.bilibili.com/video/BVNEW"},
+                    {"bvid": "BVDEFAULT", "title": "default", "url": "https://www.bilibili.com/video/BVDEFAULT"},
+                ],
+                "2": [{"bvid": "BVUSER", "title": "user", "url": "https://www.bilibili.com/video/BVUSER"}],
+            },
+            "profiles": {},
+            "refresh_summary": {
+                "uids": [
+                    {"uid": "1", "mode": "incremental", "added_count": 1, "total_count": 2},
+                    {"uid": "2", "mode": "incremental", "added_count": 0, "total_count": 1},
+                ]
+            },
         }
 
         with (
@@ -2498,39 +2544,7 @@ class BilibiliParserTest(unittest.TestCase):
             )
 
         uploaded_entries = append_lark.call_args.args[0]
-        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVDEFAULT", "BVUSER"])
-
-    def test_startup_gatcha_refresh_uploads_cached_default_uids_to_cloudflare_append_path(self):
-        class FakeThread:
-            def __init__(self, *, target, daemon=None, name=None):
-                self.target = target
-
-            def start(self):
-                self.target()
-
-        cache_payload = {
-            "uids": {
-                "1": [{"bvid": "BVDEFAULT", "title": "default", "url": "https://www.bilibili.com/video/BVDEFAULT"}],
-                "2": [{"bvid": "BVUSER", "title": "user", "url": "https://www.bilibili.com/video/BVUSER"}],
-            },
-            "profiles": {},
-        }
-
-        with (
-            patch.object(bilibili_module, "refresh_gatcha_cache", return_value=cache_payload),
-            patch.object(bilibili_module, "_default_gatcha_uids", return_value=["1"]),
-            patch.object(bilibili_module, "_append_lark_pool_entries_async") as append_lark,
-            patch.object(bilibili_module.threading, "Thread", FakeThread),
-        ):
-            self.assertTrue(
-                bilibili_module.refresh_gatcha_cache_in_background(
-                    use_global_lock=False,
-                    upload_default_uids_to_lark=False,
-                )
-            )
-
-        uploaded_entries = append_lark.call_args.args[0]
-        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVDEFAULT", "BVUSER"])
+        self.assertEqual([entry["bvid"] for entry in uploaded_entries], ["BVNEW"])
 
     def test_manual_gatcha_refresh_uploads_default_uids_to_cloudflare_append_path_by_default(self):
         class FakeThread:
@@ -2546,6 +2560,12 @@ class BilibiliParserTest(unittest.TestCase):
                 "2": [{"bvid": "BVUSER", "title": "user", "url": "https://www.bilibili.com/video/BVUSER"}],
             },
             "profiles": {},
+            "refresh_summary": {
+                "uids": [
+                    {"uid": "1", "mode": "full", "added_count": 1, "total_count": 1},
+                    {"uid": "2", "mode": "full", "added_count": 1, "total_count": 1},
+                ]
+            },
         }
 
         with (


### PR DESCRIPTION
## 中文

### 概述

本 PR 修复 Gatcha 增量刷新可能遗漏中间视频的问题，并减少 Host 启动及月度维护对 D1 的重复读写。

此前刷新主要依赖当前结果与本地缓存比较：如果某个较新的 BV 已通过单独点歌进入本地，但其前后仍有未同步视频，刷新可能过早判断该 UID 没有变化；另一方面，启动后的结构重建会把完整曲库重新交给线上服务，正常使用也可能被放大为大量数据库操作。

### 主要改动

- 在 Rust Gatcha Repository 中持久化每个 UID 上次观察到的原始首页边界，并持续翻页直到遇到该边界。
- 边界判断发生在关键词过滤之前，因此普通投稿也可以作为稳定检查点，避免过滤结果造成中间 BV 缺失。
- 刷新开始前冻结旧检查点，避免进度状态重置影响本轮增量判断；同时兼容没有新检查点字段的旧缓存。
- Host 启动后的结构重建不再上传完整曲库，正常后台刷新只同步 Rust 刷新摘要确认的新增记录。
- 月度维护改为一次导出现有 D1 数据后在本地计算差集，并按受控批次上传缺失项，能够发现“最新视频存在但中间视频缺失”的情况。
- 配套线上防护采用分层限流、输入边界、写前去重、搜索缓存/索引和维护任务鉴权，将恶意或异常请求的数据库放大倍数限制在可控范围；具体公开接口与阈值不在 PR 中展开。

### 兼容性

- 收藏夹批量添加行为保持不变。
- Python Host 仍负责网络与 D1 I/O；UID 增量边界和刷新决策由 Rust Runtime 持有。
- 旧 Gatcha 缓存可继续读取，并在后续成功刷新时补齐持久化检查点。
- 不影响播放、下载、队列和现有缓存。

### 验证

- Rust Runtime：`cargo fmt --check`、Clippy、105 项测试及 release build 通过。
- Rust Core：`cargo fmt --check`、Clippy、201 项测试及 release build 通过。
- Python：强制加载 Rust Native 的完整测试 1363 项通过，10 项按环境跳过；编译检查通过。
- Tauri：Clippy、75 项测试及 release build 通过。
- 月度增量、启动不全量上传、旧检查点兼容和中间 BV 缺失均有回归测试。
- 配套 Worker 类型检查、25 项测试和部署 dry-run 通过；本地 D1 使用 49,000 行验证全量索引 migration 成功。

---

## English

### Overview

This PR fixes a Gatcha incremental-refresh gap that could miss videos between an already-known newest BV and an older cached boundary. It also prevents normal Host startup and monthly maintenance from amplifying into repeated full-library D1 work.

### Main Changes

- Persist the last raw first-page boundary for every UID in the Rust Gatcha Repository and continue paging until that boundary is reached.
- Compare boundaries before keyword filtering, allowing ordinary uploads to remain stable checkpoints without hiding matching videos between pages.
- Freeze the previous checkpoints before refresh progress is reset and retain compatibility with legacy caches that do not contain the new checkpoint field.
- Stop resubmitting the complete local library after Host schema reconstruction; normal background refreshes now synchronize only entries reported as newly added by Rust.
- Export the existing D1 dataset once during monthly maintenance, compute the difference locally, and upload only missing entries in bounded batches.
- Harden the accompanying online path through layered rate limiting, bounded inputs, pre-write deduplication, cached/indexed search, and authenticated maintenance work. Exact public routes and thresholds are intentionally omitted here.

### Compatibility

- Existing favlist batch additions remain supported.
- Python remains responsible for network and D1 I/O, while Rust Runtime owns UID refresh boundaries and incremental decisions.
- Legacy Gatcha caches remain readable and gain persisted checkpoints after later successful refreshes.
- Playback, downloading, queue behavior, and existing media caches are unaffected.

### Validation

- Rust Runtime formatting, Clippy, 105 tests, and release build passed.
- Rust Core formatting, Clippy, 201 tests, and release build passed.
- Full Python suite with mandatory Rust Native loading passed 1363 tests with 10 environment skips; compilation checks passed.
- Tauri Clippy, 75 tests, and release build passed.
- Regression coverage includes monthly diffing, startup upload suppression, legacy checkpoint compatibility, and missing-middle-BV recovery.
- Accompanying Worker type checks, 25 tests, and deployment dry-run passed; a local D1 migration completed against 49,000 rows.

## Summary by Sourcery

Make Gatcha refreshes reliably incremental while reducing redundant D1 synchronization and maintenance writes.

Bug Fixes:
- Ensure incremental Gatcha refreshes continue through raw upload boundaries so videos between known entries are not missed.
- Make monthly maintenance detect missing middle videos and upload only locally computed missing records.

Enhancements:
- Prevent startup cache reconstruction and routine refreshes from resubmitting the full local library to D1 by synchronizing only newly added entries.
- Persist per-UID refresh checkpoints with compatibility for legacy caches and freeze checkpoints before refresh progress updates.
- Add authenticated, bounded-batch D1 uploads with local deduplication during monthly maintenance.

Tests:
- Add regression coverage for checkpoint persistence and legacy fallback, raw boundary detection, missing-middle-video discovery, bounded authenticated uploads, and startup upload suppression.