### PR TITLE
ci(remote): dispatch production asset sync from release branches

### DIFF
--- a/.github/workflows/internet-remote-sync.yml
+++ b/.github/workflows/internet-remote-sync.yml
@@ -3,12 +3,23 @@ name: Sync Internet Remote Production
 on:
   push:
     branches: [dev, work/v0.8.0]
+    # Keep in sync with the asset-copy allowlist. Tests and workflow edits are
+    # validated on PRs; workflow_dispatch is the explicit redeployment path.
     paths:
-      - .github/workflows/internet-remote-sync.yml
       - scripts/sync_internet_remote_assets.ps1
-      - static/**
-      - tests/test_internet_remote_frontend.py
-      - tests/test_internet_remote_deployment.py
+      - static/export-download.js
+      - static/export-guard.js
+      - static/i18n.json
+      - static/internet-remote-transport.js
+      - static/remote-queue.css
+      - static/remote-queue.js
+      - static/remote-transport-client.js
+      - static/remote.css
+      - static/remote.html
+      - static/remote.js
+      - static/song-detail.css
+      - static/song-detail.js
+      - static/pic/*
   pull_request:
     branches: [dev, work/v0.8.0]
     paths:

--- a/.github/workflows/internet-remote-sync.yml
+++ b/.github/workflows/internet-remote-sync.yml
@@ -1,0 +1,103 @@
+name: Sync Internet Remote Production
+
+on:
+  push:
+    branches: [dev, work/v0.8.0]
+    paths:
+      - .github/workflows/internet-remote-sync.yml
+      - scripts/sync_internet_remote_assets.ps1
+      - static/**
+      - tests/test_internet_remote_frontend.py
+  pull_request:
+    branches: [dev, work/v0.8.0]
+    paths:
+      - .github/workflows/internet-remote-sync.yml
+      - scripts/sync_internet_remote_assets.ps1
+      - static/**
+      - tests/test_internet_remote_frontend.py
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: internet-remote-production-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Validate shared Remote contract
+        run: python -m unittest tests.test_internet_remote_frontend -v
+
+      - name: Check browser scripts
+        run: |
+          node --check static/internet-remote-host.js
+          node --check static/internet-remote-transport.js
+          node --check static/remote-transport-client.js
+          node --check static/remote.js
+          node --check static/remote-queue.js
+          node --check static/song-detail.js
+
+      - name: Note optional deployment configuration
+        if: vars.INTERNET_REMOTE_WORKER_REPOSITORY == ''
+        run: echo "::notice::Remote validation passed. Configure INTERNET_REMOTE_WORKER_REPOSITORY and INTERNET_REMOTE_WORKER_TOKEN to enable production sync."
+
+  dispatch:
+    needs: validate
+    if: >-
+      github.event_name != 'pull_request' &&
+      (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/work/v0.8.0') &&
+      vars.INTERNET_REMOTE_WORKER_REPOSITORY != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require cross-repository credential
+        env:
+          WORKER_REPO_TOKEN: ${{ secrets.INTERNET_REMOTE_WORKER_TOKEN }}
+        run: |
+          if [ -z "$WORKER_REPO_TOKEN" ]; then
+            echo "::error::INTERNET_REMOTE_WORKER_REPOSITORY is configured, but INTERNET_REMOTE_WORKER_TOKEN is missing."
+            exit 1
+          fi
+
+      - name: Dispatch production Remote sync
+        uses: actions/github-script@v8
+        env:
+          WORKER_REPOSITORY: ${{ vars.INTERNET_REMOTE_WORKER_REPOSITORY }}
+        with:
+          github-token: ${{ secrets.INTERNET_REMOTE_WORKER_TOKEN }}
+          script: |
+            const target = process.env.WORKER_REPOSITORY.trim();
+            if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/u.test(target)) {
+              throw new Error("INTERNET_REMOTE_WORKER_REPOSITORY must be owner/repository.");
+            }
+            const [owner, repo] = target.split("/");
+            await github.rest.repos.createDispatchEvent({
+              owner,
+              repo,
+              event_type: "sync-bilikara-production",
+              client_payload: {
+                source_repository: context.repo.owner + "/" + context.repo.repo,
+                source_ref: context.ref.replace(/^refs\/heads\//u, ""),
+                source_sha: context.sha,
+              },
+            });
+            core.notice("Production Remote sync requested for " + context.sha);

--- a/.github/workflows/internet-remote-sync.yml
+++ b/.github/workflows/internet-remote-sync.yml
@@ -8,6 +8,7 @@ on:
       - scripts/sync_internet_remote_assets.ps1
       - static/**
       - tests/test_internet_remote_frontend.py
+      - tests/test_internet_remote_deployment.py
   pull_request:
     branches: [dev, work/v0.8.0]
     paths:
@@ -15,6 +16,7 @@ on:
       - scripts/sync_internet_remote_assets.ps1
       - static/**
       - tests/test_internet_remote_frontend.py
+      - tests/test_internet_remote_deployment.py
   workflow_dispatch:
 
 permissions:
@@ -45,10 +47,12 @@ jobs:
           node-version: 24
 
       - name: Validate shared Remote contract
-        run: python -m unittest tests.test_internet_remote_frontend -v
+        run: python -m unittest tests.test_internet_remote_frontend tests.test_internet_remote_deployment -v
 
       - name: Check browser scripts
         run: |
+          node --check static/export-guard.js
+          node --check static/export-download.js
           node --check static/internet-remote-host.js
           node --check static/internet-remote-transport.js
           node --check static/remote-transport-client.js

--- a/docs/internet-remote-deployment.md
+++ b/docs/internet-remote-deployment.md
@@ -1,0 +1,69 @@
+# Internet Remote asset deployment
+
+The Host and the online Remote use the same frontend files. After a Remote
+change is pushed to `dev` or merged into `work/v0.8.0`, the **Sync Internet
+Remote Production** workflow validates the frontend and requests a deployment
+from a separately maintained private Worker repository. Pull requests only
+validate; they never dispatch a deployment or receive the deployment token.
+
+The private repository mirrors the triggering source commit, commits the shared
+assets, validates the Worker, and deploys to `rtc.kevinx96.icu`. Worker source,
+Cloudflare credentials, and deployment configuration remain in that repository.
+The application repository does not deploy the Worker itself.
+
+## Public repository configuration
+
+Configure these under **Settings → Secrets and variables → Actions** in each
+public repository that should request production deployments:
+
+| Kind | Name | Value |
+| --- | --- | --- |
+| Variable | `INTERNET_REMOTE_WORKER_REPOSITORY` | The private deployment repository, as `owner/repository` |
+| Secret | `INTERNET_REMOTE_WORKER_TOKEN` | A GitHub token permitted to send dispatch events to that private repository |
+
+A fine-grained token needs **Contents: read and write** on the selected private
+repository. The public repository's built-in `GITHUB_TOKEN` cannot provide
+cross-repository access. Prefer a dedicated token or GitHub App installation
+credential rather than a maintainer's general-purpose credential. See the
+[GitHub dispatch permission reference](https://docs.github.com/en/rest/repos/repos#create-a-repository-dispatch-event).
+
+If the target variable is absent, validation still runs and deployment is
+disabled. If the variable is present but the token is missing or invalid, the
+dispatch job fails visibly. Fork PRs remain validation-only regardless of the
+target repository's configuration. No Cloudflare secret is needed in Bilikara.
+
+## Private deployment repository configuration
+
+The receiver workflow must be present on the private repository's **default
+branch** for `repository_dispatch` to run. It checks out the production Worker
+branch and validates the dispatch's source repository, branch, and full commit
+SHA before fetching any public source. It deploys that exact commit, and skips
+requests superseded by newer source commits.
+
+Only one public source owns production at a time. The private repository's
+`BILIKARA_PRODUCTION_REPOSITORY` and `BILIKARA_PRODUCTION_REF` variables select
+either the fork's `dev` or upstream's `work/v0.8.0`. Events from the inactive
+source are skipped with an explanation, so a fork push cannot overwrite an
+upstream deployment after upstream takes over. Production deployments run
+serially and are not cancelled halfway through publication.
+
+The private repository alone holds `CLOUDFLARE_API_TOKEN` and the
+`CLOUDFLARE_ACCOUNT_ID` variable. These are separate from the GitHub dispatch
+credential. See [Cloudflare's GitHub Actions setup](https://developers.cloudflare.com/workers/ci-cd/external-cicd/github-actions/).
+
+## Upstream handover
+
+1. Merge the public workflow and this document into upstream `work/v0.8.0`.
+2. Configure the target-repository variable and a dedicated dispatch-token secret
+   in upstream. Secrets and variables are not copied by a PR or fork.
+3. In the private repository, switch the production source to
+   `VZRXS/bilikara` and `work/v0.8.0` together, then run its production workflow
+   manually once. This publishes the branch head even if enabling the workflow
+   did not produce a new frontend commit.
+4. Later upstream Remote changes request deployment automatically. The fork's
+   `codex/rtc-dev` continues to use the isolated `rtc-dev.kevinx96.icu` workflow
+   and its private `dev` branch.
+
+Updating online assets affects newly loaded Remote pages. It does not update
+installed Host bundles. Changes to the Remote protocol must preserve support
+for already-released Hosts or coordinate a compatible Host release first.

--- a/docs/internet-remote-deployment.md
+++ b/docs/internet-remote-deployment.md
@@ -6,6 +6,14 @@ Remote Production** workflow validates the frontend and requests a deployment
 from a separately maintained private Worker repository. Pull requests only
 validate; they never dispatch a deployment or receive the deployment token.
 
+Automatic push synchronization is limited to the files copied by
+`scripts/sync_internet_remote_assets.ps1`, the pictures it copies, and that
+sync script itself. Changes only to tests, this workflow, or Host-only assets
+do not request a production deployment. PR validation still covers those
+frontend tests and workflow changes. Use **Run workflow** explicitly when a
+configuration-only change needs a redeployment; its branch and credential
+checks still apply.
+
 The private repository mirrors the triggering source commit, commits the shared
 assets, validates the Worker, and deploys to `rtc.kevinx96.icu`. Worker source,
 Cloudflare credentials, and deployment configuration remain in that repository.
@@ -38,7 +46,10 @@ The receiver workflow must be present on the private repository's **default
 branch** for `repository_dispatch` to run. It checks out the production Worker
 branch and validates the dispatch's source repository, branch, and full commit
 SHA before fetching any public source. It deploys that exact commit, and skips
-requests superseded by newer source commits.
+requests superseded by newer Remote asset or sync-script changes. Later
+test-only, workflow-only, or Host-only commits do not replace that deployment,
+so the receiver must preserve the pending request's validated source SHA. Keep
+its changed-input checks aligned with the public workflow's push allowlist.
 
 Only one public source owns production at a time. The private repository's
 `BILIKARA_PRODUCTION_REPOSITORY` and `BILIKARA_PRODUCTION_REF` variables select

--- a/tests/test_internet_remote_deployment.py
+++ b/tests/test_internet_remote_deployment.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+from fnmatch import fnmatchcase
 from html.parser import HTMLParser
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -46,6 +47,11 @@ class InternetRemoteDeploymentTest(unittest.TestCase):
         cls.resources.feed((ROOT / "static" / "remote.html").read_text(encoding="utf-8"))
         cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
 
+    def event_paths(self, event: str) -> set[str]:
+        block = self.workflow.split(f"\n  {event}:\n", 1)[1]
+        block = re.split(r"\n  [a-z_]+:", block, maxsplit=1)[0]
+        return set(re.findall(r"^      - ([^\n]+)$", block, re.MULTILINE))
+
     def test_sync_copies_current_remote_html_dependencies(self):
         powershell = shutil.which("pwsh") or shutil.which("powershell")
         if powershell is None:
@@ -78,6 +84,44 @@ class InternetRemoteDeploymentTest(unittest.TestCase):
     def test_production_syntax_checks_cover_every_remote_script(self):
         checked = set(re.findall(r"node --check static/([^\s]+)", self.workflow))
         self.assertEqual(self.resources.scripts - checked, set())
+
+    def test_push_filter_matches_the_actual_sync_allowlist(self):
+        sync = (ROOT / "scripts" / "sync_internet_remote_assets.ps1").read_text(
+            encoding="utf-8"
+        )
+        allowlist = re.search(r"\$files = @\((.*?)\)", sync, re.DOTALL)
+        self.assertIsNotNone(allowlist)
+        assets = set(re.findall(r'"([^"]+)"', allowlist.group(1)))
+        self.assertTrue(self.resources.scripts <= assets)
+        expected = {f"static/{asset}" for asset in assets} | {
+            "static/pic/*", "scripts/sync_internet_remote_assets.ps1"
+        }
+        self.assertEqual(self.event_paths("push"), expected)
+
+    def test_test_workflow_and_host_only_pushes_do_not_deploy(self):
+        push_paths = self.event_paths("push")
+        for path in (
+            "tests/test_internet_remote_frontend.py",
+            "tests/test_internet_remote_deployment.py",
+            ".github/workflows/internet-remote-sync.yml",
+            "static/app.js",
+            "static/index.html",
+            "static/internet-remote-host.js",
+            "static/styles.css",
+        ):
+            with self.subTest(path=path):
+                self.assertFalse(any(fnmatchcase(path, pattern) for pattern in push_paths))
+
+    def test_pr_validation_and_explicit_redeployment_remain_available(self):
+        pr_paths = self.event_paths("pull_request")
+        self.assertTrue({
+            ".github/workflows/internet-remote-sync.yml",
+            "tests/test_internet_remote_frontend.py",
+            "tests/test_internet_remote_deployment.py",
+            "static/**",
+        } <= pr_paths)
+        self.assertIn("\n  workflow_dispatch:", self.workflow)
+        self.assertIn("github.event_name != 'pull_request'", self.workflow)
 
 
 if __name__ == "__main__":

--- a/tests/test_internet_remote_deployment.py
+++ b/tests/test_internet_remote_deployment.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = ROOT / ".github" / "workflows" / "internet-remote-sync.yml"
+
+
+class RemoteResourcesParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.resources: set[str] = set()
+        self.scripts: set[str] = set()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        if tag == "script":
+            source = attributes.get("src")
+        elif tag == "link":
+            source = attributes.get("href")
+        else:
+            return
+        if not source:
+            return
+        url = urlsplit(source)
+        if url.scheme or url.netloc:
+            return
+        path = url.path.lstrip("/")
+        self.resources.add(path)
+        if tag == "script":
+            self.scripts.add(path)
+
+
+class InternetRemoteDeploymentTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.resources = RemoteResourcesParser()
+        cls.resources.feed((ROOT / "static" / "remote.html").read_text(encoding="utf-8"))
+        cls.workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_sync_copies_current_remote_html_dependencies(self):
+        powershell = shutil.which("pwsh") or shutil.which("powershell")
+        if powershell is None:
+            self.skipTest("PowerShell is required to execute the actual asset sync")
+        self.assertTrue({"export-guard.js", "export-download.js"} <= self.resources.scripts)
+        with tempfile.TemporaryDirectory(prefix="bilikara-remote-assets-") as directory:
+            destination = Path(directory)
+            for script in ("export-guard.js", "export-download.js"):
+                (destination / script).write_text("stale export script", encoding="utf-8")
+            result = subprocess.run(
+                [
+                    powershell, "-NoProfile", "-File",
+                    str(ROOT / "scripts" / "sync_internet_remote_assets.ps1"),
+                    "-Destination", str(destination),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            for asset in sorted(self.resources.resources | {"remote.html", "i18n.json"}):
+                with self.subTest(asset=asset):
+                    self.assertTrue((destination / asset).is_file(), f"Missing {asset}")
+                    self.assertEqual(
+                        (destination / asset).read_bytes(),
+                        (ROOT / "static" / asset).read_bytes(),
+                    )
+
+    def test_production_syntax_checks_cover_every_remote_script(self):
+        checked = set(re.findall(r"node --check static/([^\s]+)", self.workflow))
+        self.assertEqual(self.resources.scripts - checked, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_internet_remote_frontend.py
+++ b/tests/test_internet_remote_frontend.py
@@ -530,6 +530,8 @@ console.log(JSON.stringify({{ sent, reconnects }}));
 
     def test_worker_asset_sync_uses_the_product_remote_dependencies(self):
         for asset in (
+            "export-download.js",
+            "export-guard.js",
             "remote.html",
             "remote.css",
             "remote.js",


### PR DESCRIPTION
中文

### 概述

Remote 前端修改目前需要另行手动同步到公网服务，否则已更新的 Host 和线上手机页面容易出现版本不一致。本 PR 在 `dev` / `work/v0.8.0` 的相关推送后自动校验共享 Remote，并通知独立的私有部署仓库同步该次提交。PR 本身只进行校验。

配套私有工作流会提交镜像资产、验证 Worker 并发布正式环境；校验来源与提交版本、跳过过时请求，并串行执行部署。测试环境继续独立运行。Worker 实现、Cloudflare 凭据和部署配置不进入此 PR。

### Maintainer 配置

- 上游 Actions Variable：`INTERNET_REMOTE_WORKER_REPOSITORY`，填写私有部署仓库的 `owner/repository`。
- 上游 Actions Secret：`INTERNET_REMOTE_WORKER_TOKEN`，使用具有该私有仓库 `Contents: read and write` 权限的专用 GitHub Token。
- 上游不需要 Cloudflare Token。现有 fork 的 Secrets 不会随 PR 继承。
- 正式来源当前为 fork `dev`；接管时，在私有部署仓库把来源切到 `VZRXS/bilikara` / `work/v0.8.0`，然后手动触发一次正式同步。之后只接受该来源，避免 fork 与 upstream 交替覆盖正式页面。

### 验证

- `python -m unittest tests.test_internet_remote_frontend -v`：35 项通过。
- 两个工作流的 actionlint 检查通过；私有来源校验 8 项、Worker 14 项测试通过。
- fork 真实推送验证：公开同步任务和私有部署任务均成功，正式域名的 12 个共享资源与触发提交一致（HTML 排除 CDN 自动注入的统计脚本）。测试域名保持原测试版。
- 本 PR 仅新增工作流和接入文档；不修改 Python/Rust/Tauri 业务逻辑，未重新构建桌面安装包。

---

## English

### Overview

Remote frontend updates currently require a separate manual upload to the public service. This PR validates the shared Remote on relevant pushes to `dev` / `work/v0.8.0` and dispatches the triggering commit to a separately maintained private deployment repository. Pull requests only validate.

The companion private workflow commits mirrored assets, validates the Worker, and deploys production. It admits only the configured source and current commit, skips superseded requests, and serializes deployments. Development remains isolated. No Worker implementation, deployment configuration, or Cloudflare credential is added to this PR.

### Maintainer setup

- Set repository variable `INTERNET_REMOTE_WORKER_REPOSITORY` to the private deployment repository's `owner/repository`.
- Set secret `INTERNET_REMOTE_WORKER_TOKEN` to a dedicated token with `Contents: read and write` on that private repository.
- No Cloudflare token is required upstream; fork secrets are not inherited.
- Production currently follows the fork's `dev`. On handover, select `VZRXS/bilikara` / `work/v0.8.0` in the private deployment repository and run production sync once. Only the selected source can subsequently publish.

### Validation

- 35 shared Remote tests, actionlint, 8 production-source tests, and 14 Worker tests passed.
- A real fork push completed both workflows and production deployment. All 12 shared assets matched the source commit after excluding Cloudflare's injected analytics script from HTML; the development site retained its test version.
- Workflow/documentation-only change; no Python/Rust/Tauri business logic changed and no desktop bundle was rebuilt.

## Summary by Sourcery

Automate validated production Internet Remote asset synchronization from supported release branches through a private deployment repository.

New Features:
- Add automated validation and cross-repository dispatch for production Internet Remote asset synchronization on relevant branch pushes.

Enhancements:
- Define production asset-change filtering, concurrency, credential handling, and explicit redeployment behavior for Remote synchronization.
- Add deployment documentation covering repository configuration, source handover, and production ownership.

CI:
- Add CI checks for Remote frontend contracts, browser script syntax, asset synchronization coverage, and deployment workflow behavior.

Deployment:
- Delegate production Remote deployment requests to a separately maintained private Worker repository while keeping deployment credentials and infrastructure isolated.

Documentation:
- Document public and private repository setup, source selection, credentials, deployment behavior, and upstream handover procedures.

Tests:
- Add deployment-focused tests covering asset dependencies, synchronization allowlists, syntax-check coverage, and validation-only paths.
- Extend frontend asset tests to include export scripts.